### PR TITLE
chore: relax eslint rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,16 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unnecessary-type-constraint": "off",
+      "prefer-const": "off",
+      "react-hooks/exhaustive-deps": "warn",
+      "react/no-unescaped-entities": "off",
+    },
+  },
 ];
 
 export default eslintConfig;


### PR DESCRIPTION
## Summary
- disable strict eslint rules for unused variables, explicit any and others

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68979d9ec5fc8325bbcb3b3e6c59bef7