### PR TITLE
fix: improve api fallback and asset handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@
 # API Configuration
 NEXT_PUBLIC_API_BASE_URL=https://advancemais-api-7h1q.onrender.com
 NEXT_PUBLIC_API_VERSION=v1
+NEXT_PUBLIC_API_FALLBACK=loading
 
 # Support Information
 NEXT_PUBLIC_SUPPORT_PHONE=82994360962

--- a/next.config.ts
+++ b/next.config.ts
@@ -32,7 +32,10 @@ const nextConfig = {
   },
 
   // Asset prefix baseado no ambiente
-  assetPrefix: process.env.NEXT_PUBLIC_BASE_URL || undefined,
+  assetPrefix:
+    process.env.NODE_ENV === "production"
+      ? process.env.NEXT_PUBLIC_BASE_URL || undefined
+      : undefined,
 
   // Configurações de performance
   poweredByHeader: false,

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -5,11 +5,14 @@
 
 type Environment = "development" | "production" | "test";
 
+export type ApiFallback = "loading" | "skeleton" | "mock";
+
 interface AppConfig {
   // API
   readonly apiBaseUrl: string;
   readonly apiVersion: string;
   readonly baseUrl: string;
+  readonly apiFallback: ApiFallback;
 
   // App Info
   readonly appName: string;
@@ -47,6 +50,7 @@ export const env: AppConfig = {
   ),
   apiVersion: getEnvVar("NEXT_PUBLIC_API_VERSION", "v1"),
   baseUrl: getEnvVar("NEXT_PUBLIC_BASE_URL", "https://advancemais.com.br"),
+  apiFallback: getEnvVar("NEXT_PUBLIC_API_FALLBACK", "loading") as ApiFallback,
 
   // App Configuration
   appName: getEnvVar("NEXT_PUBLIC_APP_NAME", "AdvanceMais"),

--- a/src/theme/website/components/about-advantages/constants/index.ts
+++ b/src/theme/website/components/about-advantages/constants/index.ts
@@ -1,6 +1,7 @@
 // src/theme/website/components/about-advantages/constants/index.ts
 
 import type { AboutAdvantagesApiData } from "../types";
+import { websiteRoutes } from "@/api/routes";
 
 /**
  * Dados padrão para fallback quando a API falha
@@ -77,7 +78,7 @@ export const DEFAULT_ABOUT_ADVANTAGES_DATA: AboutAdvantagesApiData = {
  */
 export const ABOUT_ADVANTAGES_CONFIG = {
   api: {
-    endpoint: "/api/about/advantages",
+    endpoint: websiteRoutes.home.about(),
     timeout: 5000,
     retryAttempts: 3,
     retryDelay: 1000,

--- a/src/theme/website/components/about-advantages/hooks/useAboutAdvantagesData.ts
+++ b/src/theme/website/components/about-advantages/hooks/useAboutAdvantagesData.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_ABOUT_ADVANTAGES_DATA,
   ABOUT_ADVANTAGES_CONFIG,
 } from "../constants";
+import { env } from "@/lib/env";
 
 interface UseAboutAdvantagesDataReturn {
   data: AboutAdvantagesApiData;
@@ -67,22 +68,33 @@ export function useAboutAdvantagesData(
       }
 
       setData(result.data);
+      setIsLoading(false);
     } catch (err) {
       console.error("Erro ao buscar dados de vantagens:", err);
 
       if (err instanceof Error) {
         if (err.name === "AbortError") {
-          setError("Tempo limite excedido. Usando dados padrão.");
+          setError("Tempo limite excedido.");
         } else {
-          setError(`Erro na API: ${err.message}. Usando dados padrão.`);
+          setError(`Erro na API: ${err.message}`);
         }
       } else {
-        setError("Erro desconhecido. Usando dados padrão.");
+        setError("Erro desconhecido");
       }
 
-      setData(DEFAULT_ABOUT_ADVANTAGES_DATA);
-    } finally {
-      setIsLoading(false);
+      switch (env.apiFallback) {
+        case "mock":
+          setData(DEFAULT_ABOUT_ADVANTAGES_DATA);
+          setIsLoading(false);
+          break;
+        case "skeleton":
+          setIsLoading(true);
+          break;
+        case "loading":
+        default:
+          setIsLoading(true);
+          break;
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- conditionally set asset prefix only in production
- expose `NEXT_PUBLIC_API_FALLBACK` to control API error strategy
- wire About Advantages section to central route and fallback options
- document `NEXT_PUBLIC_API_FALLBACK` in `.env.example`

## Testing
- `pnpm lint` *(fails: many existing lint errors)*
- `pnpm test` *(fails: missing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68935c1b573c832594d8a8b285bf5064