### PR TITLE
fix loading readiness timing

### DIFF
--- a/src/app/website/page.tsx
+++ b/src/app/website/page.tsx
@@ -1,17 +1,9 @@
 "use client";
 
-import React, { useEffect } from "react";
+import React from "react";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import Slider from "@/theme/website/components/slider";
 import AboutSection from "@/theme/website/components/about";
-import BannersGroup from "@/theme/website/components/banners";
-import CounterInformation from "@/theme/website/components/counter-information";
-import BusinessGroupInformation from "@/theme/website/components/business-group-information";
-import CoursesCarousel from "@/theme/website/components/courses-carousel";
-import BlogSection from "@/theme/website/components/blog-section";
-import LogoEnterprises from "@/theme/website/components/logo-enterprises";
-import { useWebsiteLoading } from "./loading-context";
-import { apiKeepAlive } from "@/lib/api-keep-alive";
 
 /**
  * Página Inicial do Website Institucional
@@ -20,26 +12,8 @@ import { apiKeepAlive } from "@/lib/api-keep-alive";
  * e apresenta seus serviços, cursos e soluções.
  */
 export default function WebsiteHomePage() {
-  const { setReady, setError } = useWebsiteLoading();
-
   // Configura o título da página
   usePageTitle("Página Inicial");
-
-  useEffect(() => {
-    // Inicia keep-alive da API
-    apiKeepAlive.start();
-
-    // Auto-ready após 2.5 segundos (antes do timeout de 3s)
-    const timer = setTimeout(() => {
-      console.log("📄 Página principal marcada como pronta");
-      setReady(true);
-    }, 2500);
-
-    return () => {
-      clearTimeout(timer);
-      apiKeepAlive.stop();
-    };
-  }, [setReady]);
 
   const handleComponentLoaded = (componentName: string) => {
     console.log(`✅ Componente carregado: ${componentName}`);

--- a/src/app/website/pagebackup.tsx
+++ b/src/app/website/pagebackup.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect } from "react";
+import React from "react";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import Slider from "@/theme/website/components/slider";
 import AboutSection from "@/theme/website/components/about";
@@ -10,8 +10,6 @@ import BusinessGroupInformation from "@/theme/website/components/business-group-
 import CoursesCarousel from "@/theme/website/components/courses-carousel";
 import BlogSection from "@/theme/website/components/blog-section";
 import LogoEnterprises from "@/theme/website/components/logo-enterprises";
-import { useWebsiteLoading } from "./loading-context";
-import { apiKeepAlive } from "@/lib/api-keep-alive";
 
 /**
  * Página Inicial do Website Institucional
@@ -20,26 +18,8 @@ import { apiKeepAlive } from "@/lib/api-keep-alive";
  * e apresenta seus serviços, cursos e soluções.
  */
 export default function WebsiteHomePage() {
-  const { setReady, setError } = useWebsiteLoading();
-
   // Configura o título da página
   usePageTitle("Página Inicial");
-
-  useEffect(() => {
-    // Inicia keep-alive da API
-    apiKeepAlive.start();
-
-    // Auto-ready após 2.5 segundos (antes do timeout de 3s)
-    const timer = setTimeout(() => {
-      console.log("📄 Página principal marcada como pronta");
-      setReady(true);
-    }, 2500);
-
-    return () => {
-      clearTimeout(timer);
-      apiKeepAlive.stop();
-    };
-  }, [setReady]);
 
   const handleComponentLoaded = (componentName: string) => {
     console.log(`✅ Componente carregado: ${componentName}`);

--- a/src/hooks/use-loading-status.ts
+++ b/src/hooks/use-loading-status.ts
@@ -1,5 +1,5 @@
 import { useWebsiteLoading } from "@/app/website/loading-context";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 interface UseLoadingStatusOptions {
   componentName?: string;
@@ -11,14 +11,28 @@ interface UseLoadingStatusOptions {
  */
 export function useLoadingStatus(options: UseLoadingStatusOptions = {}) {
   const { autoRegister = true } = options;
-  const { setReady, setError } = useWebsiteLoading();
-  const [hasRegistered, setHasRegistered] = useState(false);
+  const { startLoading, finishLoading, setError } = useWebsiteLoading();
+  const [isRegistered, setIsRegistered] = useState(false);
+
+  // Registra automaticamente o componente no contador global
+  useEffect(() => {
+    if (autoRegister && !isRegistered) {
+      startLoading();
+      setIsRegistered(true);
+    }
+
+    return () => {
+      if (autoRegister && isRegistered) {
+        finishLoading();
+      }
+    };
+  }, [autoRegister, isRegistered, startLoading, finishLoading]);
 
   // Marca o carregamento como concluído
   const markAsLoaded = () => {
-    if (!hasRegistered && autoRegister) {
-      setReady(true);
-      setHasRegistered(true);
+    if (isRegistered) {
+      finishLoading();
+      setIsRegistered(false);
     }
   };
 
@@ -36,6 +50,5 @@ export function useLoadingStatus(options: UseLoadingStatusOptions = {}) {
     markAsLoaded,
     reportError,
     clearError,
-    hasRegistered,
   };
 }

--- a/src/theme/website/components/about/components/AboutContent.tsx
+++ b/src/theme/website/components/about/components/AboutContent.tsx
@@ -4,11 +4,11 @@ import { AboutContentProps } from "@/api/websites/components";
 
 const AboutContent = ({ title, description }: AboutContentProps) => {
   return (
-    <div className="w-full text-center lg:w-1/2 lg:text-left">
-      <h2 className="text-3xl lg:text-4xl font-bold mb-4 text-[var(--primary-color)] leading-tight">
-        {title}
-      </h2>
-      <p className="text-gray-600 mb-6 leading-relaxed text-justify lg:text-left text-base lg:text-lg">
+    <div className="w-full lg:w-1/2 lg:text-left">
+      <h1 className="text-3xl mb-4 text-neutral-600">
+        <span className="font-bold">{title}</span>
+      </h1>
+      <p className="text-neutral-400 leading-relaxed text-justify lg:text-left text-base lg:text-lg">
         {description}
       </p>
     </div>

--- a/src/theme/website/components/about/components/AboutImage.tsx
+++ b/src/theme/website/components/about/components/AboutImage.tsx
@@ -21,24 +21,24 @@ const AboutImage = ({ src, alt, width, height }: AboutImageProps) => {
   return (
     <div className="w-full lg:w-1/2 relative">
       {/* Loading State */}
-      {isLoading && (
-        <div className="aspect-[3/2] bg-gray-200 animate-pulse rounded-lg flex items-center justify-center">
-          <div className="w-8 h-8 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
-        </div>
-      )}
+        {isLoading && (
+          <div className="aspect-[3/2] bg-gray-200 animate-pulse rounded-lg flex items-center justify-center">
+            <div className="w-8 h-8 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+          </div>
+        )}
 
       {/* Error State usando ImageNotFound */}
       {hasError && (
-        <ImageNotFound
-          size="full"
-          variant="muted"
-          aspectRatio="landscape"
-          message="Imagem indisponível"
-          icon="ImageOff"
-          className="aspect-[3/2] rounded-lg"
-          showMessage={true}
-        />
-      )}
+          <ImageNotFound
+            size="full"
+            variant="muted"
+            aspectRatio="landscape"
+            message="Imagem indisponível"
+            icon="ImageOff"
+            className="aspect-[3/2] rounded-lg shadow-lg"
+            showMessage={true}
+          />
+        )}
 
       {/* Main Image */}
       {!hasError && (
@@ -48,7 +48,7 @@ const AboutImage = ({ src, alt, width, height }: AboutImageProps) => {
           width={width}
           height={height}
           className={`
-            rounded-lg object-cover w-full
+            rounded-lg shadow-lg object-cover w-full
             transition-opacity duration-500
             ${isLoading ? "opacity-0 absolute inset-0" : "opacity-100"}
           `}

--- a/src/theme/website/components/about/index.tsx
+++ b/src/theme/website/components/about/index.tsx
@@ -7,28 +7,29 @@ import AboutImage from "./components/AboutImage";
 import AboutContent from "./components/AboutContent";
 import { ImageNotFound } from "@/components/ui/custom/image-not-found";
 import { ButtonCustom } from "@/components/ui/custom/button";
+import { useLoadingStatus } from "@/hooks/use-loading-status";
 
 // Loading skeleton component
 function AboutSkeleton({ className = "" }: { className?: string }) {
   return (
-    <section
-      className={`container mx-auto pt-16 lg:pb-6 px-4 flex flex-col lg:flex-row items-center lg:gap-20 gap-6 mt-5 ${className}`}
-    >
-      {/* Image skeleton */}
-      <div className="w-full lg:w-1/2">
-        <div className="aspect-[3/2] bg-gray-200 animate-pulse rounded-lg" />
-      </div>
-
-      {/* Content skeleton */}
-      <div className="w-full lg:w-1/2 space-y-4">
-        <div className="h-8 bg-gray-200 rounded animate-pulse" />
-        <div className="h-8 bg-gray-200 rounded animate-pulse w-3/4" />
-        <div className="space-y-2">
-          <div className="h-4 bg-gray-200 rounded animate-pulse" />
-          <div className="h-4 bg-gray-200 rounded animate-pulse" />
-          <div className="h-4 bg-gray-200 rounded animate-pulse w-5/6" />
+    <section className={className}>
+      <div className="container mx-auto py-16 px-4 flex flex-col lg:flex-row items-center gap-20 mt-5">
+        {/* Image skeleton */}
+        <div className="w-full lg:w-1/2">
+          <div className="aspect-[3/2] bg-gray-200 animate-pulse rounded-lg" />
         </div>
-        <div className="h-10 bg-gray-200 rounded animate-pulse w-32" />
+
+        {/* Content skeleton */}
+        <div className="w-full lg:w-1/2 space-y-4">
+          <div className="h-8 bg-gray-200 rounded animate-pulse" />
+          <div className="h-8 bg-gray-200 rounded animate-pulse w-3/4" />
+          <div className="space-y-2">
+            <div className="h-4 bg-gray-200 rounded animate-pulse" />
+            <div className="h-4 bg-gray-200 rounded animate-pulse" />
+            <div className="h-4 bg-gray-200 rounded animate-pulse w-5/6" />
+          </div>
+          <div className="h-10 bg-gray-200 rounded animate-pulse w-32" />
+        </div>
       </div>
     </section>
   );
@@ -45,21 +46,21 @@ function AboutError({
   className?: string;
 }) {
   return (
-    <section
-      className={`container mx-auto py-16 px-4 text-center ${className}`}
-    >
-      <ImageNotFound
-        size="lg"
-        variant="error"
-        message="Erro ao carregar informações"
-        icon="AlertCircle"
-        className="mx-auto mb-6"
-        showMessage={true}
-      />
-      <p className="text-gray-600 mb-6 max-w-md mx-auto">{error}</p>
-      <ButtonCustom onClick={onRetry} variant="primary" size="md">
-        Tentar Novamente
-      </ButtonCustom>
+    <section className={className}>
+      <div className="container mx-auto py-16 px-4 text-center">
+        <ImageNotFound
+          size="lg"
+          variant="error"
+          message="Erro ao carregar informações"
+          icon="AlertCircle"
+          className="mx-auto mb-6"
+          showMessage={true}
+        />
+        <p className="text-gray-600 mb-6 max-w-md mx-auto">{error}</p>
+        <ButtonCustom onClick={onRetry} variant="primary" size="md">
+          Tentar Novamente
+        </ButtonCustom>
+      </div>
     </section>
   );
 }
@@ -135,20 +136,24 @@ export default function AboutSection({
   onError,
 }: AboutSectionProps) {
   const { data, error, isLoading, retry, hasAutoRetried } = useAboutLoading();
+  const { markAsLoaded, reportError } = useLoadingStatus({ componentName: "About" });
 
   // Notify parent components about data loading
   useEffect(() => {
     if (data && !isLoading) {
       onDataLoaded?.(data);
+      markAsLoaded();
     }
-  }, [data, isLoading, onDataLoaded]);
+  }, [data, isLoading, onDataLoaded, markAsLoaded]);
 
   // Notify parent components about errors
   useEffect(() => {
-    if (error && hasAutoRetried) {
+    if (error && hasAutoRetried && !isLoading) {
       onError?.(error);
+      reportError(error);
+      markAsLoaded();
     }
-  }, [error, hasAutoRetried, onError]);
+  }, [error, hasAutoRetried, isLoading, onError, reportError, markAsLoaded]);
 
   // Loading state
   if (isLoading) {
@@ -168,21 +173,17 @@ export default function AboutSection({
 
   // Success state - render the actual content
   return (
-    <section
-      className={`container mx-auto pt-16 lg:pb-6 px-4 flex flex-col lg:flex-row items-center lg:gap-20 gap-6 mt-5 ${className}`}
-    >
-      {/* Image Section - CORRIGIDO: removido priority, adicionado width/height */}
-      <div className="w-full lg:w-1/2">
+    <section className={className}>
+      <div className="container mx-auto py-16 px-4 flex flex-col lg:flex-row items-center gap-20 mt-5">
+        {/* Image Section */}
         <AboutImage
           src={data.src}
           alt={data.title || "Sobre nós"}
           width={600}
           height={400}
         />
-      </div>
 
-      {/* Content Section */}
-      <div className="w-full lg:w-1/2">
+        {/* Content Section */}
         <AboutContent title={data.title} description={data.description} />
       </div>
     </section>


### PR DESCRIPTION
## Summary
- track pending loads in website loading provider instead of fixed timeout
- update loading hook and About section to report load completion
- remove early auto-ready from website homepage
- realign About section layout and styles with business-group-information component

## Testing
- `pnpm lint` *(fails: Unexpected any, @typescript-eslint/no-unused-vars, and others)*
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_68962c096b2083258832103e88902f3d