### PR TITLE
fix: update loader import path

### DIFF
--- a/src/theme/website/components/about-advantages/AboutAdvantages.tsx
+++ b/src/theme/website/components/about-advantages/AboutAdvantages.tsx
@@ -11,7 +11,7 @@ import { ImageNotFound } from "@/components/ui/custom/image-not-found";
 import { ButtonCustom } from "@/components/ui/custom/button";
 import type { AboutAdvantagesProps } from "./types";
 import { env } from "@/lib/env";
-import { Loader } from "@/components/ui/loader";
+import { Loader } from "@/components/ui/custom/loader";
 
 const AboutAdvantages: React.FC<AboutAdvantagesProps> = ({
   className,


### PR DESCRIPTION
## Summary
- fix loader import path for AboutAdvantages

## Testing
- `npx eslint src/theme/website/components/about-advantages/AboutAdvantages.tsx`
- `pnpm lint` (fails: Unexpected any and unused variables)
- `pnpm type-check` (fails: Property 'register' does not exist on type 'SimpleLoadingContextValue')

------
https://chatgpt.com/codex/tasks/task_e_68950cfe7d1883259185362ce46aabdf