### PR TITLE
feat: integrate slider with API

### DIFF
--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -16,6 +16,7 @@ export const websiteRoutes = {
   delete: (id: string) => `${prefix}/website/${id}`,
   home: {
     about: () => `${prefix}/website/sobre`,
+    slide: () => `${prefix}/website/slide`,
   },
 };
 

--- a/src/api/websites/components/index.ts
+++ b/src/api/websites/components/index.ts
@@ -1,6 +1,8 @@
 export { getAboutData, getAboutDataClient } from "./about";
+export { getSliderData, getSliderDataClient } from "./slide";
 export type {
   AboutApiResponse,
   AboutImageProps,
   AboutContentProps,
 } from "./about/types";
+export type { SlideBackendResponse, SlideApiResponse } from "./slide/types";

--- a/src/api/websites/components/slide/index.ts
+++ b/src/api/websites/components/slide/index.ts
@@ -1,0 +1,67 @@
+/**
+ * API Client para componente Slider
+ * Busca dados do componente Slider do website
+ */
+
+import routes from "@/api/routes";
+import { apiFetch } from "@/api/client";
+import { apiConfig, env } from "@/lib/env";
+import { sliderMockData } from "./mock";
+import type { SlideBackendResponse } from "./types";
+import type { SlideData } from "@/theme/website/components/slider/types";
+
+function mapSlideResponse(data: SlideBackendResponse[]): SlideData[] {
+  return data
+    .sort((a, b) => a.ordem - b.ordem)
+    .map((item) => ({
+      id: item.ordem,
+      image: item.imagemUrl,
+      alt: item.imagemTitulo,
+      link: item.link,
+      overlay: false,
+    }));
+}
+
+export async function getSliderData(): Promise<SlideData[]> {
+  try {
+    const raw = await apiFetch<SlideBackendResponse[]>(
+      routes.website.home.slide(),
+      {
+        init: { headers: apiConfig.headers, ...apiConfig.cache.medium },
+      },
+    );
+
+    const data = mapSlideResponse(raw);
+    console.log("✅ Slider data loaded:", data);
+    return data;
+  } catch (error) {
+    console.error("❌ Erro ao buscar dados do Slider:", error);
+    if (env.apiFallback === "mock") {
+      return sliderMockData;
+    }
+    throw new Error("Falha ao carregar dados do Slider");
+  }
+}
+
+export async function getSliderDataClient(): Promise<SlideData[]> {
+  const endpoint = routes.website.home.slide();
+
+  try {
+    const raw = await apiFetch<SlideBackendResponse[]>(endpoint, {
+      init: { headers: apiConfig.headers },
+      cache: "short",
+    });
+
+    const data = mapSlideResponse(raw);
+    console.log("✅ Slider data loaded (client):", data);
+    return data;
+  } catch (error) {
+    console.error("❌ Erro ao buscar dados do Slider (client):", error);
+
+    if (env.apiFallback === "mock") {
+      return sliderMockData;
+    }
+
+    throw new Error("Falha ao carregar dados do Slider");
+  }
+}

--- a/src/api/websites/components/slide/mock/index.ts
+++ b/src/api/websites/components/slide/mock/index.ts
@@ -1,0 +1,9 @@
+import type { SlideData } from "@/theme/website/components/slider/types";
+import { SLIDES } from "@/theme/website/components/slider/constants/slides";
+
+export const sliderMockData: SlideData[] = SLIDES.desktop;
+
+export async function getSliderDataMock(): Promise<SlideData[]> {
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  return sliderMockData;
+}

--- a/src/api/websites/components/slide/types/index.ts
+++ b/src/api/websites/components/slide/types/index.ts
@@ -1,0 +1,11 @@
+import type { SlideData } from "@/theme/website/components/slider/types";
+
+export type SlideApiResponse = SlideData[];
+
+export interface SlideBackendResponse {
+  id: string;
+  imagemUrl: string;
+  imagemTitulo: string;
+  link?: string;
+  ordem: number;
+}

--- a/src/theme/website/components/slider/SliderBasic.tsx
+++ b/src/theme/website/components/slider/SliderBasic.tsx
@@ -1,17 +1,17 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { SliderContainer } from "./components/SliderContainer";
 import { ImageNotFound } from "@/components/ui/custom/image-not-found";
 import { SLIDER_CONFIG } from "./constants/config";
 import { useSlider } from "./hooks/useSlider";
 import { useSliderAutoplay } from "./hooks/useSliderAutoplay";
