### PR TITLE
Fix About loading loop and add caching

### DIFF
--- a/src/api/websites/components/about/index.ts
+++ b/src/api/websites/components/about/index.ts
@@ -45,22 +45,17 @@ export async function getAboutData(): Promise<AboutApiResponse> {
 
 /**
  * Busca dados do componente About (Client-side)
- * Sem cache para dados dinâmicos no cliente
+ * Usa o cliente API com cache e suporte a mock
  */
 export async function getAboutDataClient(): Promise<AboutApiResponse> {
   const endpoint = routes.website.home.about();
 
   try {
-    const res = await fetch(endpoint, {
-      cache: "no-store",
-      headers: apiConfig.headers,
+    const raw = await apiFetch<AboutBackendResponse[]>(endpoint, {
+      init: { headers: apiConfig.headers },
+      cache: "short",
     });
 
-    if (!res.ok) {
-      throw new Error(`API responded with ${res.status}`);
-    }
-
-    const raw = (await res.json()) as AboutBackendResponse[];
     const data = mapAboutResponse(raw);
     console.log("✅ About data loaded (client):", data);
     return data;

--- a/src/hooks/use-loading-status.ts
+++ b/src/hooks/use-loading-status.ts
@@ -1,5 +1,5 @@
 import { useWebsiteLoading } from "@/app/website/loading-context";
-import { useEffect, useState } from "react";
+import { useEffect, useRef } from "react";
 
 interface UseLoadingStatusOptions {
   componentName?: string;
@@ -12,27 +12,27 @@ interface UseLoadingStatusOptions {
 export function useLoadingStatus(options: UseLoadingStatusOptions = {}) {
   const { autoRegister = true } = options;
   const { startLoading, finishLoading, setError } = useWebsiteLoading();
-  const [isRegistered, setIsRegistered] = useState(false);
+  const isRegisteredRef = useRef(false);
 
   // Registra automaticamente o componente no contador global
   useEffect(() => {
-    if (autoRegister && !isRegistered) {
+    if (autoRegister) {
       startLoading();
-      setIsRegistered(true);
+      isRegisteredRef.current = true;
     }
 
     return () => {
-      if (autoRegister && isRegistered) {
+      if (autoRegister && isRegisteredRef.current) {
         finishLoading();
       }
     };
-  }, [autoRegister, isRegistered, startLoading, finishLoading]);
+  }, [autoRegister, startLoading, finishLoading]);
 
   // Marca o carregamento como concluído
   const markAsLoaded = () => {
-    if (isRegistered) {
+    if (isRegisteredRef.current) {
       finishLoading();
-      setIsRegistered(false);
+      isRegisteredRef.current = false;
     }
   };
 

--- a/src/theme/website/components/about/index.tsx
+++ b/src/theme/website/components/about/index.tsx
@@ -5,8 +5,6 @@ import { getAboutDataClient } from "@/api/websites/components/about";
 import type { AboutApiResponse } from "@/api/websites/components/about/types";
 import AboutImage from "./components/AboutImage";
 import AboutContent from "./components/AboutContent";
-import { ImageNotFound } from "@/components/ui/custom/image-not-found";
-import { ButtonCustom } from "@/components/ui/custom/button";
 import { useLoadingStatus } from "@/hooks/use-loading-status";
 
 // Loading skeleton component
@@ -30,36 +28,6 @@ function AboutSkeleton({ className = "" }: { className?: string }) {
           </div>
           <div className="h-10 bg-gray-200 rounded animate-pulse w-32" />
         </div>
-      </div>
-    </section>
-  );
-}
-
-// Error component
-function AboutError({
-  error,
-  onRetry,
-  className = "",
-}: {
-  error: string;
-  onRetry: () => void;
-  className?: string;
-}) {
-  return (
-    <section className={className}>
-      <div className="container mx-auto py-16 px-4 text-center">
-        <ImageNotFound
-          size="lg"
-          variant="error"
-          message="Erro ao carregar informações"
-          icon="AlertCircle"
-          className="mx-auto mb-6"
-          showMessage={true}
-        />
-        <p className="text-gray-600 mb-6 max-w-md mx-auto">{error}</p>
-        <ButtonCustom onClick={onRetry} variant="primary" size="md">
-          Tentar Novamente
-        </ButtonCustom>
       </div>
     </section>
   );
@@ -135,7 +103,7 @@ export default function AboutSection({
   onDataLoaded,
   onError,
 }: AboutSectionProps) {
-  const { data, error, isLoading, retry, hasAutoRetried } = useAboutLoading();
+  const { data, error, isLoading, hasAutoRetried } = useAboutLoading();
   const { markAsLoaded, reportError } = useLoadingStatus({ componentName: "About" });
 
   // Notify parent components about data loading
@@ -160,15 +128,9 @@ export default function AboutSection({
     return <AboutSkeleton className={className} />;
   }
 
-  // Error state (after auto-retries)
+  // Error state (after auto-retries) - hide component if data is not available
   if (error || !data) {
-    return (
-      <AboutError
-        error={error || "Dados não encontrados"}
-        onRetry={retry}
-        className={className}
-      />
-    );
+    return null;
   }
 
   // Success state - render the actual content


### PR DESCRIPTION
## Summary
- prevent infinite global loading registration by stabilizing `useLoadingStatus`
- cache About API responses on client and return mock data on failure
- hide About section when data fails to load

## Testing
- `npx eslint src/api/websites/components/about/index.ts src/hooks/use-loading-status.ts src/theme/website/components/about/index.tsx`
- `npm run type-check`
- `npm run lint` *(fails: Unexpected any, unused vars in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68963492b34c8325b0c8c950a03653fd