### PR TITLE
feat: add banners section to website home

### DIFF
--- a/src/app/website/page.tsx
+++ b/src/app/website/page.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import Slider from "@/theme/website/components/slider";
 import AboutSection from "@/theme/website/components/about";
+import BannersGroup from "@/theme/website/components/banners";
 
 /**
  * Página Inicial do Website Institucional
@@ -33,6 +34,9 @@ export default function WebsiteHomePage() {
         onDataLoaded={() => handleComponentLoaded("About")}
         onError={(error) => handleComponentError("About", error)}
       />
+
+      {/* Banners de Destaque */}
+      <BannersGroup />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show BannersGroup component under about section on website home page

## Testing
- `pnpm lint --file src/app/website/page.tsx`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_68993c337d288325a068da0c0e4cb21d