### PR TITLE
fix: proxy api requests and stabilize loader

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -74,6 +74,17 @@ const nextConfig = {
     optimizeCss: true,
     scrollRestoration: true,
   },
+
+  // Proxy das rotas /api para o backend, evitando problemas de CORS
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination:
+          "https://advancemais-api-7h1q.onrender.com/api/:path*",
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;

--- a/src/app/website/loading-context.tsx
+++ b/src/app/website/loading-context.tsx
@@ -103,8 +103,8 @@ export function LoadingProvider({ children }: { children: React.ReactNode }) {
         </div>
       )}
 
-      {/* Content */}
-      {contextValue.isReady && !error && children}
+      {/* Content sempre renderizado; o Loader sobrepõe enquanto carrega */}
+      {!error && children}
     </SimpleLoadingContext.Provider>
   );
 }

--- a/src/lib/api-keep-alive.ts
+++ b/src/lib/api-keep-alive.ts
@@ -2,10 +2,13 @@
  * Keep-Alive para API da Render
  * Previne cold starts fazendo ping a cada 8 minutos
  */
+import { env } from "@/lib/env";
+
 class ApiKeepAlive {
   private interval: NodeJS.Timeout | null = null;
   private readonly PING_INTERVAL = 8 * 60 * 1000; // 8 minutos
-  private readonly API_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+  // Usa a base da API ou fallback para rota relativa /api
+  private readonly API_URL = env.apiBaseUrl || "/api";
 
   start() {
     if (typeof window === "undefined" || !this.API_URL) return;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -44,10 +44,8 @@ function getEnvVar(key: string, fallback: string = ""): string {
  */
 export const env: AppConfig = {
   // API Configuration
-  apiBaseUrl: getEnvVar(
-    "NEXT_PUBLIC_API_BASE_URL",
-    "https://advancemais-api-7h1q.onrender.com"
-  ),
+  // Base da API. Quando vazio, usa o mesmo domínio do front com rewrites.
+  apiBaseUrl: getEnvVar("NEXT_PUBLIC_API_BASE_URL", ""),
   apiVersion: getEnvVar("NEXT_PUBLIC_API_VERSION", "v1"),
   baseUrl: getEnvVar("NEXT_PUBLIC_BASE_URL", "https://advancemais.com.br"),
   apiFallback: getEnvVar("NEXT_PUBLIC_API_FALLBACK", "loading") as ApiFallback,


### PR DESCRIPTION
## Summary
- keep loader from unmounting page content to stop repeated requests
- proxy `/api/*` through Next.js to avoid CORS and use relative base URL
- tie API keep-alive to new base URL

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, unused vars, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68963b326958832580953d1bca6a912d