### PR TITLE
Remove dark mode and simplify theme

### DIFF
--- a/src/app/components/slider/page.tsx
+++ b/src/app/components/slider/page.tsx
@@ -18,9 +18,9 @@ export default function HomePage() {
       <Slider />
 
       {/* Resto do conteúdo */}
-      <section className="py-20 bg-white dark:bg-gray-900">
+      <section className="py-20 bg-white">
         <PageWrapper maxWidth="xl">
-          <h2 className="text-3xl md:text-4xl font-bold text-center mb-16 text-gray-900 dark:text-gray-100">
+          <h2 className="text-3xl md:text-4xl font-bold text-center mb-16 text-gray-900">
             Funcionalidades Principais
           </h2>
         </PageWrapper>

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { ReactNode, useEffect, useState } from "react";
-import { useTheme } from "next-themes";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { DashboardSidebar } from "@/theme";
 import { Icon } from "@/components/ui/custom/Icons";
@@ -14,9 +13,6 @@ interface DashboardLayoutProps {
  * Layout específico para a seção de Dashboard
  */
 export default function DashboardLayout({ children }: DashboardLayoutProps) {
-  // Acesso ao tema atual
-  const { theme } = useTheme();
-
   // Hook personalizado para detectar dispositivos móveis
   const isMobileDevice = useIsMobile();
 
@@ -64,7 +60,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   }
 
   return (
-    <div className={`flex h-screen ${theme === "dark" ? "dark" : ""}`}>
+    <div className="flex h-screen">
       {/* Sidebar principal do dashboard */}
       <DashboardSidebar
         isMobileMenuOpen={isMobileMenuOpen}
@@ -73,13 +69,13 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
       />
 
       {/* Container principal de conteúdo */}
-      <div className="w-full flex flex-1 flex-col transition-all duration-300 ease-in-out bg-white dark:bg-[#0F0F12]">
+      <div className="w-full flex flex-1 flex-col transition-all duration-300 ease-in-out bg-white">
         {/* Cabeçalho/barra superior */}
-        <header className="h-16 border-b border-gray-200 dark:border-[#1F1F23] flex items-center px-4 bg-white dark:bg-[#0F0F12] z-10">
+        <header className="h-16 border-b border-gray-200 flex items-center px-4 bg-white z-10">
           {/* Botão de toggle do sidebar */}
           <button
             onClick={toggleSidebar}
-            className="mr-4 p-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            className="mr-4 p-2 rounded-md hover:bg-gray-100 transition-colors"
             aria-label={isCollapsed ? "Expandir sidebar" : "Colapsar sidebar"}
           >
             <Icon
@@ -97,19 +93,19 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
 
           {/* Ícones e controles de usuário na direita */}
           <div className="flex items-center gap-3">
-            <button className="p-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors relative">
+            <button className="p-2 rounded-md hover:bg-gray-100 transition-colors relative">
               <Icon name="Bell" size={20} />
               <span className="absolute top-1 right-1 w-2 h-2 bg-red-500 rounded-full"></span>
             </button>
 
-            <button className="p-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
+            <button className="p-2 rounded-md hover:bg-gray-100 transition-colors">
               <Icon name="User" size={20} />
             </button>
           </div>
         </header>
 
         {/* Conteúdo principal */}
-        <main className="flex-1 overflow-auto p-6 bg-white dark:bg-[#0F0F12]">
+        <main className="flex-1 overflow-auto p-6 bg-white">
           {children}
         </main>
       </div>

--- a/src/app/website/cookies/page.tsx
+++ b/src/app/website/cookies/page.tsx
@@ -39,7 +39,7 @@ export default function CookiesPage() {
     return (
       <div className="min-h-screen">
         {/* Loading placeholder que é igual ao conteúdo */}
-        <section className="relative min-h-[300px] bg-gray-100 dark:bg-gray-800">
+        <section className="relative min-h-[300px] bg-gray-100">
           <div className="flex items-center justify-center h-[300px]">
             <div className="animate-pulse">
               <div className="h-4 bg-gray-300 rounded w-48 mb-2"></div>

--- a/src/app/website/cursos/page.tsx
+++ b/src/app/website/cursos/page.tsx
@@ -24,7 +24,7 @@ export default function CursosPage() {
     return (
       <div className="min-h-screen">
         {/* Loading placeholder que é igual ao conteúdo */}
-        <section className="relative min-h-[300px] bg-gray-100 dark:bg-gray-800">
+        <section className="relative min-h-[300px] bg-gray-100">
           <div className="flex items-center justify-center h-[300px]">
             <div className="animate-pulse">
               <div className="h-4 bg-gray-300 rounded w-48 mb-2"></div>

--- a/src/app/website/fale-conosco/page.tsx
+++ b/src/app/website/fale-conosco/page.tsx
@@ -39,7 +39,7 @@ export default function FaleConoscoPage() {
     return (
       <div className="min-h-screen">
         {/* Loading placeholder que é igual ao conteúdo */}
-        <section className="relative min-h-[300px] bg-gray-100 dark:bg-gray-800">
+        <section className="relative min-h-[300px] bg-gray-100">
           <div className="flex items-center justify-center h-[300px]">
             <div className="animate-pulse">
               <div className="h-4 bg-gray-300 rounded w-48 mb-2"></div>

--- a/src/app/website/faq/page.tsx
+++ b/src/app/website/faq/page.tsx
@@ -39,7 +39,7 @@ export default function OuvidoriaPage() {
     return (
       <div className="min-h-screen">
         {/* Loading placeholder que é igual ao conteúdo */}
-        <section className="relative min-h-[300px] bg-gray-100 dark:bg-gray-800">
+        <section className="relative min-h-[300px] bg-gray-100">
           <div className="flex items-center justify-center h-[300px]">
             <div className="animate-pulse">
               <div className="h-4 bg-gray-300 rounded w-48 mb-2"></div>

--- a/src/app/website/loading.tsx
+++ b/src/app/website/loading.tsx
@@ -5,7 +5,7 @@ export default function Loading() {
     <div className="min-h-screen flex items-center justify-center">
       <div className="flex flex-col items-center space-y-4">
         <div className="w-12 h-12 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin"></div>
-        <p className="text-gray-600 dark:text-gray-300">Carregando...</p>
+        <p className="text-gray-600">Carregando...</p>
       </div>
     </div>
   );

--- a/src/app/website/not-found.tsx
+++ b/src/app/website/not-found.tsx
@@ -5,15 +5,15 @@ export default function NotFound() {
   return (
     <div className="min-h-screen flex items-center justify-center px-4">
       <div className="text-center space-y-6 max-w-md">
-        <div className="text-6xl font-bold text-gray-300 dark:text-gray-600">
+        <div className="text-6xl font-bold text-gray-300">
           404
         </div>
 
         <div>
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">
             Página não encontrada
           </h2>
-          <p className="text-gray-600 dark:text-gray-300">
+          <p className="text-gray-600">
             A página que você está procurando não existe ou foi movida.
           </p>
         </div>

--- a/src/app/website/ouvidoria/page.tsx
+++ b/src/app/website/ouvidoria/page.tsx
@@ -39,7 +39,7 @@ export default function FaqPage() {
     return (
       <div className="min-h-screen">
         {/* Loading placeholder que é igual ao conteúdo */}
-        <section className="relative min-h-[300px] bg-gray-100 dark:bg-gray-800">
+        <section className="relative min-h-[300px] bg-gray-100">
           <div className="flex items-center justify-center h-[300px]">
             <div className="animate-pulse">
               <div className="h-4 bg-gray-300 rounded w-48 mb-2"></div>

--- a/src/app/website/politica-privacidade/page.tsx
+++ b/src/app/website/politica-privacidade/page.tsx
@@ -39,7 +39,7 @@ export default function PoliticaPrivacidadePage() {
     return (
       <div className="min-h-screen">
         {/* Loading placeholder que é igual ao conteúdo */}
-        <section className="relative min-h-[300px] bg-gray-100 dark:bg-gray-800">
+        <section className="relative min-h-[300px] bg-gray-100">
           <div className="flex items-center justify-center h-[300px]">
             <div className="animate-pulse">
               <div className="h-4 bg-gray-300 rounded w-48 mb-2"></div>

--- a/src/app/website/sobre/page.tsx
+++ b/src/app/website/sobre/page.tsx
@@ -46,7 +46,7 @@ export default function SobrePage() {
     return (
       <div className="min-h-screen">
         {/* Loading placeholder que é igual ao conteúdo */}
-        <section className="relative min-h-[300px] bg-gray-100 dark:bg-gray-800">
+        <section className="relative min-h-[300px] bg-gray-100">
           <div className="flex items-center justify-center h-[300px]">
             <div className="animate-pulse">
               <div className="h-4 bg-gray-300 rounded w-48 mb-2"></div>

--- a/src/app/website/solucoes/recrutamento-selecao/page.tsx
+++ b/src/app/website/solucoes/recrutamento-selecao/page.tsx
@@ -48,7 +48,7 @@ export default function RecrutamentoPage() {
     return (
       <div className="min-h-screen">
         {/* Loading placeholder que é igual ao conteúdo */}
-        <section className="relative min-h-[300px] bg-gray-100 dark:bg-gray-800">
+        <section className="relative min-h-[300px] bg-gray-100">
           <div className="flex items-center justify-center h-[300px]">
             <div className="animate-pulse">
               <div className="h-4 bg-gray-300 rounded w-48 mb-2"></div>

--- a/src/app/website/solucoes/treinamento-company/page.tsx
+++ b/src/app/website/solucoes/treinamento-company/page.tsx
@@ -45,7 +45,7 @@ export default function TreinamentoPage() {
     return (
       <div className="min-h-screen">
         {/* Loading placeholder que é igual ao conteúdo */}
-        <section className="relative min-h-[300px] bg-gray-100 dark:bg-gray-800">
+        <section className="relative min-h-[300px] bg-gray-100">
           <div className="flex items-center justify-center h-[300px]">
             <div className="animate-pulse">
               <div className="h-4 bg-gray-300 rounded w-48 mb-2"></div>

--- a/src/app/website/termos-uso/page.tsx
+++ b/src/app/website/termos-uso/page.tsx
@@ -39,7 +39,7 @@ export default function TermosUsoPage() {
     return (
       <div className="min-h-screen">
         {/* Loading placeholder que é igual ao conteúdo */}
-        <section className="relative min-h-[300px] bg-gray-100 dark:bg-gray-800">
+        <section className="relative min-h-[300px] bg-gray-100">
           <div className="flex items-center justify-center h-[300px]">
             <div className="animate-pulse">
               <div className="h-4 bg-gray-300 rounded w-48 mb-2"></div>

--- a/src/app/website/vagas/page.tsx
+++ b/src/app/website/vagas/page.tsx
@@ -24,7 +24,7 @@ export default function VagasPage() {
     return (
       <div className="min-h-screen">
         {/* Loading placeholder que é igual ao conteúdo */}
-        <section className="relative min-h-[300px] bg-gray-100 dark:bg-gray-800">
+        <section className="relative min-h-[300px] bg-gray-100">
           <div className="flex items-center justify-center h-[300px]">
             <div className="animate-pulse">
               <div className="h-4 bg-gray-300 rounded w-48 mb-2"></div>

--- a/src/components/layout/SidebarContainer.tsx
+++ b/src/components/layout/SidebarContainer.tsx
@@ -33,7 +33,7 @@ export function SidebarContainer({ children }: SidebarContainerProps) {
   };
 
   return (
-    <div className="flex h-screen overflow-hidden bg-gray-50 dark:bg-gray-900">
+    <div className="flex h-screen overflow-hidden bg-gray-50">
       {/* Sidebar */}
       <Sidebar
         isMobileMenuOpen={isMobileOpen}
@@ -44,7 +44,7 @@ export function SidebarContainer({ children }: SidebarContainerProps) {
       {/* Conteúdo principal */}
       <div className="flex flex-col flex-1 w-0 overflow-hidden transition-all duration-200">
         {/* Barra superior com toggle do sidebar */}
-        <div className="flex items-center h-16 shadow-sm bg-white dark:bg-gray-800 px-4 border-b border-gray-200 dark:border-gray-700">
+        <div className="flex items-center h-16 shadow-sm bg-white px-4 border-b border-gray-200">
           <Button
             variant="ghost"
             size="icon"

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
   {
     variants: {
       variant: {
@@ -14,7 +14,7 @@ const badgeVariants = cva(
         secondary:
           "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
         destructive:
-          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20",
         outline:
           "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
       },

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,20 +5,20 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
         default:
           "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
         destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
         ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+          "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -6,7 +6,7 @@ import * as RechartsPrimitive from "recharts";
 import { cn } from "@/lib/utils";
 
 // Format: { THEME_NAME: CSS_SELECTOR }
-const THEMES = { light: "", dark: ".dark" } as const;
+const THEMES = { light: "" } as const;
 
 export type ChartConfig = {
   [k in string]: {

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -14,7 +14,7 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer border-input data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/src/components/ui/custom/button/variants.ts
+++ b/src/components/ui/custom/button/variants.ts
@@ -5,19 +5,19 @@ import { cva } from "class-variance-authority";
  * Atualizado para utilizar o novo sistema de cores global
  */
 export const buttonCustomVariants = cva(
-  "inline-flex items-center justify-center gap-2 hover:opacity-90 whitespace-nowrap text-sm font-medium transition-all duration-200 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer",
+  "inline-flex items-center justify-center gap-2 hover:opacity-90 whitespace-nowrap text-sm font-medium transition-all duration-200 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive cursor-pointer",
   {
     variants: {
       variant: {
         default:
-          "bg-[var(--global-button)] hover:bg-[var(--global-button-hover)] text-[var(--global-cor-cinza-ardosia)] border-2 border-[var(--global-button-border)] !rounded-full relative pr-12 pl-4 font-semibold dark:text-[var(--global-bg-dark)] dark:hover:bg-[var(--global-button-hover-dark)]",
+          "bg-[var(--global-button)] hover:bg-[var(--global-button-hover)] text-[var(--global-cor-cinza-ardosia)] border-2 border-[var(--global-button-border)] !rounded-full relative pr-12 pl-4 font-semibold",
         primary:
           "bg-[var(--global-button)] text-[var(--global-cor-cinza-ardosia)] rounded-md",
         secondary: "bg-[var(--global-cor-roxo-medio)] text-white rounded-md",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 rounded-md",
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground rounded-md",
         ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 rounded-md",
+          "hover:bg-accent hover:text-accent-foreground rounded-md",
         link: "text-primary underline-offset-4 hover:underline",
         danger: "bg-[var(--global-cor-vermelho-terra)] text-white rounded-md",
       },

--- a/src/components/ui/custom/input/InputCustom.tsx
+++ b/src/components/ui/custom/input/InputCustom.tsx
@@ -136,7 +136,7 @@ export const InputCustom = React.forwardRef<HTMLInputElement, InputCustomProps>(
 
     // Aumentamos a altura do campo para todos os tamanhos
     const inputClasses = cn(
-      "w-full text-foreground dark:bg-background focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+      "w-full text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
       {
         "pr-10":
           icon || rightIcon || (type === "password" && showPasswordToggle),

--- a/src/components/ui/custom/toast/variants.ts
+++ b/src/components/ui/custom/toast/variants.ts
@@ -21,39 +21,39 @@ export const toastVariants = cva(
         default: ["border-border/40 bg-background/80", "text-foreground"],
 
         success: [
-          "border-emerald-500/30 bg-emerald-50/90 dark:bg-emerald-950/90",
-          "text-emerald-800 dark:text-emerald-300",
+          "border-emerald-500/30 bg-emerald-50/90",
+          "text-emerald-800",
         ],
 
         error: [
           "border-destructive/30 bg-destructive/10",
-          "text-destructive dark:text-destructive-foreground",
+          "text-destructive",
         ],
 
         warning: [
-          "border-amber-500/30 bg-amber-50/90 dark:bg-amber-950/90",
-          "text-amber-800 dark:text-amber-300",
+          "border-amber-500/30 bg-amber-50/90",
+          "text-amber-800",
         ],
 
         info: [
-          "border-blue-500/30 bg-blue-50/90 dark:bg-blue-950/90",
-          "text-blue-800 dark:text-blue-300",
+          "border-blue-500/30 bg-blue-50/90",
+          "text-blue-800",
         ],
 
         // Novos estilos inspirados na imagem
         action: [
-          "border-purple-500/30 bg-purple-50/90 dark:bg-purple-950/90",
-          "text-purple-800 dark:text-purple-300",
+          "border-purple-500/30 bg-purple-50/90",
+          "text-purple-800",
         ],
 
         confirmation: [
-          "border-indigo-500/30 bg-indigo-50/90 dark:bg-indigo-950/90",
-          "text-indigo-800 dark:text-indigo-300",
+          "border-indigo-500/30 bg-indigo-50/90",
+          "text-indigo-800",
         ],
 
         status: [
-          "border-gray-500/30 bg-gray-50/90 dark:bg-gray-800/90",
-          "text-gray-800 dark:text-gray-300",
+          "border-gray-500/30 bg-gray-50/90",
+          "text-gray-800",
         ],
       },
 
@@ -141,8 +141,8 @@ export const toastLinkVariants = cva(
         default: "text-primary hover:underline",
         muted: "text-muted-foreground hover:underline",
         destructive: "text-destructive hover:underline",
-        success: "text-emerald-600 dark:text-emerald-400 hover:underline",
-        info: "text-blue-600 dark:text-blue-400 hover:underline",
+        success: "text-emerald-600 hover:underline",
+        info: "text-blue-600 hover:underline",
       },
     },
     defaultVariants: {

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -74,7 +74,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/src/components/ui/input-otp.tsx
+++ b/src/components/ui/input-otp.tsx
@@ -51,7 +51,7 @@ function InputOTPSlot({
       data-slot="input-otp-slot"
       data-active={isActive}
       className={cn(
-        "data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive dark:bg-input/30 border-input relative flex h-9 w-9 items-center justify-center border-y border-r text-sm shadow-xs transition-all outline-none first:rounded-l-md first:border-l last:rounded-r-md data-[active=true]:z-10 data-[active=true]:ring-[3px]",
+        "data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive border-input relative flex h-9 w-9 items-center justify-center border-y border-r text-sm shadow-xs transition-all outline-none first:rounded-l-md first:border-l last:rounded-r-md data-[active=true]:z-10 data-[active=true]:ring-[3px]",
         className
       )}
       {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,9 +8,9 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        "aria-invalid:ring-destructive/20 aria-invalid:border-destructive",
         className
       )}
       {...props}

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -103,7 +103,7 @@ function MenubarItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -27,7 +27,7 @@ function RadioGroupItem({
     <RadioGroupPrimitive.Item
       data-slot="radio-group-item"
       className={cn(
-        "border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 aria-invalid:border-destructive aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -37,7 +37,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 aria-invalid:border-destructive flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,14 +1,12 @@
 "use client"
 
-import { useTheme } from "next-themes"
 import { Toaster as Sonner, ToasterProps } from "sonner"
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme()
 
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme="light"
       className="toaster group"
       style={
         {

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -13,7 +13,7 @@ function Switch({
     <SwitchPrimitive.Root
       data-slot="switch"
       className={cn(
-        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}
@@ -21,7 +21,7 @@ function Switch({
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+          "bg-background pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
         )}
       />
     </SwitchPrimitive.Root>

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -42,7 +42,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[state=active]:bg-background focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 aria-invalid:border-destructive flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className
       )}
       {...props}

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -7,7 +7,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 aria-invalid:border-destructive whitespace-nowrap",
   {
     variants: {
       variant: {

--- a/src/theme/dashboard/header/index.tsx
+++ b/src/theme/dashboard/header/index.tsx
@@ -2,7 +2,6 @@
 
 import React from "react";
 import { Button } from "@/components/ui/button";
-import { DarkTheme } from "@/components/partials/darkTheme/darkTheme";
 import Image from "next/image";
 import { Bell } from "lucide-react";
 
@@ -27,16 +26,12 @@ export function DashboardHeader({
             alt="DashCode"
             width={130}
             height={45}
-            className="dark:invert transition-all duration-300"
+            className="transition-all duration-300"
           />
         </div>
       </div>
 
-      <div className="flex items-center gap-4">
-        {/* Theme toggle */}
-        <DarkTheme />
-
-        {/* Ícones de notificação */}
+      <div className="flex items-center gap-4">{/* Ícones de notificação */}
         <Button variant="ghost" size="icon" className="relative">
           <Bell size={20} />
           <span className="absolute top-0 right-0 h-2 w-2 rounded-full bg-red-500"></span>

--- a/src/theme/dashboard/sidebar/Sidebar.tsx
+++ b/src/theme/dashboard/sidebar/Sidebar.tsx
@@ -23,8 +23,8 @@ export function Sidebar({
       {/* Container principal do sidebar */}
       <div
         className={cn(
-          "fixed inset-y-0 left-0 bg-white dark:bg-[#0F0F12] z-50",
-          "lg:translate-x-0 lg:static border-r border-gray-200 dark:border-[#1F1F23]",
+          "fixed inset-y-0 left-0 bg-white z-50",
+          "lg:translate-x-0 lg:static border-r border-gray-200",
           "h-full flex flex-col overflow-hidden",
           isMobileMenuOpen ? "translate-x-0" : "-translate-x-full",
           "transition-all duration-300 ease-in-out",
@@ -38,12 +38,12 @@ export function Sidebar({
         />
 
         {/* Seletor de Projetos */}
-        <div className="px-4 py-4 border-b border-gray-200 dark:border-[#1F1F23]">
+        <div className="px-4 py-4 border-b border-gray-200">
           <ProjectSelector isCollapsed={isCollapsed} />
         </div>
 
         {/* Conteúdo do Menu */}
-        <div className="flex-1 overflow-y-auto overflow-x-hidden py-4 scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-700 scrollbar-track-transparent">
+        <div className="flex-1 overflow-y-auto overflow-x-hidden py-4 scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent">
           <MenuList
             sections={menuSections}
             isCollapsed={isCollapsed}

--- a/src/theme/dashboard/sidebar/components/header/SidebarHeader.tsx
+++ b/src/theme/dashboard/sidebar/components/header/SidebarHeader.tsx
@@ -26,7 +26,7 @@ export function SidebarHeader({
   };
 
   return (
-    <div className="h-16 px-4 flex items-center justify-between border-b border-gray-200 dark:border-[#1F1F23] transition-all duration-300">
+    <div className="h-16 px-4 flex items-center justify-between border-b border-gray-200 transition-all duration-300">
       <div className="flex items-center gap-3">
         <div onClick={handleLogoClick} className="cursor-pointer">
           <Image
@@ -34,19 +34,19 @@ export function SidebarHeader({
             alt="Logo"
             width={32}
             height={32}
-            className="flex-shrink-0 hidden dark:block"
+            className="flex-shrink-0 hidden"
           />
           <Image
             src="https://kokonutui.com/logo-black.svg"
             alt="Logo"
             width={32}
             height={32}
-            className="flex-shrink-0 block dark:hidden"
+            className="flex-shrink-0 block"
           />
         </div>
 
         {!isCollapsed && (
-          <span className="font-semibold text-gray-900 dark:text-white ml-1 transition-opacity duration-300">
+          <span className="font-semibold text-gray-900 ml-1 transition-opacity duration-300">
             IntegreApp
           </span>
         )}
@@ -55,7 +55,7 @@ export function SidebarHeader({
       {/* Botão de fechar para mobile - visível apenas em telas pequenas */}
       <button
         onClick={onCloseMobile}
-        className="md:hidden p-1.5 rounded-md text-gray-500 hover:bg-gray-100 dark:hover:bg-[#1F1F23] transition-colors"
+        className="md:hidden p-1.5 rounded-md text-gray-500 hover:bg-gray-100 transition-colors"
         aria-label="Fechar menu"
       >
         <Icon name="X" size={20} />

--- a/src/theme/dashboard/sidebar/components/menu/MenuItem.tsx
+++ b/src/theme/dashboard/sidebar/components/menu/MenuItem.tsx
@@ -52,8 +52,8 @@ export function MenuItem({
         className={cn(
           "relative w-10 h-10 mx-auto my-1 flex items-center justify-center rounded-md transition-colors",
           isActive || isSubmenuOpen
-            ? "bg-primary/90 text-primary-foreground dark:bg-primary/90 dark:text-primary-foreground"
-            : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-[#1F1F23]"
+            ? "bg-primary/90 text-primary-foreground"
+            : "text-gray-700 hover:bg-gray-100"
         )}
       >
         {item.icon && <Icon name={item.icon} size={20} />}
@@ -78,7 +78,7 @@ export function MenuItem({
         {hasSubmenu && isSubmenuOpen && (
           <div
             className={cn(
-              "absolute left-full top-0 ml-2 w-48 rounded-md bg-white dark:bg-[#202024] shadow-lg border border-gray-100 dark:border-gray-800 py-1 z-50",
+              "absolute left-full top-0 ml-2 w-48 rounded-md bg-white shadow-lg border border-gray-100 py-1 z-50",
               "origin-left transition-all duration-150 ease-out"
             )}
             onClick={(e) => e.stopPropagation()}
@@ -101,17 +101,17 @@ export function MenuItem({
                       onClick={handleItemNavigation}
                       className={cn(
                         "flex items-center px-2 py-1.5 text-sm rounded-md",
-                        "hover:bg-gray-100 dark:hover:bg-[#2A2A30]",
-                        "text-gray-700 dark:text-gray-300",
+                        "hover:bg-gray-100",
+                        "text-gray-700",
                         subItem.active &&
-                          "bg-gray-100 dark:bg-[#2A2A30] font-medium"
+                          "bg-gray-100 font-medium"
                       )}
                     >
                       {subItem.icon && (
                         <Icon
                           name={subItem.icon}
                           size={16}
-                          className="mr-2 text-gray-500 dark:text-gray-400"
+                          className="mr-2 text-gray-500"
                         />
                       )}
                       <span>{subItem.label}</span>
@@ -122,14 +122,14 @@ export function MenuItem({
                         e.stopPropagation();
                         toggleSubmenu(e);
                       }}
-                      className="flex items-center justify-between w-full px-2 py-1.5 text-sm rounded-md hover:bg-gray-100 dark:hover:bg-[#2A2A30] text-gray-700 dark:text-gray-300"
+                      className="flex items-center justify-between w-full px-2 py-1.5 text-sm rounded-md hover:bg-gray-100 text-gray-700"
                     >
                       <div className="flex items-center">
                         {subItem.icon && (
                           <Icon
                             name={subItem.icon}
                             size={16}
-                            className="mr-2 text-gray-500 dark:text-gray-400"
+                            className="mr-2 text-gray-500"
                           />
                         )}
                         <span>{subItem.label}</span>
@@ -161,10 +161,10 @@ export function MenuItem({
           onClick={handleItemNavigation}
           className={cn(
             "flex items-center px-3 py-2 text-sm rounded-md transition-colors w-full",
-            "hover:bg-gray-100 dark:hover:bg-[#1F1F23]",
+            "hover:bg-gray-100",
             isActive
-              ? "bg-gray-100 dark:bg-[#1F1F23] text-gray-900 dark:text-white font-medium"
-              : "text-gray-600 dark:text-gray-300",
+              ? "bg-gray-100 text-gray-900 font-medium"
+              : "text-gray-600",
             level > 0 && "text-xs"
           )}
         >
@@ -178,10 +178,10 @@ export function MenuItem({
           onClick={toggleSubmenu}
           className={cn(
             "flex items-center justify-between w-full px-3 py-2 text-sm rounded-md transition-colors",
-            "hover:bg-gray-100 dark:hover:bg-[#1F1F23]",
+            "hover:bg-gray-100",
             isSubmenuOpen || isActive
-              ? "bg-gray-100 dark:bg-[#1F1F23] text-gray-900 dark:text-white"
-              : "text-gray-600 dark:text-gray-300",
+              ? "bg-gray-100 text-gray-900"
+              : "text-gray-600",
             level > 0 && "text-xs"
           )}
         >
@@ -210,7 +210,7 @@ export function MenuItem({
       {hasSubmenu && (
         <div
           className={cn(
-            "mt-1 pl-4 border-l border-gray-200 dark:border-gray-700",
+            "mt-1 pl-4 border-l border-gray-200",
             "overflow-hidden transition-all duration-300 ease-in-out",
             isSubmenuOpen ? "max-h-96 opacity-100" : "max-h-0 opacity-0"
           )}

--- a/src/theme/dashboard/sidebar/components/menu/MenuSection.tsx
+++ b/src/theme/dashboard/sidebar/components/menu/MenuSection.tsx
@@ -16,7 +16,7 @@ export function MenuSection({
     >
       {/* Título da seção - visível apenas quando não está colapsado */}
       {!isCollapsed && (
-        <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 transition-opacity duration-200">
+        <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-500 transition-opacity duration-200">
           {section.title}
         </div>
       )}

--- a/src/theme/dashboard/sidebar/modules/project-selector/components/ProjectSelector.tsx
+++ b/src/theme/dashboard/sidebar/modules/project-selector/components/ProjectSelector.tsx
@@ -51,7 +51,7 @@ export function ProjectSelector({ isCollapsed = false }: ProjectSelectorProps) {
         className={cn(
           "w-full flex items-center p-2 rounded-lg transition-all duration-300",
           isCollapsed ? "justify-center" : "justify-between",
-          "hover:bg-slate-100 dark:hover:bg-slate-800",
+          "hover:bg-slate-100",
           "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50"
         )}
         aria-label="Selecionar projeto"
@@ -63,8 +63,8 @@ export function ProjectSelector({ isCollapsed = false }: ProjectSelectorProps) {
               size={isCollapsed ? "md" : "sm"}
             />
           ) : (
-            <div className="w-8 h-8 rounded-md bg-slate-200 dark:bg-slate-700 flex items-center justify-center">
-              <span className="text-xs font-medium text-slate-500 dark:text-slate-400">
+            <div className="w-8 h-8 rounded-md bg-slate-200 flex items-center justify-center">
+              <span className="text-xs font-medium text-slate-500">
                 ?
               </span>
             </div>
@@ -81,11 +81,11 @@ export function ProjectSelector({ isCollapsed = false }: ProjectSelectorProps) {
                 transition={{ duration: 0.2 }}
                 className="text-left overflow-hidden"
               >
-                <p className="text-sm font-medium text-slate-900 dark:text-white truncate max-w-[160px]">
+                <p className="text-sm font-medium text-slate-900 truncate max-w-[160px]">
                   {truncateName(selectedProject.name)}
                 </p>
                 {isLoading && (
-                  <p className="text-xs text-slate-500 dark:text-slate-400">
+                  <p className="text-xs text-slate-500">
                     Carregando dados...
                   </p>
                 )}
@@ -106,7 +106,7 @@ export function ProjectSelector({ isCollapsed = false }: ProjectSelectorProps) {
               <Icon
                 name="ChevronDown"
                 size={16}
-                className="text-slate-500 dark:text-slate-400 flex-shrink-0 transition-transform duration-200"
+                className="text-slate-500 flex-shrink-0 transition-transform duration-200"
               />
             </motion.div>
           )}

--- a/src/theme/dashboard/sidebar/modules/project-selector/components/ProjectSelectorModal.tsx
+++ b/src/theme/dashboard/sidebar/modules/project-selector/components/ProjectSelectorModal.tsx
@@ -189,8 +189,8 @@ export function ProjectSelectorModal() {
                       className={cn(
                         "flex items-center gap-3 p-3 rounded-lg cursor-pointer border transition-all",
                         temporarySelectedProject?.id === project.id
-                          ? "bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-700"
-                          : "hover:bg-gray-50 dark:hover:bg-gray-800/50 border-gray-200 dark:border-gray-700",
+                          ? "bg-blue-50 border-blue-200"
+                          : "hover:bg-gray-50 border-gray-200",
                         isConfirmingSelection &&
                           "opacity-60 pointer-events-none"
                       )}
@@ -204,10 +204,10 @@ export function ProjectSelectorModal() {
                       <ProjectAvatar project={project} size="md" />
 
                       <div className="flex-1 min-w-0">
-                        <h3 className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                        <h3 className="text-sm font-medium text-gray-900 truncate">
                           {project.name}
                         </h3>
-                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                        <p className="text-xs text-gray-500">
                           Criado em:{" "}
                           {new Date(project.createdAt).toLocaleDateString()}
                         </p>
@@ -235,7 +235,7 @@ export function ProjectSelectorModal() {
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -10 }}
                   transition={{ duration: 0.2 }}
-                  className="flex flex-col items-center justify-center py-10 text-gray-500 dark:text-gray-400"
+                  className="flex flex-col items-center justify-center py-10 text-gray-500"
                 >
                   <Icon name="Info" size={40} className="mb-2 opacity-50" />
                   <p className="text-center">

--- a/src/theme/website/components/about-advantages/AboutAdvantages.tsx
+++ b/src/theme/website/components/about-advantages/AboutAdvantages.tsx
@@ -46,19 +46,19 @@ const AboutAdvantages: React.FC<AboutAdvantagesProps> = ({
               {Array.from({ length: 4 }).map((_, index) => (
                 <div
                   key={index}
-                  className="bg-gray-200 dark:bg-gray-700 rounded-lg p-6 animate-pulse"
+                  className="bg-gray-200 rounded-lg p-6 animate-pulse"
                 >
-                  <div className="w-16 h-16 bg-gray-300 dark:bg-gray-600 rounded-full mx-auto mb-4" />
-                  <div className="h-4 bg-gray-300 dark:bg-gray-600 rounded mb-2" />
-                  <div className="h-3 bg-gray-300 dark:bg-gray-600 rounded w-3/4 mx-auto" />
+                  <div className="w-16 h-16 bg-gray-300 rounded-full mx-auto mb-4" />
+                  <div className="h-4 bg-gray-300 rounded mb-2" />
+                  <div className="h-3 bg-gray-300 rounded w-3/4 mx-auto" />
                 </div>
               ))}
             </div>
             <div className="flex-1 space-y-4">
-              <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-              <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-              <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-3/4" />
-              <div className="h-12 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-48" />
+              <div className="h-8 bg-gray-200 rounded animate-pulse" />
+              <div className="h-4 bg-gray-200 rounded animate-pulse" />
+              <div className="h-4 bg-gray-200 rounded animate-pulse w-3/4" />
+              <div className="h-12 bg-gray-200 rounded animate-pulse w-48" />
             </div>
           </div>
         </section>
@@ -68,13 +68,13 @@ const AboutAdvantages: React.FC<AboutAdvantagesProps> = ({
           <div className="container mx-auto">
             <div className="flex flex-col lg:flex-row gap-8">
               <div className="w-full lg:w-1/2 space-y-4">
-                <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-2/3" />
+                <div className="h-8 bg-gray-200 rounded animate-pulse" />
+                <div className="h-4 bg-gray-200 rounded animate-pulse" />
+                <div className="h-4 bg-gray-200 rounded animate-pulse" />
+                <div className="h-4 bg-gray-200 rounded animate-pulse w-2/3" />
               </div>
               <div className="w-full lg:w-1/2">
-                <div className="aspect-[530/360] bg-gray-200 dark:bg-gray-700 animate-pulse rounded-lg" />
+                <div className="aspect-[530/360] bg-gray-200 animate-pulse rounded-lg" />
               </div>
             </div>
           </div>
@@ -95,7 +95,7 @@ const AboutAdvantages: React.FC<AboutAdvantagesProps> = ({
             icon="AlertCircle"
             className="mx-auto mb-6"
           />
-          <p className="text-gray-600 dark:text-gray-400 mb-4 max-w-md mx-auto">
+          <p className="text-gray-600 mb-4 max-w-md mx-auto">
             Não foi possível carregar as informações sobre a empresa.
             {error.includes("padrão") ? " Exibindo dados de exemplo." : ""}
           </p>

--- a/src/theme/website/components/about-advantages/components/AboutSection.tsx
+++ b/src/theme/website/components/about-advantages/components/AboutSection.tsx
@@ -36,7 +36,7 @@ export const AboutSection: React.FC<AboutSectionProps> = ({ data }) => {
               {data.paragraphs.map((paragraph, index) => (
                 <p
                   key={index}
-                  className="text-lg text-gray-600 dark:text-gray-300 leading-relaxed max-w-4xl mx-auto mb-4"
+                  className="text-lg text-gray-600 leading-relaxed max-w-4xl mx-auto mb-4"
                 >
                   {paragraph}
                 </p>
@@ -49,7 +49,7 @@ export const AboutSection: React.FC<AboutSectionProps> = ({ data }) => {
             <div className="relative rounded-lg overflow-hidden shadow-lg h-full">
               {/* Loading State */}
               {isLoading && (
-                <div className="aspect-[530/360] bg-gray-200 dark:bg-gray-700 animate-pulse rounded-lg flex items-center justify-center">
+                <div className="aspect-[530/360] bg-gray-200 animate-pulse rounded-lg flex items-center justify-center">
                   <div className="w-8 h-8 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
                 </div>
               )}

--- a/src/theme/website/components/about-advantages/components/WhyChooseSection.tsx
+++ b/src/theme/website/components/about-advantages/components/WhyChooseSection.tsx
@@ -31,7 +31,7 @@ export const WhyChooseSection: React.FC<WhyChooseSectionProps> = ({
           <h2 className="text-4xl font-bold text-[var(--primary-color)] mb-6">
             {data.title}
           </h2>
-          <p className="text-gray-600 dark:text-gray-300 text-lg leading-relaxed mb-6">
+          <p className="text-gray-600 text-lg leading-relaxed mb-6">
             {data.description}
           </p>
 

--- a/src/theme/website/components/about/index.tsx
+++ b/src/theme/website/components/about/index.tsx
@@ -10,15 +10,15 @@ function AboutSkeleton() {
       <div className="max-w-6xl mx-auto">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
           {/* Image skeleton */}
-          <div className="w-full h-96 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />
+          <div className="w-full h-96 bg-gray-200 rounded-lg animate-pulse" />
 
           {/* Content skeleton */}
           <div className="space-y-4">
-            <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-3/4 animate-pulse" />
+            <div className="h-8 bg-gray-200 rounded w-3/4 animate-pulse" />
             <div className="space-y-2">
-              <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-              <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-              <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-5/6 animate-pulse" />
+              <div className="h-4 bg-gray-200 rounded animate-pulse" />
+              <div className="h-4 bg-gray-200 rounded animate-pulse" />
+              <div className="h-4 bg-gray-200 rounded w-5/6 animate-pulse" />
             </div>
           </div>
         </div>

--- a/src/theme/website/components/blog-section/BlogSection.tsx
+++ b/src/theme/website/components/blog-section/BlogSection.tsx
@@ -95,9 +95,9 @@ const BlogSection: React.FC<BlogSectionProps> = ({
       >
         {/* Header Skeleton */}
         <div className="flex items-center justify-between mb-8">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-80" />
+          <div className="h-8 bg-gray-200 rounded animate-pulse w-80" />
           {!isMobile && (
-            <div className="h-12 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-48" />
+            <div className="h-12 bg-gray-200 rounded animate-pulse w-48" />
           )}
         </div>
 
@@ -106,7 +106,7 @@ const BlogSection: React.FC<BlogSectionProps> = ({
           {Array.from({ length: maxPosts }).map((_, index) => (
             <div
               key={index}
-              className="bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse"
+              className="bg-gray-200 rounded-lg animate-pulse"
               style={{ aspectRatio: "7/9" }}
             />
           ))}
@@ -115,7 +115,7 @@ const BlogSection: React.FC<BlogSectionProps> = ({
         {/* Mobile Button Skeleton */}
         {isMobile && (
           <div className="mt-4 flex justify-center">
-            <div className="h-12 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-48" />
+            <div className="h-12 bg-gray-200 rounded animate-pulse w-48" />
           </div>
         )}
       </section>
@@ -134,7 +134,7 @@ const BlogSection: React.FC<BlogSectionProps> = ({
             icon="FileText"
             className="mx-auto mb-6"
           />
-          <p className="text-gray-600 dark:text-gray-400 mb-4 max-w-md mx-auto">
+          <p className="text-gray-600 mb-4 max-w-md mx-auto">
             Não foi possível carregar os posts do blog.
             {error.includes("padrão") ? " Exibindo dados de exemplo." : ""}
           </p>

--- a/src/theme/website/components/blog-section/components/BlogCard.tsx
+++ b/src/theme/website/components/blog-section/components/BlogCard.tsx
@@ -35,7 +35,7 @@ export const BlogCard: React.FC<BlogCardProps> = ({ post, onPostClick }) => {
       <div className="relative w-full aspect-[7/9] bg-gray-200">
         {/* Loading State */}
         {isLoading && !hasError && (
-          <div className="absolute inset-0 bg-gray-200 dark:bg-gray-700 animate-pulse flex items-center justify-center z-10">
+          <div className="absolute inset-0 bg-gray-200 animate-pulse flex items-center justify-center z-10">
             <div className="w-8 h-8 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
           </div>
         )}

--- a/src/theme/website/components/communication-highlights/CommunicationHighlights.tsx
+++ b/src/theme/website/components/communication-highlights/CommunicationHighlights.tsx
@@ -63,20 +63,20 @@ const CommunicationHighlights: React.FC<CommunicationHighlightsProps> = ({
       >
         {/* Skeleton do texto */}
         <div className="lg:w-1/2 w-full space-y-6">
-          <div className="h-10 bg-gray-200 dark:bg-gray-700 rounded animate-pulse mb-6" />
+          <div className="h-10 bg-gray-200 rounded animate-pulse mb-6" />
           <div className="space-y-4">
-            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-3/4" />
+            <div className="h-4 bg-gray-200 rounded animate-pulse" />
+            <div className="h-4 bg-gray-200 rounded animate-pulse" />
+            <div className="h-4 bg-gray-200 rounded animate-pulse w-3/4" />
           </div>
           <div className="space-y-4">
-            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-2/3" />
+            <div className="h-4 bg-gray-200 rounded animate-pulse" />
+            <div className="h-4 bg-gray-200 rounded animate-pulse w-2/3" />
           </div>
           <div className="space-y-4">
-            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-4/5" />
+            <div className="h-4 bg-gray-200 rounded animate-pulse" />
+            <div className="h-4 bg-gray-200 rounded animate-pulse" />
+            <div className="h-4 bg-gray-200 rounded animate-pulse w-4/5" />
           </div>
         </div>
 
@@ -85,7 +85,7 @@ const CommunicationHighlights: React.FC<CommunicationHighlightsProps> = ({
           {Array.from({ length: 4 }).map((_, index) => (
             <div
               key={index}
-              className="aspect-[4/3] bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse"
+              className="aspect-[4/3] bg-gray-200 rounded-lg animate-pulse"
             />
           ))}
         </div>
@@ -107,7 +107,7 @@ const CommunicationHighlights: React.FC<CommunicationHighlightsProps> = ({
             icon="AlertCircle"
             className="mx-auto mb-6"
           />
-          <p className="text-gray-600 dark:text-gray-400 mb-4 max-w-md mx-auto">
+          <p className="text-gray-600 mb-4 max-w-md mx-auto">
             Não foi possível carregar as informações de comunicação.
             {error.includes("padrão") ? " Exibindo dados de exemplo." : ""}
           </p>

--- a/src/theme/website/components/communication-highlights/components/ImageGallery.tsx
+++ b/src/theme/website/components/communication-highlights/components/ImageGallery.tsx
@@ -37,7 +37,7 @@ export const ImageGallery: React.FC<ImageGalleryProps> = ({ images }) => {
         >
           {/* Loading State */}
           {loadingStates[image.id] && (
-            <div className="aspect-[4/3] bg-gray-200 dark:bg-gray-700 animate-pulse flex items-center justify-center">
+            <div className="aspect-[4/3] bg-gray-200 animate-pulse flex items-center justify-center">
               <div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
             </div>
           )}

--- a/src/theme/website/components/communication-highlights/components/TextContent.tsx
+++ b/src/theme/website/components/communication-highlights/components/TextContent.tsx
@@ -27,7 +27,7 @@ export const TextContent: React.FC<TextContentProps> = ({ content }) => {
           {highlight}
         </span>
         {citation && (
-          <span className="italic text-gray-600 dark:text-gray-400 ml-1">
+          <span className="italic text-gray-600 ml-1">
             {citation}
           </span>
         )}
@@ -49,7 +49,7 @@ export const TextContent: React.FC<TextContentProps> = ({ content }) => {
           {content.paragraphs.map((paragraph, index) => (
             <p
               key={index}
-              className="text-lg text-gray-700 dark:text-gray-300 leading-relaxed text-justify lg:text-left"
+              className="text-lg text-gray-700 leading-relaxed text-justify lg:text-left"
             >
               {index === 0
                 ? renderParagraphWithHighlight(

--- a/src/theme/website/components/contact-form-section/ContactFormSection.tsx
+++ b/src/theme/website/components/contact-form-section/ContactFormSection.tsx
@@ -81,23 +81,23 @@ const ContactFormSection: React.FC<ContactFormSectionProps> = ({
         <div className="flex flex-col lg:flex-row items-center gap-8">
           {/* Skeleton da imagem */}
           <div className="w-full lg:w-1/2">
-            <div className="aspect-[3/2] bg-gray-200 dark:bg-gray-700 animate-pulse rounded-lg" />
+            <div className="aspect-[3/2] bg-gray-200 animate-pulse rounded-lg" />
           </div>
 
           {/* Skeleton do formulário */}
           <div className="w-full lg:w-1/2">
-            <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-8 space-y-6">
-              <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded animate-pulse mx-auto w-48" />
-              <div className="h-1 bg-gray-200 dark:bg-gray-700 rounded animate-pulse mx-auto w-12" />
+            <div className="bg-gray-50 rounded-lg p-8 space-y-6">
+              <div className="h-8 bg-gray-200 rounded animate-pulse mx-auto w-48" />
+              <div className="h-1 bg-gray-200 rounded animate-pulse mx-auto w-12" />
               <div className="space-y-4">
                 {Array.from({ length: 6 }).map((_, i) => (
                   <div
                     key={i}
-                    className="h-12 bg-gray-200 dark:bg-gray-700 rounded animate-pulse"
+                    className="h-12 bg-gray-200 rounded animate-pulse"
                   />
                 ))}
-                <div className="h-20 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-                <div className="h-12 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-32 mx-auto" />
+                <div className="h-20 bg-gray-200 rounded animate-pulse" />
+                <div className="h-12 bg-gray-200 rounded animate-pulse w-32 mx-auto" />
               </div>
             </div>
           </div>
@@ -113,7 +113,7 @@ const ContactFormSection: React.FC<ContactFormSectionProps> = ({
         <div className="lg:w-1/2 flex justify-center relative">
           {/* Loading State */}
           {isImageLoading && (
-            <div className="aspect-[3/2] w-full max-w-[600px] bg-gray-200 dark:bg-gray-700 animate-pulse rounded-lg flex items-center justify-center">
+            <div className="aspect-[3/2] w-full max-w-[600px] bg-gray-200 animate-pulse rounded-lg flex items-center justify-center">
               <div className="w-8 h-8 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
             </div>
           )}

--- a/src/theme/website/components/contact-form-section/components/ContactForm.tsx
+++ b/src/theme/website/components/contact-form-section/components/ContactForm.tsx
@@ -43,12 +43,12 @@ export const ContactForm: React.FC<ContactFormProps> = ({
   // Se formulário foi enviado com sucesso
   if (formState.isSuccess) {
     return (
-      <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-8 text-center">
+      <div className="bg-gray-50 rounded-lg p-8 text-center">
         <CheckCircle className="w-16 h-16 text-green-500 mx-auto mb-4" />
-        <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+        <h3 className="text-xl font-bold text-gray-900 mb-2">
           Enviado com sucesso!
         </h3>
-        <p className="text-gray-600 dark:text-gray-400 mb-6">
+        <p className="text-gray-600 mb-6">
           {config.successMessage}
         </p>
         <Button onClick={resetForm} variant="outline" className="mx-auto">
@@ -59,12 +59,12 @@ export const ContactForm: React.FC<ContactFormProps> = ({
   }
 
   return (
-    <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-8">
+    <div className="bg-gray-50 rounded-lg p-8">
       {/* Título */}
-      <h2 className="text-2xl font-bold text-center mb-2 text-gray-900 dark:text-gray-100">
+      <h2 className="text-2xl font-bold text-center mb-2 text-gray-900">
         {config.title}
       </h2>
-      <hr className="border-t-2 border-gray-900 dark:border-gray-100 w-12 mx-auto mb-6" />
+      <hr className="border-t-2 border-gray-900 w-12 mx-auto mb-6" />
 
       <form onSubmit={handleSubmit} className="space-y-6">
         {/* Primeira linha - Nome e Nome da Empresa */}
@@ -74,7 +74,7 @@ export const ContactForm: React.FC<ContactFormProps> = ({
               placeholder="Seu Nome"
               value={formState.formData.name}
               onChange={(e) => updateField("name", e.target.value)}
-              className="bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600"
+              className="bg-white border-gray-300"
               disabled={formState.isSubmitting}
             />
             {formState.errors.name && (
@@ -88,7 +88,7 @@ export const ContactForm: React.FC<ContactFormProps> = ({
               placeholder="Nome da Empresa"
               value={formState.formData.companyName}
               onChange={(e) => updateField("companyName", e.target.value)}
-              className="bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600"
+              className="bg-white border-gray-300"
               disabled={formState.isSubmitting}
             />
             {formState.errors.companyName && (
@@ -107,7 +107,7 @@ export const ContactForm: React.FC<ContactFormProps> = ({
               placeholder="Email"
               value={formState.formData.email}
               onChange={(e) => updateField("email", e.target.value)}
-              className="bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600"
+              className="bg-white border-gray-300"
               disabled={formState.isSubmitting}
             />
             {formState.errors.email && (
@@ -122,7 +122,7 @@ export const ContactForm: React.FC<ContactFormProps> = ({
               placeholder="Telefone"
               value={formState.formData.phone}
               onChange={(e) => handlePhoneChange(e.target.value)}
-              className="bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600"
+              className="bg-white border-gray-300"
               disabled={formState.isSubmitting}
             />
             {formState.errors.phone && (
@@ -139,7 +139,7 @@ export const ContactForm: React.FC<ContactFormProps> = ({
             placeholder="CEP"
             value={formState.formData.cep}
             onChange={(e) => handleCepChangeWithFormat(e.target.value)}
-            className="bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600"
+            className="bg-white border-gray-300"
             disabled={formState.isSubmitting}
             maxLength={9}
           />
@@ -155,7 +155,7 @@ export const ContactForm: React.FC<ContactFormProps> = ({
               placeholder="Endereço"
               value={formState.formData.address}
               onChange={(e) => updateField("address", e.target.value)}
-              className="bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600"
+              className="bg-white border-gray-300"
               disabled={formState.isSubmitting || formState.fieldsDisabled}
             />
             {formState.errors.address && (
@@ -169,7 +169,7 @@ export const ContactForm: React.FC<ContactFormProps> = ({
               placeholder="Cidade"
               value={formState.formData.city}
               onChange={(e) => updateField("city", e.target.value)}
-              className="bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600"
+              className="bg-white border-gray-300"
               disabled={formState.isSubmitting || formState.fieldsDisabled}
             />
             {formState.errors.city && (
@@ -186,7 +186,7 @@ export const ContactForm: React.FC<ContactFormProps> = ({
             placeholder="Estado"
             value={formState.formData.state}
             onChange={(e) => updateField("state", e.target.value)}
-            className="bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600"
+            className="bg-white border-gray-300"
             disabled={formState.isSubmitting || formState.fieldsDisabled}
           />
           {formState.errors.state && (
@@ -202,7 +202,7 @@ export const ContactForm: React.FC<ContactFormProps> = ({
             placeholder="Tem algo mais para informar?"
             value={formState.formData.additionalInfo}
             onChange={(e) => updateField("additionalInfo", e.target.value)}
-            className="bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 min-h-[100px]"
+            className="bg-white border-gray-300 min-h-[100px]"
             disabled={formState.isSubmitting}
             rows={4}
           />

--- a/src/theme/website/components/course/CourseCatalog.tsx
+++ b/src/theme/website/components/course/CourseCatalog.tsx
@@ -198,7 +198,7 @@ const CourseCatalog: React.FC<CourseCatalogProps> = ({
               icon="AlertCircle"
               className="mx-auto mb-6"
             />
-            <p className="text-gray-600 dark:text-gray-400 mb-6 max-w-md mx-auto">
+            <p className="text-gray-600 mb-6 max-w-md mx-auto">
               Não foi possível carregar o catálogo de cursos.
               {error.includes("padrão") ? " Exibindo dados de exemplo." : ""}
             </p>

--- a/src/theme/website/components/course/components/CourseCard.tsx
+++ b/src/theme/website/components/course/components/CourseCard.tsx
@@ -56,7 +56,7 @@ export const CourseCard: React.FC<CourseCardProps> = ({ course, index }) => {
         <div className="relative overflow-hidden">
           {/* Loading State */}
           {isLoading && course.imagem && (
-            <div className="w-full h-48 bg-gray-200 dark:bg-gray-700 animate-pulse flex items-center justify-center">
+            <div className="w-full h-48 bg-gray-200 animate-pulse flex items-center justify-center">
               <div className="w-8 h-8 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
             </div>
           )}

--- a/src/theme/website/components/courses-carousel/components/CourseCard.tsx
+++ b/src/theme/website/components/courses-carousel/components/CourseCard.tsx
@@ -28,7 +28,7 @@ export const CourseCard: React.FC<CourseCardProps> = ({ course }) => {
     <>
       {/* Loading State */}
       {isLoading && !hasError && (
-        <div className="absolute inset-0 bg-gray-200 dark:bg-gray-700 animate-pulse flex items-center justify-center z-10">
+        <div className="absolute inset-0 bg-gray-200 animate-pulse flex items-center justify-center z-10">
           <div className="w-8 h-8 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
         </div>
       )}

--- a/src/theme/website/components/header-pages/HeaderPages.tsx
+++ b/src/theme/website/components/header-pages/HeaderPages.tsx
@@ -44,22 +44,22 @@ const HeaderPages: React.FC<HeaderPagesProps> = ({
           <div className="w-full flex flex-col lg:flex-row items-start justify-between">
             {/* Skeleton do texto */}
             <div className="text-center lg:text-left" style={{ width: "43%" }}>
-              <div className="h-6 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-32 mb-1" />
-              <div className="h-12 bg-gray-200 dark:bg-gray-700 rounded animate-pulse mb-4" />
+              <div className="h-6 bg-gray-200 rounded animate-pulse w-32 mb-1" />
+              <div className="h-12 bg-gray-200 rounded animate-pulse mb-4" />
               <div className="space-y-2 mb-6">
-                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-3/4" />
+                <div className="h-4 bg-gray-200 rounded animate-pulse" />
+                <div className="h-4 bg-gray-200 rounded animate-pulse w-3/4" />
               </div>
-              <div className="h-12 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-32" />
+              <div className="h-12 bg-gray-200 rounded animate-pulse w-32" />
             </div>
 
             {/* Skeleton da imagem - CORRIGIDO: Tamanho fixo 810x360 */}
             <div className="header-pages-container">
               <div className="header-pages-breadcrumbs mb-4">
-                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-48" />
+                <div className="h-4 bg-gray-200 rounded animate-pulse w-48" />
               </div>
               <div
-                className="bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse"
+                className="bg-gray-200 rounded-lg animate-pulse"
                 style={{
                   width: "810px",
                   height: "360px",
@@ -84,7 +84,7 @@ const HeaderPages: React.FC<HeaderPagesProps> = ({
             icon="AlertCircle"
             className="mx-auto mb-6"
           />
-          <p className="text-gray-600 dark:text-gray-400 mb-4 max-w-md mx-auto">
+          <p className="text-gray-600 mb-4 max-w-md mx-auto">
             Não foi possível carregar as informações do header.
             {error.includes("padrão") ? " Exibindo dados de exemplo." : ""}
           </p>

--- a/src/theme/website/components/header-pages/components/HeaderContent.tsx
+++ b/src/theme/website/components/header-pages/components/HeaderContent.tsx
@@ -39,7 +39,7 @@ export const HeaderContent: React.FC<HeaderContentProps> = ({ data }) => {
   // Componente de Breadcrumbs
   const BreadcrumbsComponent = () => (
     <nav className="header-pages-breadcrumbs">
-      <ol className="flex items-center space-x-2 text-sm text-gray-600 dark:text-gray-400">
+      <ol className="flex items-center space-x-2 text-sm text-gray-600">
         <li>
           <Link
             href="/"

--- a/src/theme/website/components/logo-enterprises/LogoEnterprises.tsx
+++ b/src/theme/website/components/logo-enterprises/LogoEnterprises.tsx
@@ -106,7 +106,7 @@ const LogoEnterprises: React.FC<LogoEnterprisesProps> = ({
             icon="Building2"
             className="mx-auto mb-6"
           />
-          <p className="text-gray-600 dark:text-gray-400 mb-4 max-w-md mx-auto">
+          <p className="text-gray-600 mb-4 max-w-md mx-auto">
             Não foi possível carregar os logos das empresas parceiras.
             {error.includes("padrão") ? " Exibindo dados de exemplo." : ""}
           </p>

--- a/src/theme/website/components/pricing-plans/PricingPlans.tsx
+++ b/src/theme/website/components/pricing-plans/PricingPlans.tsx
@@ -79,8 +79,8 @@ const PricingPlans: React.FC<PricingPlansProps> = ({
         className={cn("pxResponsive container w-full mx-auto py-24", className)}
       >
         <div className="text-center animate-fade-in mb-12">
-          <div className="h-10 bg-gray-200 dark:bg-gray-700 rounded w-64 mx-auto mb-4 animate-pulse" />
-          <div className="h-6 bg-gray-200 dark:bg-gray-700 rounded w-96 mx-auto animate-pulse" />
+          <div className="h-10 bg-gray-200 rounded w-64 mx-auto mb-4 animate-pulse" />
+          <div className="h-6 bg-gray-200 rounded w-96 mx-auto animate-pulse" />
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
@@ -125,7 +125,7 @@ const PricingPlans: React.FC<PricingPlansProps> = ({
             icon="AlertCircle"
             className="mx-auto mb-6"
           />
-          <p className="text-gray-600 dark:text-gray-400 mb-4 max-w-md mx-auto">
+          <p className="text-gray-600 mb-4 max-w-md mx-auto">
             Não foi possível carregar os planos de preços.
             {error.includes("padrão") ? " Exibindo dados de exemplo." : ""}
           </p>
@@ -146,10 +146,10 @@ const PricingPlans: React.FC<PricingPlansProps> = ({
     >
       {/* Header da seção */}
       <div className="text-center animate-fade-in mb-12">
-        <h2 className="text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+        <h2 className="text-4xl font-bold text-gray-900 mb-4">
           {title}
         </h2>
-        <p className="text-lg text-gray-600 dark:text-gray-400 leading-relaxed max-w-2xl mx-auto">
+        <p className="text-lg text-gray-600 leading-relaxed max-w-2xl mx-auto">
           {subtitle}
         </p>
       </div>

--- a/src/theme/website/components/problem-solution-section/ProblemSolutionSection.tsx
+++ b/src/theme/website/components/problem-solution-section/ProblemSolutionSection.tsx
@@ -73,12 +73,12 @@ const ProblemSolutionSection: React.FC<ProblemSolutionSectionProps> = ({
         <div className="flex flex-col lg:flex-row items-center gap-16">
           {/* Skeleton do texto */}
           <div className="lg:w-1/2 space-y-6">
-            <div className="h-12 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-            <div className="h-12 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-3/4" />
+            <div className="h-12 bg-gray-200 rounded animate-pulse" />
+            <div className="h-12 bg-gray-200 rounded animate-pulse w-3/4" />
             <div className="space-y-3">
-              <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-              <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-              <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-2/3" />
+              <div className="h-4 bg-gray-200 rounded animate-pulse" />
+              <div className="h-4 bg-gray-200 rounded animate-pulse" />
+              <div className="h-4 bg-gray-200 rounded animate-pulse w-2/3" />
             </div>
           </div>
 
@@ -87,13 +87,13 @@ const ProblemSolutionSection: React.FC<ProblemSolutionSectionProps> = ({
             {Array.from({ length: 3 }).map((_, index) => (
               <div
                 key={index}
-                className="flex items-start gap-6 p-6 bg-gray-100 dark:bg-gray-800 rounded-lg animate-pulse"
+                className="flex items-start gap-6 p-6 bg-gray-100 rounded-lg animate-pulse"
               >
-                <div className="w-14 h-14 bg-gray-200 dark:bg-gray-700 rounded-full flex-shrink-0" />
+                <div className="w-14 h-14 bg-gray-200 rounded-full flex-shrink-0" />
                 <div className="flex-1 space-y-2">
-                  <div className="h-6 bg-gray-200 dark:bg-gray-700 rounded" />
-                  <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded" />
-                  <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-3/4" />
+                  <div className="h-6 bg-gray-200 rounded" />
+                  <div className="h-4 bg-gray-200 rounded" />
+                  <div className="h-4 bg-gray-200 rounded w-3/4" />
                 </div>
               </div>
             ))}
@@ -117,7 +117,7 @@ const ProblemSolutionSection: React.FC<ProblemSolutionSectionProps> = ({
             icon="AlertCircle"
             className="mx-auto mb-6"
           />
-          <p className="text-gray-600 dark:text-gray-400 mb-4 max-w-md mx-auto">
+          <p className="text-gray-600 mb-4 max-w-md mx-auto">
             Não foi possível carregar as informações.
             {error.includes("padrão") ? " Exibindo dados de exemplo." : ""}
           </p>
@@ -141,11 +141,11 @@ const ProblemSolutionSection: React.FC<ProblemSolutionSectionProps> = ({
     >
       {/* Texto no lado esquerdo */}
       <div className="lg:w-1/2 text-center lg:text-left">
-        <h2 className="text-3xl lg:text-4xl xl:text-5xl font-bold text-gray-900 dark:text-gray-100 mb-8 leading-tight">
+        <h2 className="text-3xl lg:text-4xl xl:text-5xl font-bold text-gray-900 mb-8 leading-tight">
           {data.mainTitle}
         </h2>
 
-        <p className="text-lg text-gray-600 dark:text-gray-300 leading-relaxed mb-8 text-justify lg:text-left">
+        <p className="text-lg text-gray-600 leading-relaxed mb-8 text-justify lg:text-left">
           {data.mainDescription}
         </p>
 
@@ -154,7 +154,7 @@ const ProblemSolutionSection: React.FC<ProblemSolutionSectionProps> = ({
           <div className="mt-8 lg:hidden">
             {/* Loading State */}
             {imageLoading && (
-              <div className="aspect-video bg-gray-200 dark:bg-gray-700 animate-pulse rounded-lg flex items-center justify-center">
+              <div className="aspect-video bg-gray-200 animate-pulse rounded-lg flex items-center justify-center">
                 <div className="w-8 h-8 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
               </div>
             )}

--- a/src/theme/website/components/problem-solution-section/components/ProblemCard.tsx
+++ b/src/theme/website/components/problem-solution-section/components/ProblemCard.tsx
@@ -10,7 +10,7 @@ import type { ProblemCardProps } from "../types";
 export const ProblemCard: React.FC<ProblemCardProps> = ({ data, index }) => {
   return (
     <div
-      className="flex items-start gap-6 p-6 bg-white dark:bg-gray-800 rounded-lg shadow-soft hover:shadow-medium transition-all duration-300 border border-gray-200 dark:border-gray-700 hover:border-blue-300 dark:hover:border-blue-500 hover-lift"
+      className="flex items-start gap-6 p-6 bg-white rounded-lg shadow-soft hover:shadow-medium transition-all duration-300 border border-gray-200 hover:border-blue-300 hover-lift"
       style={{
         // Animação de entrada com stagger
         animationDelay: `${index * 150}ms`,
@@ -19,7 +19,7 @@ export const ProblemCard: React.FC<ProblemCardProps> = ({ data, index }) => {
       }}
     >
       {/* Ícone */}
-      <div className="flex items-center justify-center w-14 h-14 rounded-full bg-gray-50 dark:bg-gray-700 flex-shrink-0">
+      <div className="flex items-center justify-center w-14 h-14 rounded-full bg-gray-50 flex-shrink-0">
         <Icon
           name={data.icon as any}
           size={32}
@@ -32,10 +32,10 @@ export const ProblemCard: React.FC<ProblemCardProps> = ({ data, index }) => {
 
       {/* Conteúdo */}
       <div className="flex-1">
-        <h3 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2 leading-tight">
+        <h3 className="text-xl font-semibold text-gray-900 mb-2 leading-tight">
           {data.title}
         </h3>
-        <p className="text-gray-600 dark:text-gray-300 leading-relaxed text-base">
+        <p className="text-gray-600 leading-relaxed text-base">
           {data.description}
         </p>
       </div>

--- a/src/theme/website/components/process-steps/components/ProcessStepItem.tsx
+++ b/src/theme/website/components/process-steps/components/ProcessStepItem.tsx
@@ -39,7 +39,7 @@ export const ProcessStepItem: React.FC<ProcessStepItemProps> = ({
           // Renderiza imagem se fornecida
           <div className="relative w-16 h-16">
             {isImageLoading && (
-              <div className="absolute inset-0 bg-gray-200 dark:bg-gray-700 animate-pulse rounded-full flex items-center justify-center">
+              <div className="absolute inset-0 bg-gray-200 animate-pulse rounded-full flex items-center justify-center">
                 <div className="w-4 h-4 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
               </div>
             )}

--- a/src/theme/website/components/service-benefits/ServiceBenefits.tsx
+++ b/src/theme/website/components/service-benefits/ServiceBenefits.tsx
@@ -62,23 +62,23 @@ const ServiceBenefits: React.FC<ServiceBenefitsProps> = ({
           >
             {/* Skeleton da imagem */}
             <div className="lg:w-1/2 w-full">
-              <div className="w-full h-64 lg:h-80 bg-gray-200 dark:bg-gray-700 animate-pulse rounded-lg" />
+              <div className="w-full h-64 lg:h-80 bg-gray-200 animate-pulse rounded-lg" />
             </div>
 
             {/* Skeleton do texto */}
             <div className="lg:w-1/2 w-full space-y-4">
-              <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-              <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-3/4" />
+              <div className="h-8 bg-gray-200 rounded animate-pulse" />
+              <div className="h-8 bg-gray-200 rounded animate-pulse w-3/4" />
               <div className="space-y-2">
-                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-2/3" />
+                <div className="h-4 bg-gray-200 rounded animate-pulse" />
+                <div className="h-4 bg-gray-200 rounded animate-pulse" />
+                <div className="h-4 bg-gray-200 rounded animate-pulse w-2/3" />
               </div>
               <div className="space-y-3 mt-6">
                 {Array.from({ length: 4 }).map((_, i) => (
                   <div
                     key={i}
-                    className="h-10 bg-gray-200 dark:bg-gray-700 rounded-full animate-pulse w-3/4"
+                    className="h-10 bg-gray-200 rounded-full animate-pulse w-3/4"
                   />
                 ))}
               </div>
@@ -101,7 +101,7 @@ const ServiceBenefits: React.FC<ServiceBenefitsProps> = ({
             icon="AlertCircle"
             className="mx-auto mb-6"
           />
-          <p className="text-gray-600 dark:text-gray-400 mb-4 max-w-md mx-auto">
+          <p className="text-gray-600 mb-4 max-w-md mx-auto">
             Não foi possível carregar as informações dos benefícios.
             {error.includes("padrão") ? " Exibindo dados de exemplo." : ""}
           </p>

--- a/src/theme/website/components/service-benefits/components/ServiceBenefitsItem.tsx
+++ b/src/theme/website/components/service-benefits/components/ServiceBenefitsItem.tsx
@@ -50,7 +50,7 @@ export const ServiceBenefitsItem: React.FC<ServiceBenefitsItemProps> = ({
           <div
             className={`rounded-lg shadow-${
               isMobile ? "md" : "lg"
-            } bg-gray-200 dark:bg-gray-700 animate-pulse flex items-center justify-center`}
+            } bg-gray-200 animate-pulse flex items-center justify-center`}
             style={{
               width: isMobile ? 300 : 600,
               height: isMobile ? 200 : 400,

--- a/src/theme/website/components/service-highlight/ServiceHighlight.tsx
+++ b/src/theme/website/components/service-highlight/ServiceHighlight.tsx
@@ -62,27 +62,27 @@ const ServiceHighlight: React.FC<ServiceHighlightProps> = ({
           >
             {/* Skeleton do texto */}
             <div className="lg:col-span-1 space-y-4">
-              <div className="h-12 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-              <div className="h-12 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-3/4" />
+              <div className="h-12 bg-gray-200 rounded animate-pulse" />
+              <div className="h-12 bg-gray-200 rounded animate-pulse w-3/4" />
               <div className="space-y-2">
-                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-2/3" />
+                <div className="h-4 bg-gray-200 rounded animate-pulse" />
+                <div className="h-4 bg-gray-200 rounded animate-pulse" />
+                <div className="h-4 bg-gray-200 rounded animate-pulse w-2/3" />
               </div>
             </div>
 
             {/* Skeleton da imagem */}
             <div className="lg:col-span-1 flex justify-center">
-              <div className="aspect-[3/2] w-full max-w-[600px] bg-gray-200 dark:bg-gray-700 animate-pulse rounded-lg shadow-lg" />
+              <div className="aspect-[3/2] w-full max-w-[600px] bg-gray-200 animate-pulse rounded-lg shadow-lg" />
             </div>
 
             {/* Skeleton dos benefícios */}
             <div className="lg:col-span-1 space-y-6">
               {Array.from({ length: 3 }).map((_, benefitIndex) => (
                 <div key={benefitIndex} className="space-y-2">
-                  <div className="h-6 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-2/3" />
-                  <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-                  <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-5/6" />
+                  <div className="h-6 bg-gray-200 rounded animate-pulse w-2/3" />
+                  <div className="h-4 bg-gray-200 rounded animate-pulse" />
+                  <div className="h-4 bg-gray-200 rounded animate-pulse w-5/6" />
                 </div>
               ))}
             </div>
@@ -104,7 +104,7 @@ const ServiceHighlight: React.FC<ServiceHighlightProps> = ({
             icon="AlertCircle"
             className="mx-auto mb-6"
           />
-          <p className="text-gray-600 dark:text-gray-400 mb-4 max-w-md mx-auto">
+          <p className="text-gray-600 mb-4 max-w-md mx-auto">
             Não foi possível carregar as informações dos serviços.
             {error.includes("padrão") ? " Exibindo dados de exemplo." : ""}
           </p>

--- a/src/theme/website/components/service-highlight/components/HighlightSection.tsx
+++ b/src/theme/website/components/service-highlight/components/HighlightSection.tsx
@@ -42,11 +42,11 @@ export const HighlightSection: React.FC<HighlightSectionProps> = ({
         <h2 className="text-4xl text-[var(--primary-color)] sm:text-4xl mb-6 font-bold leading-tight text-center lg:text-left">
           {data.title}
         </h2>
-        <p className="text-gray-600 dark:text-gray-300 leading-relaxed text-justify text-lg mb-4">
+        <p className="text-gray-600 leading-relaxed text-justify text-lg mb-4">
           {data.description}
         </p>
         {data.highlightText && (
-          <p className="text-gray-600 dark:text-gray-300 leading-relaxed text-justify text-lg">
+          <p className="text-gray-600 leading-relaxed text-justify text-lg">
             <span className="text-red-500 font-bold">{data.highlightText}</span>
           </p>
         )}
@@ -57,7 +57,7 @@ export const HighlightSection: React.FC<HighlightSectionProps> = ({
         <div className="relative w-full max-w-[600px]">
           {/* Loading State */}
           {isLoading && (
-            <div className="aspect-[3/2] bg-gray-200 dark:bg-gray-700 animate-pulse rounded-lg shadow-lg flex items-center justify-center">
+            <div className="aspect-[3/2] bg-gray-200 animate-pulse rounded-lg shadow-lg flex items-center justify-center">
               <div className="w-8 h-8 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
             </div>
           )}
@@ -115,7 +115,7 @@ export const HighlightSection: React.FC<HighlightSectionProps> = ({
             <h3 className="text-xl font-semibold text-[var(--primary-color)] mb-2">
               {benefit.title}
             </h3>
-            <p className="text-gray-600 dark:text-gray-300 leading-relaxed text-justify">
+            <p className="text-gray-600 leading-relaxed text-justify">
               {benefit.description}
             </p>
           </div>

--- a/src/theme/website/components/testimonials-carousel/TestimonialsCarousel.tsx
+++ b/src/theme/website/components/testimonials-carousel/TestimonialsCarousel.tsx
@@ -77,8 +77,8 @@ const TestimonialsCarousel: React.FC<TestimonialsCarouselProps> = ({
       <section className={cn("py-16", className)}>
         <div className="container mx-auto">
           <div className="text-center mb-12">
-            <div className="h-10 bg-gray-200 dark:bg-gray-700 rounded w-64 mx-auto mb-4 animate-pulse" />
-            <div className="h-6 bg-gray-200 dark:bg-gray-700 rounded w-96 mx-auto animate-pulse" />
+            <div className="h-10 bg-gray-200 rounded w-64 mx-auto mb-4 animate-pulse" />
+            <div className="h-6 bg-gray-200 rounded w-96 mx-auto animate-pulse" />
           </div>
         </div>
       </section>

--- a/src/theme/website/components/training-results/TrainingResults.tsx
+++ b/src/theme/website/components/training-results/TrainingResults.tsx
@@ -105,7 +105,7 @@ const TrainingResults: React.FC<TrainingResultsProps> = ({
           icon="AlertCircle"
           className="mx-auto mb-6"
         />
-        <p className="text-gray-600 dark:text-gray-400 mb-4 max-w-md mx-auto">
+        <p className="text-gray-600 mb-4 max-w-md mx-auto">
           Não foi possível carregar os resultados do treinamento.
           {error.includes("padrão") ? " Exibindo dados de exemplo." : ""}
         </p>


### PR DESCRIPTION
## Summary
- drop `next-themes` and theme toggle
- strip all `dark:` Tailwind classes for a single light style
- set toast and chart components to light theme only

## Testing
- `pnpm lint` *(fails: react/no-unescaped-entities, @typescript-eslint/no-unused-vars, and other existing lint errors)*
- `pnpm build` *(fails: react/no-unescaped-entities, @typescript-eslint/no-unused-vars, and other existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6892df0888a88325874077a56ed8a309