-import { SLIDES } from "./constants/slides";
-import { useIsMobile } from "@/hooks/use-mobile";
+import { getSliderDataClient } from "@/api/websites/components/slide";
+import type { SlideData } from "./types";
 
 const SliderBasic: React.FC = () => {
-  const isMobile = useIsMobile();
-  const slides = isMobile ? SLIDES.mobile : SLIDES.desktop;
+  const [slides, setSlides] = useState<SlideData[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   const {
     emblaRef,
@@ -24,8 +24,38 @@ const SliderBasic: React.FC = () => {
     slideCount,
   } = useSlider(SLIDER_CONFIG);
 
+  // Carrega slides da API
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const data = await getSliderDataClient();
+        if (active) setSlides(data);
+      } catch (error) {
+        console.error("Erro ao carregar slides:", error);
+      } finally {
+        if (active) setIsLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // Re-inicializa o Embla quando os slides mudam
+  useEffect(() => {
+    if (emblaApi) {
+      emblaApi.reInit();
+    }
+  }, [emblaApi, slides]);
+
   // Autoplay básico
   useSliderAutoplay(emblaApi, SLIDER_CONFIG.autoplay);
+
+  // Enquanto carrega, mostra apenas um espaço reservado
+  if (isLoading) {
+    return <div className="w-full" style={{ aspectRatio: 16 / 9 }} />;
+  }
 
   // Se não há slides, renderiza um fallback elegante
   if (!slides || slides.length === 0) {
@@ -53,6 +83,7 @@ const SliderBasic: React.FC = () => {
       onScrollNext={scrollNext}
       currentSlide={currentSlide}
       slideCount={slideCount}
+      slides={slides}
     />
   );
 };

--- a/src/theme/website/components/slider/components/SliderContainer.tsx
+++ b/src/theme/website/components/slider/components/SliderContainer.tsx
@@ -11,16 +11,17 @@ export const SliderContainer: React.FC<SliderContainerProps> = ({
   canScrollNext,
   onScrollPrev,
   onScrollNext,
+  slides,
 }) => {
   const isMobile = useIsMobile();
-  const slides = isMobile ? SLIDES.mobile : SLIDES.desktop;
+  const slideData = slides ?? (isMobile ? SLIDES.mobile : SLIDES.desktop);
 
   return (
     <section className="relative w-full overflow-hidden">
       {/* Container do Embla */}
       <div ref={emblaRef} className="overflow-hidden w-full">
         <div className="flex">
-          {slides.map((slide, index) => (
+          {slideData.map((slide, index) => (
             <SliderSlide
               key={slide.id}
               slide={slide}

--- a/src/theme/website/components/slider/components/SliderSlide.tsx
+++ b/src/theme/website/components/slider/components/SliderSlide.tsx
@@ -17,12 +17,8 @@ export const SliderSlide: React.FC<SliderSlideProps> = ({
   );
 
   // Função para gerar alt text seguro
-  const getAltText = (
-    slide: { title?: string; subtitle?: string },
-    index: number
-  ): string => {
-    if (slide.title) return slide.title;
-    if (slide.subtitle) return slide.subtitle;
+  const getAltText = (slide: { alt?: string }, index: number): string => {
+    if (slide.alt) return slide.alt;
     return `Slide ${index + 1}`;
   };
 
@@ -39,102 +35,71 @@ export const SliderSlide: React.FC<SliderSlideProps> = ({
     setHasError(true);
   };
 
+  const content = (
+    <>
+      {/* Loading State */}
+      {isLoading && (
+        <div className="absolute inset-0 bg-gray-200 animate-pulse flex items-center justify-center z-10">
+          <div className="w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full animate-spin" />
+        </div>
+      )}
+
+      {/* Error State usando ImageNotFound */}
+      {hasError && (
+        <ImageNotFound
+          size="full"
+          variant="muted"
+          aspectRatio="landscape"
+          message="Slide indisponível"
+          icon="ImageOff"
+          className="absolute inset-0"
+          showMessage={true}
+        />
+      )}
+
+      {/* Main Image */}
+      {!hasError && (
+        <Image
+          src={slide.image}
+          alt={getAltText(slide, index)}
+          fill
+          className={`
+            object-cover object-center
+            transition-opacity duration-500
+            ${isLoading ? "opacity-0" : "opacity-100"}
+          `}
+          priority={index === 0}
+          quality={90}
+          onLoad={handleImageLoad}
+          onError={handleImageError}
+          sizes={
+            isMobile ? "(max-width: 768px) 100vw" : "(min-width: 769px) 100vw"
+          }
+        />
+      )}
+
+      {/* Overlay para melhor legibilidade do texto */}
+      {slide.overlay && !hasError && (
+        <div className="absolute inset-0 bg-black/20" />
+      )}
+    </>
+  );
+
   return (
     <div className="flex-none w-full relative">
-      <div
-        className="relative w-full"
-        style={{ aspectRatio }}
-      >
-        {/* Loading State */}
-        {isLoading && (
-          <div className="absolute inset-0 bg-gray-200 animate-pulse flex items-center justify-center z-10">
-            <div className="w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full animate-spin" />
-          </div>
-        )}
-
-        {/* Error State usando ImageNotFound */}
-        {hasError && (
-          <ImageNotFound
-            size="full"
-            variant="muted"
-            aspectRatio="landscape"
-            message="Slide indisponível"
-            icon="ImageOff"
-            className="absolute inset-0"
-            showMessage={true}
-          />
-        )}
-
-        {/* Main Image */}
-        {!hasError && (
-          <Image
-            src={slide.image}
-            alt={getAltText(slide, index)}
-            fill
-            className={`
-              object-cover object-center
-              transition-opacity duration-500
-              ${isLoading ? "opacity-0" : "opacity-100"}
-            `}
-            priority={index === 0}
-            quality={90}
-            onLoad={handleImageLoad}
-            onError={handleImageError}
-            sizes={
-              isMobile ? "(max-width: 768px) 100vw" : "(min-width: 769px) 100vw"
-            }
-          />
-        )}
-
-        {/* Overlay para melhor legibilidade do texto */}
-        {slide.overlay && !hasError && (
-          <div className="absolute inset-0 bg-black/20" />
-        )}
-
-        {/* Conteúdo do slide - só mostra se não tiver erro */}
-        {!hasError && (slide.title || slide.subtitle || slide.cta) && (
-          <div className="absolute inset-0 flex flex-col justify-center items-center text-center z-10 px-4 sm:px-6 lg:px-8">
-            {slide.title && (
-              <h2
-                className={`
-                font-bold text-white mb-4 drop-shadow-lg
-                ${
-                  isMobile
-                    ? "text-2xl sm:text-3xl"
-                    : "text-4xl md:text-5xl lg:text-6xl"
-                }
-              `}
-              >
-                {slide.title}
-              </h2>
-            )}
-
-            {slide.subtitle && (
-              <p
-                className={`
-                text-white/90 mb-6 max-w-2xl mx-auto drop-shadow-lg
-                ${isMobile ? "text-sm sm:text-base" : "text-lg md:text-xl"}
-              `}
-              >
-                {slide.subtitle}
-              </p>
-            )}
-
-            {slide.cta && (
-              <a
-                href={slide.cta.href}
-                className={`
-                  inline-block bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg 
-                  transition-all duration-200 transform hover:scale-105 shadow-lg hover:shadow-xl
-                  ${isMobile ? "px-6 py-3 text-sm" : "px-8 py-4 text-base"}
-                `}
-              >
-                {slide.cta.text}
-              </a>
-            )}
-          </div>
-        )}
-      </div>
+      {slide.link ? (
+        <a
+          href={slide.link}
+          className="relative block w-full"
+          style={{ aspectRatio }}
+        >
+          {content}
+        </a>
+      ) : (
+        <div className="relative w-full" style={{ aspectRatio }}>
+          {content}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/theme/website/components/slider/constants/slides.ts
+++ b/src/theme/website/components/slider/constants/slides.ts
@@ -5,13 +5,6 @@ export const SLIDES = {
     {
       id: 1,
       image: "/images/sliders/desktop-foqueemseunegocio.jpg",
-      //   title: "Foque em Seu Negócio",
-      //   subtitle:
-      //     "Deixe a tecnologia conosco. Soluções completas para sua empresa crescer.",
-      //   cta: {
-      //     text: "Saiba Mais",
-      //     href: "/solucoes",
-      //   },
       overlay: false,
     },
   ] as SlideData[],
@@ -20,12 +13,6 @@ export const SLIDES = {
     {
       id: 1,
       image: "/images/sliders/mobile-foqueemseunegocio.jpg",
-      //   title: "Foque em Seu Negócio",
-      //   subtitle: "Tecnologia para sua empresa crescer.",
-      //   cta: {
-      //     text: "Saiba Mais",
-      //     href: "/solucoes",
-      //   },
       overlay: false,
     },
   ] as SlideData[],

--- a/src/theme/website/components/slider/types/index.ts
+++ b/src/theme/website/components/slider/types/index.ts
@@ -1,12 +1,8 @@
 export interface SlideData {
   id: number;
   image: string;
-  title?: string;
-  subtitle?: string;
-  cta?: {
-    text: string;
-    href: string;
-  };
+  alt?: string;
+  link?: string;
   overlay?: boolean;
 }
 
@@ -28,6 +24,7 @@ export interface SliderContainerProps {
   onScrollNext: () => void;
   currentSlide: number;
   slideCount: number;
+  slides?: SlideData[];
 }
 
 export interface SliderSlideProps {


### PR DESCRIPTION
## Summary
- add slide endpoint to API routes
- fetch and map slide data from backend
- load slides dynamically in hero slider with alt support
- drop unused title/subtitle fields from slider implementation
- linkify slide images when administrator supplies a URL

## Testing
- `pnpm lint`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_6897a1f42c5c8325ba7114777405680f