### PR TITLE
refactor: simplify loader component

### DIFF
--- a/src/components/ui/custom/loader/loader.tsx
+++ b/src/components/ui/custom/loader/loader.tsx
@@ -26,7 +26,6 @@ export function Loader({
   showOverlay = true,
   fullScreen = true,
   className = "",
-  variant = "default",
 }: LoaderProps) {
   const overlayClasses = showOverlay
     ? "fixed inset-0 bg-white bg-opacity-90 z-50"
@@ -36,24 +35,16 @@ export function Loader({
     ? "fixed inset-0 flex items-center justify-center z-50"
     : "flex items-center justify-center p-8";
 
-  const loaderVariantClasses = {
-    default: "adv-loader-card",
-    minimal: "adv-loader-card-minimal",
-    compact: "adv-loader-card-compact",
-  };
-
   return (
     <div className={`${overlayClasses} ${containerClasses} ${className}`}>
-      <div className={loaderVariantClasses[variant]}>
-        <div className="adv-loader">
-          <p>Juntos, somos + </p>
-          <div className="adv-loader-words">
-            {LOADER_WORDS.map((word, index) => (
-              <span key={`${word}-${index}`} className="adv-loader-word">
-                {word}
-              </span>
-            ))}
-          </div>
+      <div className="adv-loader">
+        <p>Juntos, somos + </p>
+        <div className="adv-loader-words">
+          {LOADER_WORDS.map((word, index) => (
+            <span key={`${word}-${index}`} className="adv-loader-word">
+              {word}
+            </span>
+          ))}
         </div>
       </div>
     </div>
@@ -66,16 +57,14 @@ export function Loader({
 export function SimpleLoader({ className = "" }: { className?: string }) {
   return (
     <div className={`flex items-center justify-center p-4 ${className}`}>
-      <div className="adv-loader-card">
-        <div className="adv-loader">
-          <p>Juntos, somos + </p>
-          <div className="adv-loader-words">
-            {LOADER_WORDS.map((word, index) => (
-              <span key={`${word}-${index}`} className="adv-loader-word">
-                {word}
-              </span>
-            ))}
-          </div>
+      <div className="adv-loader">
+        <p>Juntos, somos + </p>
+        <div className="adv-loader-words">
+          {LOADER_WORDS.map((word, index) => (
+            <span key={`${word}-${index}`} className="adv-loader-word">
+              {word}
+            </span>
+          ))}
         </div>
       </div>
     </div>

--- a/src/components/ui/custom/loader/types.ts
+++ b/src/components/ui/custom/loader/types.ts
@@ -18,12 +18,6 @@ export interface LoaderProps {
    * Classes CSS customizadas
    */
   className?: string;
-
-  /**
-   * Variant do loader
-   * @default 'default'
-   */
-  variant?: "default" | "minimal" | "compact";
 }
 
 /**

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -2,35 +2,6 @@
 /* ENHANCED GLOBAL LOADER STYLES */
 /* ===================================== */
 
-.adv-loader-card {
-  /* Variável de cor para clipping suave */
-  --bg-color: #f6f3f4;
-  background-color: var(--bg-color);
-  padding: 2rem 3rem;
-  border-radius: 1.5rem;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-}
-
-/* Variant minimal - menor padding */
-.adv-loader-card-minimal {
-  --bg-color: #f6f3f4;
-  background-color: var(--bg-color);
-  padding: 1.5rem 2rem;
-  border-radius: 1rem;
-  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.2);
-}
-
-/* Variant compact - bem pequeno */
-.adv-loader-card-compact {
-  --bg-color: #f6f3f4;
-  background-color: var(--bg-color);
-  padding: 1rem 1.5rem;
-  border-radius: 0.75rem;
-  box-shadow: 0 3px 15px rgba(0, 0, 0, 0.2);
-}
-
 .adv-loader {
   color: rgb(124, 124, 124);
   font-family: "Poppins", sans-serif;
@@ -55,20 +26,6 @@
   position: relative;
   height: 40px;
   margin-left: 6px;
-}
-
-.adv-loader-words::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    var(--bg-color) 10%,
-    transparent 30%,
-    transparent 70%,
-    var(--bg-color) 90%
-  );
-  z-index: 20;
-  pointer-events: none;
 }
 
 .adv-loader-word {
@@ -110,11 +67,6 @@
 
 /* Responsividade do loader */
 @media (max-width: 768px) {
-  .adv-loader-card {
-    padding: 1.5rem 2rem;
-    border-radius: 1rem;
-  }
-
   .adv-loader {
     font-size: 20px;
     height: 32px;
@@ -131,11 +83,6 @@
 }
 
 @media (max-width: 480px) {
-  .adv-loader-card {
-    padding: 1rem 1.5rem;
-    border-radius: 0.75rem;
-  }
-
   .adv-loader {
     font-size: 18px;
     height: 28px;
@@ -168,8 +115,3 @@
   }
 }
 
-.adv-loader-card,
-.adv-loader-card-minimal,
-.adv-loader-card-compact {
-  animation: adv-loader-fade-in 0.6s ease-out forwards;
-}


### PR DESCRIPTION
## Summary
- remove card styling from loader component and CSS
- drop variant prop from loader types

## Testing
- `pnpm lint` *(fails: Unexpected any, unused vars, etc.)*
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_68952a1729b8832593ed0aa41ec45792