### PR TITLE
fix: fetch about data via next proxy to avoid CORS

### DIFF
--- a/src/api/websites/components/about/index.ts
+++ b/src/api/websites/components/about/index.ts
@@ -41,14 +41,19 @@ export async function getAboutData(): Promise<AboutApiResponse> {
  * Sem cache para dados dinâmicos no cliente
  */
 export async function getAboutDataClient(): Promise<AboutApiResponse> {
+  const endpoint = routes.website.home.about();
+
   try {
-    const data = await apiFetch<AboutApiResponse>(
-      routes.website.home.about(),
-      {
-        init: { headers: apiConfig.headers, cache: "no-store" },
-        mockData: aboutMockData,
-      },
-    );
+    const res = await fetch(endpoint, {
+      cache: "no-store",
+      headers: apiConfig.headers,
+    });
+
+    if (!res.ok) {
+      throw new Error(`API responded with ${res.status}`);
+    }
+
+    const data = (await res.json()) as AboutApiResponse;
 
     if (env.isDevelopment) {
       console.debug("✅ About data loaded (client):", data);
@@ -59,6 +64,11 @@ export async function getAboutDataClient(): Promise<AboutApiResponse> {
     if (env.isDevelopment) {
       console.warn("❌ Erro ao buscar dados do About (client):", error);
     }
+
+    if (env.apiFallback === "mock") {
+      return aboutMockData;
+    }
+
     throw new Error("Falha ao carregar dados do About");
   }
 }

--- a/src/theme/website/components/about/index.tsx
+++ b/src/theme/website/components/about/index.tsx
@@ -1,7 +1,10 @@
-import { Suspense } from "react";
-import { getAboutData } from "@/api/websites/components/about";
-import AboutImage from "./components/AboutImage";
-import AboutContent from "./components/AboutContent";
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getAboutDataClient } from '@/api/websites/components/about';
+import type { AboutApiResponse } from '@/api/websites/components/about/types';
+import AboutImage from './components/AboutImage';
+import AboutContent from './components/AboutContent';
 
 // Loading component
 function AboutSkeleton() {
@@ -27,31 +30,17 @@ function AboutSkeleton() {
   );
 }
 
-// Main About component
-async function AboutSection() {
-  try {
-    const aboutData = await getAboutData();
+export default function AboutSection() {
+  const [data, setData] = useState<AboutApiResponse | null>(null);
+  const [error, setError] = useState(false);
 
-    return (
-      <section className="py-16 px-4">
-        <div className="max-w-6xl mx-auto">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
-            <AboutImage
-              src={aboutData.src}
-              alt={aboutData.title}
-              width={600}
-              height={400}
-            />
-            <AboutContent
-              title={aboutData.title}
-              description={aboutData.description}
-            />
-          </div>
-        </div>
-      </section>
-    );
-  } catch (error) {
-    // Error boundary ou fallback
+  useEffect(() => {
+    getAboutDataClient()
+      .then(setData)
+      .catch(() => setError(true));
+  }, []);
+
+  if (error) {
     return (
       <section className="py-16 px-4">
         <div className="max-w-6xl mx-auto text-center">
@@ -62,13 +51,28 @@ async function AboutSection() {
       </section>
     );
   }
-}
 
-// Export with Suspense wrapper
-export default function About() {
+  if (!data) {
+    return <AboutSkeleton />;
+  }
+
   return (
-    <Suspense fallback={<AboutSkeleton />}>
-      <AboutSection />
-    </Suspense>
+    <section className="py-16 px-4">
+      <div className="max-w-6xl mx-auto">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
+          <AboutImage
+            src={data.src}
+            alt={data.title}
+            width={600}
+            height={400}
+          />
+          <AboutContent
+            title={data.title}
+            description={data.description}
+          />
+        </div>
+      </div>
+    </section>
   );
 }
+


### PR DESCRIPTION
## Summary
- use client-side fetch through Next.js proxy for About section
- load data with `useEffect` and handle errors/skeleton on client

## Testing
- `pnpm lint --file src/api/websites/components/about/index.ts --file src/theme/website/components/about/index.tsx`
- `pnpm type-check`

`pnpm lint` (full) reports pre-existing errors in the repository.

------
https://chatgpt.com/codex/tasks/task_e_689380308238832588c19beb560e7c23