### PR TITLE
feat: improve loader text responsiveness

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -6,9 +6,9 @@
   color: rgb(124, 124, 124);
   font-family: "Poppins", sans-serif;
   font-weight: 500;
-  font-size: 32px;
+  font-size: clamp(32px, 6vw, 48px);
   box-sizing: content-box;
-  height: 52px;
+  height: 1.6em;
   padding: 10px;
   display: flex;
   align-items: center;
@@ -19,19 +19,22 @@
 .adv-loader p {
   margin: 0;
   white-space: nowrap;
+  font-size: 1.2em;
+  line-height: 1.6em;
+  height: 1.6em;
 }
 
 .adv-loader-words {
   overflow: hidden;
   position: relative;
-  height: 52px;
+  height: 1.6em;
   margin-left: 6px;
 }
 
 .adv-loader-word {
   display: block;
-  height: 52px;
-  line-height: 52px;
+  height: 1.6em;
+  line-height: 1.6em;
   padding-left: 6px;
   color: #00257d;
   animation: adv-spin 4s infinite;
@@ -66,39 +69,19 @@
 }
 
 /* Responsividade do loader */
-@media (max-width: 768px) {
-  .adv-loader {
-    font-size: 26px;
-    height: 42px;
-  }
-
-  .adv-loader-words {
-    height: 42px;
-  }
-
-  .adv-loader-word {
-    height: 42px;
-    line-height: 42px;
-  }
-}
-
 @media (max-width: 480px) {
   .adv-loader {
-    font-size: 22px;
-    height: 36px;
     flex-direction: column;
     align-items: flex-start;
     gap: 4px;
+    height: auto;
   }
 
   .adv-loader-words {
-    height: 36px;
     margin-left: 0;
   }
 
   .adv-loader-word {
-    height: 36px;
-    line-height: 36px;
     padding-left: 0;
   }
 }


### PR DESCRIPTION
## Summary
- enlarge loader tagline and rotating word
- switch loader sizing to clamp for better scaling
- adjust mobile layout for clearer display

## Testing
- `pnpm lint --file src/components/ui/custom/loader/loader.tsx`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_689542c4823c83258c89e7f77fa6a7a5