### PR TITLE
Improve API failure handling

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { motion } from "framer-motion";
+import { generateErrorSupportLink } from "@/lib/support";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function GlobalError({ error, reset }: ErrorProps) {
+  const handleContactSupport = () => {
+    const whatsappLink = generateErrorSupportLink(
+      error.message,
+      "Erro global da aplicação"
+    );
+    window.open(whatsappLink, "_blank");
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <div className="text-center space-y-6 max-w-md w-full">
+        <motion.div
+          initial={{ scale: 0 }}
+          animate={{ scale: 1 }}
+          className="w-16 h-16 bg-red-100 rounded-full mx-auto flex items-center justify-center"
+        >
+          <AlertTriangle className="w-8 h-8 text-red-600" />
+        </motion.div>
+
+        <div>
+          <h2 className="text-2xl font-bold text-[var(--primary-color)] mb-2">
+            Ops! Algo deu errado
+          </h2>
+          <p className="text-gray-600 text-sm">
+            {error.message || "Ocorreu um erro inesperado. Tente novamente."}
+          </p>
+        </div>
+
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <Button
+            onClick={reset}
+            variant="outline"
+            className="border-[var(--primary-color)] text-[var(--primary-color)] hover:bg-[var(--primary-color)] hover:text-white"
+          >
+            Tentar novamente
+          </Button>
+
+          <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+            <Button
+              onClick={handleContactSupport}
+              className="bg-[var(--secondary-color)] text-white hover:opacity-90"
+            >
+              Falar com suporte
+            </Button>
+          </motion.div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/theme/website/components/about-advantages/AboutAdvantages.tsx
+++ b/src/theme/website/components/about-advantages/AboutAdvantages.tsx
@@ -94,7 +94,7 @@ const AboutAdvantages: React.FC<AboutAdvantagesProps> = ({
   }
 
   // Estado de erro
-  if (error && !data) {
+  if (error && env.apiFallback !== "mock") {
     return (
       <div className={cn("py-16", className)}>
         <div className="container mx-auto px-4 text-center">

--- a/src/theme/website/components/about-advantages/hooks/useAboutAdvantagesData.ts
+++ b/src/theme/website/components/about-advantages/hooks/useAboutAdvantagesData.ts
@@ -72,7 +72,6 @@ export function useAboutAdvantagesData(
       }
 
       setData(result.data);
-      setIsLoading(false);
     } catch (err) {
       console.error("Erro ao buscar dados de vantagens:", err);
 
@@ -88,10 +87,9 @@ export function useAboutAdvantagesData(
 
       if (env.apiFallback === "mock") {
         setData(DEFAULT_ABOUT_ADVANTAGES_DATA);
-        setIsLoading(false);
-      } else {
-        setIsLoading(true);
       }
+    } finally {
+      setIsLoading(false);
     }
   };
 


### PR DESCRIPTION
## Summary
- ensure AboutAdvantages hook clears loading state and uses mock data fallback
- show error screen when API requests fail
- add global error page for unhandled runtime failures

## Testing
- `pnpm lint` *(fails: Unexpected any, unused vars, and other pre-existing issues)*
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_68951e1216d08325b84917c0e75e9886