### PR TITLE
feat: add global loading for home page

### DIFF
--- a/src/app/website/layout-client.tsx
+++ b/src/app/website/layout-client.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { ToasterCustom } from "@/components/ui/custom/toast";
+import HeaderWithBackground from "@/theme/website/header";
+import WebsiteFooter from "@/theme/website/footer";
+import { LoadingProvider, useWebsiteLoading } from "./loading-context";
+import type { ReactNode } from "react";
+
+export default function LayoutClient({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <LoadingProvider>
+      <InnerLayout>{children}</InnerLayout>
+    </LoadingProvider>
+  );
+}
+
+function InnerLayout({ children }: { children: ReactNode }) {
+  const { isReady } = useWebsiteLoading();
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className={isReady ? "opacity-100" : "opacity-0"}>
+        {/* Header responsivo com navegação */}
+        <HeaderWithBackground />
+
+        {/* Conteúdo principal da aplicação */}
+        <main
+          id="main-content"
+          className="relative z-10 min-h-screen"
+          role="main"
+        >
+          {children}
+        </main>
+
+        {/* Footer do website */}
+        <WebsiteFooter />
+
+        {/* Sistema de notificações */}
+        <ToasterCustom
+          position="top-right"
+          theme="system"
+          richColors={true}
+          closeButton={false}
+          maxToasts={5}
+          gap={8}
+          defaultDuration={5000}
+        />
+      </div>
+
+      {!isReady && (
+        <div className="fixed inset-0 flex items-center justify-center bg-gray-100">
+          <div className="animate-pulse">
+            <div className="h-4 w-48 rounded bg-gray-300 mb-2"></div>
+            <div className="h-4 w-36 rounded bg-gray-300"></div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/app/website/layout.tsx
+++ b/src/app/website/layout.tsx
@@ -1,8 +1,7 @@
 // src/app/website/layout.tsx
 import type { Metadata } from "next";
-import { ToasterCustom } from "@/components/ui/custom/toast";
-import HeaderWithBackground from "@/theme/website/header";
-import WebsiteFooter from "@/theme/website/footer";
+import type { ReactNode } from "react";
+import LayoutClient from "./layout-client";
 
 export const metadata: Metadata = {
   title: "AdvanceMais - Inovação em Educação e Tecnologia",
@@ -61,35 +60,7 @@ export const metadata: Metadata = {
 export default function WebsiteLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
-  return (
-    <div className="min-h-screen bg-gray-50">
-      {/* Header responsivo com navegação */}
-      <HeaderWithBackground />
-
-      {/* Conteúdo principal da aplicação */}
-      <main
-        id="main-content"
-        className="relative z-10 min-h-screen"
-        role="main"
-      >
-        {children}
-      </main>
-
-      {/* Footer do website */}
-      <WebsiteFooter />
-
-      {/* Sistema de notificações */}
-      <ToasterCustom
-        position="top-right"
-        theme="system"
-        richColors={true}
-        closeButton={false}
-        maxToasts={5}
-        gap={8}
-        defaultDuration={5000}
-      />
-    </div>
-  );
+  return <LayoutClient>{children}</LayoutClient>;
 }

--- a/src/app/website/loading-context.tsx
+++ b/src/app/website/loading-context.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+interface LoadingContextValue {
+  register: () => void;
+  init: (total: number) => void;
+  isReady: boolean;
+}
+
+const LoadingContext = createContext<LoadingContextValue>({
+  register: () => {},
+  init: () => {},
+  isReady: true,
+});
+
+export function LoadingProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [total, setTotal] = useState(0);
+  const [loaded, setLoaded] = useState(0);
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  const register = useCallback(() => {
+    setLoaded((prev) => prev + 1);
+  }, []);
+
+  const init = useCallback((sections: number) => {
+    setTotal(sections);
+    setLoaded(0);
+  }, []);
+
+  const isReady = isClient && loaded >= total;
+
+  return (
+    <LoadingContext.Provider value={{ register, init, isReady }}>
+      {children}
+    </LoadingContext.Provider>
+  );
+}
+
+export const useWebsiteLoading = () => useContext(LoadingContext);
+

--- a/src/app/website/page.tsx
+++ b/src/app/website/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useCallback } from "react";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import Slider from "@/theme/website/components/slider";
 import AboutSection from "@/theme/website/components/about";
@@ -10,6 +10,7 @@ import BusinessGroupInformation from "@/theme/website/components/business-group-
 import CoursesCarousel from "@/theme/website/components/courses-carousel";
 import BlogSection from "@/theme/website/components/blog-section";
 import LogoEnterprises from "@/theme/website/components/logo-enterprises";
+import { useWebsiteLoading } from "./loading-context";
 
 /**
  * Página Inicial do Website Institucional
@@ -18,38 +19,32 @@ import LogoEnterprises from "@/theme/website/components/logo-enterprises";
  * e apresenta seus serviços, cursos e soluções.
  */
 export default function WebsiteHomePage() {
-  const [isClient, setIsClient] = useState(false);
+  const { register, init } = useWebsiteLoading();
 
   // Configura o título da página
   usePageTitle("Página Inicial");
 
-  // Evita problemas de hidratação
   useEffect(() => {
-    setIsClient(true);
-  }, []);
+    init(6);
+  }, [init]);
 
-  if (!isClient) {
-    return (
-      <div className="min-h-screen">
-        {/* Loading placeholder que é igual ao conteúdo */}
-        <section className="relative min-h-[300px] bg-gray-100">
-          <div className="flex items-center justify-center h-[300px]">
-            <div className="animate-pulse">
-              <div className="h-4 bg-gray-300 rounded w-48 mb-2"></div>
-              <div className="h-4 bg-gray-300 rounded w-36"></div>
-            </div>
-          </div>
-        </section>
-      </div>
-    );
-  }
+  const handleSectionLoaded = useCallback(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    (_?: unknown) => {
+      register();
+    },
+    [register]
+  );
 
   return (
     <div className="min-h-screen">
       {/* Hero Slider - Banner principal */}
       <Slider />
       {/* Seção Sobre a Empresa */}
-      <AboutSection />
+      <AboutSection
+        onDataLoaded={handleSectionLoaded}
+        onError={handleSectionLoaded}
+      />
       {/* Banners de Destaque */}
       <BannersGroup />
       {/* ============================================= */}
@@ -59,12 +54,8 @@ export default function WebsiteHomePage() {
         fetchFromApi={false}
         animated={true}
         animationDuration={1200}
-        onDataLoaded={(data) => {
-          console.log("Estatísticas carregadas:", data);
-        }}
-        onError={(error) => {
-          console.warn("Erro ao carregar estatísticas:", error);
-        }}
+        onDataLoaded={handleSectionLoaded}
+        onError={handleSectionLoaded}
       />
       {/* 
       ============================================= 
@@ -87,12 +78,8 @@ export default function WebsiteHomePage() {
       {/* ============================================= */}
       <BusinessGroupInformation
         fetchFromApi={false}
-        onDataLoaded={(data) => {
-          console.log("Seções de negócio carregadas:", data);
-        }}
-        onError={(error) => {
-          console.warn("Erro ao carregar seções:", error);
-        }}
+        onDataLoaded={handleSectionLoaded}
+        onError={handleSectionLoaded}
       />
       {/* 
       ============================================= 
@@ -116,12 +103,8 @@ export default function WebsiteHomePage() {
         title="Cursos em destaque"
         buttonText="Ver todos os cursos"
         buttonUrl="/cursos"
-        onDataLoaded={(data) => {
-          console.log("Cursos carregados:", data);
-        }}
-        onError={(error) => {
-          console.warn("Erro ao carregar cursos:", error);
-        }}
+        onDataLoaded={handleSectionLoaded}
+        onError={handleSectionLoaded}
       />
       {/* 
       ============================================= 
@@ -175,6 +158,8 @@ export default function WebsiteHomePage() {
         fetchFromApi={false}
         title="Últimas Notícias"
         buttonText="Ver todas"
+        onDataLoaded={handleSectionLoaded}
+        onError={handleSectionLoaded}
       />
       {/* // Com configurações customizadas
       <BlogSection
@@ -189,6 +174,8 @@ export default function WebsiteHomePage() {
       <LogoEnterprises
         fetchFromApi={false}
         title="Quem está com a gente nessa jornada"
+        onDataLoaded={handleSectionLoaded}
+        onError={handleSectionLoaded}
       />
     </div>
   );

--- a/src/theme/website/components/about/components/AboutContent.tsx
+++ b/src/theme/website/components/about/components/AboutContent.tsx
@@ -4,9 +4,13 @@ import { AboutContentProps } from "@/api/websites/components";
 
 const AboutContent = ({ title, description }: AboutContentProps) => {
   return (
-    <div className="w-full lg:w-1/2 lg:text-left">
-      <h2 className="mb-4 !text-[var(--primary-color)]">{title}</h2>
-      <p className="text-justify ">{description}</p>
+    <div className="w-full text-center lg:w-1/2 lg:text-left">
+      <h2 className="text-3xl lg:text-4xl font-bold mb-4 text-[var(--primary-color)] leading-tight">
+        {title}
+      </h2>
+      <p className="text-gray-600 mb-6 leading-relaxed text-justify lg:text-left text-base lg:text-lg">
+        {description}
+      </p>
     </div>
   );
 };

--- a/src/theme/website/components/about/index.tsx
+++ b/src/theme/website/components/about/index.tsx
@@ -1,77 +1,114 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { getAboutDataClient } from '@/api/websites/components/about';
 import type { AboutApiResponse } from '@/api/websites/components/about/types';
 import AboutImage from './components/AboutImage';
 import AboutContent from './components/AboutContent';
+import { ImageNotFound } from '@/components/ui/custom/image-not-found';
+import { ButtonCustom } from '@/components/ui/custom/button';
 
 // Loading component
-function AboutSkeleton() {
+function AboutSkeleton({ className = '' }: { className?: string }) {
   return (
-    <section className="py-16 px-4">
-      <div className="max-w-6xl mx-auto">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
-          {/* Image skeleton */}
-          <div className="w-full h-96 bg-gray-200 rounded-lg animate-pulse" />
+    <section
+      className={`container mx-auto pt-16 lg:pb-6 px-4 flex flex-col lg:flex-row items-center lg:gap-20 gap-6 mt-5 ${className}`}
+    >
+      {/* Image skeleton */}
+      <div className="w-full lg:w-1/2">
+        <div className="aspect-[3/2] bg-gray-200 animate-pulse rounded-lg" />
+      </div>
 
-          {/* Content skeleton */}
-          <div className="space-y-4">
-            <div className="h-8 bg-gray-200 rounded w-3/4 animate-pulse" />
-            <div className="space-y-2">
-              <div className="h-4 bg-gray-200 rounded animate-pulse" />
-              <div className="h-4 bg-gray-200 rounded animate-pulse" />
-              <div className="h-4 bg-gray-200 rounded w-5/6 animate-pulse" />
-            </div>
-          </div>
+      {/* Content skeleton */}
+      <div className="w-full lg:w-1/2 space-y-4">
+        <div className="h-8 bg-gray-200 rounded animate-pulse" />
+        <div className="h-8 bg-gray-200 rounded animate-pulse w-3/4" />
+        <div className="space-y-2">
+          <div className="h-4 bg-gray-200 rounded animate-pulse" />
+          <div className="h-4 bg-gray-200 rounded animate-pulse" />
+          <div className="h-4 bg-gray-200 rounded animate-pulse w-5/6" />
         </div>
       </div>
     </section>
   );
 }
 
-export default function AboutSection() {
-  const [data, setData] = useState<AboutApiResponse | null>(null);
-  const [error, setError] = useState(false);
+interface AboutSectionProps {
+  className?: string;
+  onDataLoaded?: (data: AboutApiResponse) => void;
+  onError?: (error: string) => void;
+}
 
-  useEffect(() => {
+export default function AboutSection({
+  className,
+  onDataLoaded,
+  onError,
+}: AboutSectionProps) {
+  const [data, setData] = useState<AboutApiResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchData = useCallback(() => {
+    setIsLoading(true);
+    setError(null);
     getAboutDataClient()
       .then(setData)
-      .catch(() => setError(true));
+      .catch((err: Error) => setError(err.message))
+      .finally(() => setIsLoading(false));
   }, []);
 
-  if (error) {
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  useEffect(() => {
+    if (data && !isLoading) {
+      onDataLoaded?.(data);
+    }
+  }, [data, isLoading, onDataLoaded]);
+
+  useEffect(() => {
+    if (error) {
+      onError?.(error);
+    }
+  }, [error, onError]);
+
+  if (isLoading) {
+    return <AboutSkeleton className={className} />;
+  }
+
+  if (error || !data) {
     return (
-      <section className="py-16 px-4">
-        <div className="max-w-6xl mx-auto text-center">
-          <p className="text-red-500">
-            Erro ao carregar informações. Tente novamente mais tarde.
-          </p>
-        </div>
-      </section>
+      <div className="container mx-auto py-16 px-4 text-center">
+        <ImageNotFound
+          size="lg"
+          variant="error"
+          message="Erro ao carregar informações"
+          icon="AlertCircle"
+          className="mx-auto mb-6"
+          showMessage={true}
+        />
+        <p className="text-gray-600 mb-4 max-w-md mx-auto">
+          Não foi possível carregar as informações do about.
+        </p>
+        <ButtonCustom onClick={fetchData} variant="default" icon="RefreshCw">
+          Tentar Novamente
+        </ButtonCustom>
+      </div>
     );
   }
 
-  if (!data) {
-    return <AboutSkeleton />;
-  }
-
   return (
-    <section className="py-16 px-4">
-      <div className="max-w-6xl mx-auto">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
-          <AboutImage
-            src={data.src}
-            alt={data.title}
-            width={600}
-            height={400}
-          />
-          <AboutContent
-            title={data.title}
-            description={data.description}
-          />
-        </div>
-      </div>
+    <section
+      className={`container mx-auto pt-16 lg:pb-6 px-4 flex flex-col lg:flex-row items-center lg:gap-20 gap-6 mt-5 ${className}`}
+    >
+      <AboutImage
+        src={data.src}
+        alt={data.title}
+        width={600}
+        height={400}
+      />
+      <AboutContent title={data.title} description={data.description} />
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- move global loading from the home page to the shared layout via a loading context
- wait for six async sections before revealing the site
- stabilize callbacks so each section reports readiness only once

## Testing
- `pnpm lint --dir src/app/website`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_6893c81e8f0c83259fb81b391f6ef376