### PR TITLE
fix: map about api response

### DIFF
--- a/src/api/websites/components/about/types/index.ts
+++ b/src/api/websites/components/about/types/index.ts
@@ -4,6 +4,12 @@ export interface AboutApiResponse {
   description: string;
 }
 
+export interface AboutBackendResponse {
+  imagemUrl: string;
+  titulo: string;
+  descricao: string;
+}
+
 export interface AboutImageProps {
   src: string;
   alt: string;


### PR DESCRIPTION
## Summary
- map backend `imagemUrl`/`titulo`/`descricao` fields to `src`/`title`/`description`
- log about component fetches and fall back to mock data when API fails

## Testing
- `pnpm lint` (fails: existing unused variables and `any` types)
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_6893839127e48325a2de688aad0c9387