### PR TITLE
feat: refine slider image dimensions

### DIFF
--- a/src/theme/website/components/slider/SliderAdvanced.tsx
+++ b/src/theme/website/components/slider/SliderAdvanced.tsx
@@ -8,6 +8,7 @@ import { useSliderKeyboard } from "./hooks/useSliderKeyboard";
 import { useSliderIntersection } from "./hooks/useSliderIntersection";
 import { SLIDES } from "./constants/slides";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { ImageNotFound } from "@/components/ui/custom/image-not-found";
 import type { SliderConfig } from "./types";
 
 interface SliderAdvancedProps {
@@ -84,11 +85,15 @@ export const SliderAdvanced: React.FC<SliderAdvancedProps> = ({
 
   if (!slides || slides.length === 0) {
     return (
-      <div
-        className="w-full relative bg-gray-200 flex items-center justify-center"
-        style={{ aspectRatio: 16 / 9 }}
-      >
-        <p className="text-gray-500">Nenhum slide disponível</p>
+      <div className="w-full h-[400px] md:h-[500px] lg:h-[600px] xl:h-[800px]">
+        <ImageNotFound
+          size="full"
+          variant="muted"
+          message="Nenhum slide disponível"
+          icon="ImageOff"
+          className="w-full h-full !rounded-none !border-0 !bg-transparent"
+          showMessage={true}
+        />
       </div>
     );
   }

--- a/src/theme/website/components/slider/SliderBasic.tsx
+++ b/src/theme/website/components/slider/SliderBasic.tsx
@@ -54,20 +54,19 @@ const SliderBasic: React.FC = () => {
 
   // Enquanto carrega, mostra apenas um espaço reservado
   if (isLoading) {
-    return <div className="w-full" style={{ aspectRatio: 16 / 9 }} />;
+    return <div className="w-full h-[400px] md:h-[500px] lg:h-[600px] xl:h-[800px]" />;
   }
 
   // Se não há slides, renderiza um fallback elegante
   if (!slides || slides.length === 0) {
     return (
-      <div className="w-full relative" style={{ aspectRatio: 16 / 9 }}>
+      <div className="w-full h-[400px] md:h-[500px] lg:h-[600px] xl:h-[800px]">
         <ImageNotFound
           size="full"
           variant="muted"
-          aspectRatio="landscape"
           message="Nenhum slide disponível"
           icon="ImageOff"
-          className="h-full"
+          className="w-full h-full !rounded-none !border-0 !bg-transparent"
           showMessage={true}
         />
       </div>

--- a/src/theme/website/components/slider/SliderWithProgress.tsx
+++ b/src/theme/website/components/slider/SliderWithProgress.tsx
@@ -8,6 +8,7 @@ import { useSliderAutoplay } from "./hooks/useSliderAutoplay";
 import { SLIDER_CONFIG } from "./constants/config";
 import { SLIDES } from "./constants/slides";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { ImageNotFound } from "@/components/ui/custom/image-not-found";
 
 interface SliderWithProgressProps {
   showNumbers?: boolean;
@@ -38,11 +39,15 @@ export const SliderWithProgress: React.FC<SliderWithProgressProps> = ({
 
   if (!slides || slides.length === 0) {
     return (
-      <div
-        className="w-full relative bg-gray-200 flex items-center justify-center"
-        style={{ aspectRatio: 16 / 9 }}
-      >
-        <p className="text-gray-500">Nenhum slide disponível</p>
+      <div className="w-full h-[400px] md:h-[500px] lg:h-[600px] xl:h-[800px]">
+        <ImageNotFound
+          size="full"
+          variant="muted"
+          message="Nenhum slide disponível"
+          icon="ImageOff"
+          className="w-full h-full !rounded-none !border-0 !bg-transparent"
+          showMessage={true}
+        />
       </div>
     );
   }

--- a/src/theme/website/components/slider/components/SliderContainer.tsx
+++ b/src/theme/website/components/slider/components/SliderContainer.tsx
@@ -17,10 +17,10 @@ export const SliderContainer: React.FC<SliderContainerProps> = ({
   const slideData = slides ?? (isMobile ? SLIDES.mobile : SLIDES.desktop);
 
   return (
-    <section className="relative w-full overflow-hidden">
+    <section className="relative w-full h-[400px] md:h-[500px] lg:h-[600px] xl:h-[800px] overflow-hidden">
       {/* Container do Embla */}
-      <div ref={emblaRef} className="overflow-hidden w-full">
-        <div className="flex">
+      <div ref={emblaRef} className="overflow-hidden w-full h-full">
+        <div className="flex h-full">
           {slideData.map((slide, index) => (
             <SliderSlide
               key={slide.id}

--- a/src/theme/website/components/slider/components/SliderSlide.tsx
+++ b/src/theme/website/components/slider/components/SliderSlide.tsx
@@ -12,22 +12,14 @@ export const SliderSlide: React.FC<SliderSlideProps> = ({
 }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
-  const [aspectRatio, setAspectRatio] = useState(
-    isMobile ? 9 / 16 : 16 / 9
-  );
-
   // Função para gerar alt text seguro
   const getAltText = (slide: { alt?: string }, index: number): string => {
     if (slide.alt) return slide.alt;
     return `Slide ${index + 1}`;
   };
 
-  const handleImageLoad = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
+  const handleImageLoad = () => {
     setIsLoading(false);
-    const { naturalWidth, naturalHeight } = e.currentTarget;
-    if (naturalWidth && naturalHeight) {
-      setAspectRatio(naturalWidth / naturalHeight);
-    }
   };
 
   const handleImageError = () => {
@@ -52,7 +44,7 @@ export const SliderSlide: React.FC<SliderSlideProps> = ({
           aspectRatio="landscape"
           message="Slide indisponível"
           icon="ImageOff"
-          className="absolute inset-0"
+          className="absolute inset-0 !rounded-none !border-0 !bg-transparent"
           showMessage={true}
         />
       )}
@@ -69,7 +61,7 @@ export const SliderSlide: React.FC<SliderSlideProps> = ({
             ${isLoading ? "opacity-0" : "opacity-100"}
           `}
           priority={index === 0}
-          quality={90}
+          quality={80}
           onLoad={handleImageLoad}
           onError={handleImageError}
           sizes={
@@ -86,19 +78,13 @@ export const SliderSlide: React.FC<SliderSlideProps> = ({
   );
 
   return (
-    <div className="flex-none w-full relative">
+    <div className="flex-none w-full h-full relative">
       {slide.link ? (
-        <a
-          href={slide.link}
-          className="relative block w-full"
-          style={{ aspectRatio }}
-        >
+        <a href={slide.link} className="relative block w-full h-full">
           {content}
         </a>
       ) : (
-        <div className="relative w-full" style={{ aspectRatio }}>
-          {content}
-        </div>
+        <div className="relative w-full h-full">{content}</div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- apply fixed heights (400px mobile, 500px tablet, 600-800px desktop) to slider container
- align loading and empty-state placeholders with the same dimensions
- serve slide images at 80% quality for faster loading

## Testing
- `pnpm lint`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_6897b3a5b70483259945b47dfd69c14c