### PR TITLE
fix: update about API endpoint

### DIFF
--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -15,7 +15,7 @@ export const websiteRoutes = {
   update: (id: string) => `${prefix}/website/${id}`,
   delete: (id: string) => `${prefix}/website/${id}`,
   home: {
-    about: () => `${prefix}/website/home/about`,
+    about: () => `${prefix}/website/sobre`,
   },
 };
 

--- a/src/api/websites/components/about/index.ts
+++ b/src/api/websites/components/about/index.ts
@@ -4,47 +4,34 @@
  */
 
 import routes from "@/api/routes";
-import { apiConfig, buildApiUrl, env } from "@/lib/env";
+import { apiFetch } from "@/api/client";
+import { apiConfig, env } from "@/lib/env";
+import { aboutMockData } from "./mock";
 import { AboutApiResponse } from "./types";
-
-/**
- * Helper para log de requisições (movido do api-config)
- */
-function logApiRequest(url: string, method: string = "GET"): void {
-  if (env.isDevelopment) {
-    console.log(`🌐 API Request: ${method} ${url}`);
-  }
-}
 
 /**
  * Busca dados do componente About (Server-side)
  * @returns Promise com os dados do about
  */
 export async function getAboutData(): Promise<AboutApiResponse> {
-  const url = buildApiUrl(routes.website.home.about());
-
   try {
-    logApiRequest(url);
-
-    const response = await fetch(url, {
-      method: "GET",
-      headers: apiConfig.headers,
-      ...apiConfig.cache.medium, // 1 hora de cache
-    });
-
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-
-    const data: AboutApiResponse = await response.json();
+    const data = await apiFetch<AboutApiResponse>(
+      routes.website.home.about(),
+      {
+        init: { headers: apiConfig.headers, ...apiConfig.cache.medium },
+        mockData: aboutMockData,
+      },
+    );
 
     if (env.isDevelopment) {
-      console.log("✅ About data loaded:", data);
+      console.debug("✅ About data loaded:", data);
     }
 
     return data;
   } catch (error) {
-    console.error("❌ Erro ao buscar dados do About:", error);
+    if (env.isDevelopment) {
+      console.warn("❌ Erro ao buscar dados do About:", error);
+    }
     throw new Error("Falha ao carregar dados do About");
   }
 }
@@ -54,30 +41,24 @@ export async function getAboutData(): Promise<AboutApiResponse> {
  * Sem cache para dados dinâmicos no cliente
  */
 export async function getAboutDataClient(): Promise<AboutApiResponse> {
-  const url = buildApiUrl(routes.website.home.about());
-
   try {
-    logApiRequest(url, "GET");
-
-    const response = await fetch(url, {
-      method: "GET",
-      headers: apiConfig.headers,
-      // No cache para client-side
-    });
-
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-
-    const data = await response.json();
+    const data = await apiFetch<AboutApiResponse>(
+      routes.website.home.about(),
+      {
+        init: { headers: apiConfig.headers, cache: "no-store" },
+        mockData: aboutMockData,
+      },
+    );
 
     if (env.isDevelopment) {
-      console.log("✅ About data loaded (client):", data);
+      console.debug("✅ About data loaded (client):", data);
     }
 
     return data;
   } catch (error) {
-    console.error("❌ Erro ao buscar dados do About (client):", error);
+    if (env.isDevelopment) {
+      console.warn("❌ Erro ao buscar dados do About (client):", error);
+    }
     throw new Error("Falha ao carregar dados do About");
   }
 }


### PR DESCRIPTION
## Summary
- point about section requests to the correct `/website/sobre` endpoint
- use shared `apiFetch` helper for About requests to keep errors out of user consoles

## Testing
- `pnpm lint` *(fails: Unexpected any, unused vars and more)*
- `pnpm type-check`
- `curl -s https://advancemais-api-7h1q.onrender.com/api/v1/website/sobre | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68936ea514e08325aef6f4c0853b7832