### PR TITLE
feat(auth): display toast notifications on login

### DIFF
--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import "@/styles/globals.css";
+import { ToasterCustom } from "@/components/ui/custom/toast";
 
 /**
  * Layout de autenticação simplificado
@@ -18,6 +19,7 @@ export default function AuthLayout({
   return (
     <section className="min-h-screen bg-[var(--background-color)]">
       {children}
+      <ToasterCustom />
     </section>
   );
 }

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -4,6 +4,7 @@ import { useTransition, useState, useEffect } from "react";
 import { SignInPage } from "@/components/partials/auth/login/sign-in";
 import { apiFetch } from "@/api/client";
 import { usuarioRoutes } from "@/api/routes";
+import { toastCustom } from "@/components/ui/custom/toast";
 
 const SignInPageDemo = () => {
   const [userName, setUserName] = useState<string | null>(null);
@@ -78,12 +79,17 @@ const SignInPageDemo = () => {
         // Redireciona para o subdomínio app
         const protocol = window.location.protocol;
         const port = window.location.port ? `:${window.location.port}` : "";
-        window.location.href = isLocalhost
-          ? "/dashboard"
-          : `${protocol}//app.${baseDomain}${port}/`;
+        toastCustom.success("Login realizado com sucesso!");
+        setTimeout(() => {
+          window.location.href = isLocalhost
+            ? "/dashboard"
+            : `${protocol}//app.${baseDomain}${port}/`;
+        }, 1000);
       } catch (error) {
         console.error("Erro ao fazer login:", error);
-        alert("Não foi possível realizar o login. Verifique suas credenciais.");
+        toastCustom.error(
+          "Não foi possível realizar o login. Verifique suas credenciais."
+        );
       }
     });
   };


### PR DESCRIPTION
## Summary
- show toast notifications for login success or failure
- include toast container in auth layout

## Testing
- `pnpm lint --file src/app/auth/layout.tsx --file src/app/auth/login/page.tsx`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_689b90589c80832593fe06d5fc25993f