### PR TITLE
feat: improve auth ui and add email verification

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -8,7 +8,7 @@ import { toastCustom } from "@/components/ui/custom/toast";
 
 const SignInPageDemo = () => {
   const [userName, setUserName] = useState<string | null>(null);
-  const [, startTransition] = useTransition();
+  const [isPending, startTransition] = useTransition();
 
   useEffect(() => {
     const storedName = localStorage.getItem("userName");
@@ -109,6 +109,7 @@ const SignInPageDemo = () => {
         onSignIn={handleSignIn}
         onResetPassword={handleResetPassword}
         onCreateAccount={handleCreateAccount}
+        isLoading={isPending}
         title={
           userName
             ? `Olá ${userName}, bem vindo de volta!`

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -7,7 +7,7 @@ import { usuarioRoutes } from "@/api/routes";
 import { toastCustom } from "@/components/ui/custom/toast";
 
 const RegisterPage = () => {
-  const [, startTransition] = useTransition();
+  const [isPending, startTransition] = useTransition();
 
   const handleSignUp = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -59,6 +59,7 @@ const RegisterPage = () => {
       <SignUpPage
         heroImageSrc="https://images.unsplash.com/photo-1642615835477-d303d7dc9ee9?w=2160&q=80"
         onSignUp={handleSignUp}
+        isLoading={isPending}
       />
     </div>
   );

--- a/src/app/auth/verify-email/page.tsx
+++ b/src/app/auth/verify-email/page.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { apiFetch } from "@/api/client";
+import { usuarioRoutes } from "@/api/routes";
+
+export default function VerifyEmailPage() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+  const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
+
+  useEffect(() => {
+    async function verify() {
+      if (!token) {
+        setStatus("error");
+        return;
+      }
+      try {
+        await apiFetch(usuarioRoutes.verification.verify(token), {
+          cache: "no-cache",
+        });
+        setStatus("success");
+      } catch (err) {
+        setStatus("error");
+      }
+    }
+    verify();
+  }, [token]);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[100dvh] bg-background text-foreground gap-6">
+      {status === "loading" && (
+        <div className="flex flex-col items-center gap-4">
+          <Loader2 className="w-8 h-8 animate-spin" />
+          <p>Verificando seu email...</p>
+        </div>
+      )}
+      {status === "success" && (
+        <div className="flex flex-col items-center gap-4">
+          <p className="text-lg font-medium">Email verificado com sucesso!</p>
+          <a
+            href="/auth/login"
+            className="px-4 py-2 rounded-md bg-[var(--color-blue)] text-white hover:bg-[var(--color-blue)]/90 cursor-pointer"
+          >
+            Ir para login
+          </a>
+        </div>
+      )}
+      {status === "error" && (
+        <div className="flex flex-col items-center gap-4">
+          <p className="text-lg font-medium">Token inválido ou expirado.</p>
+          <a
+            href="/auth/login"
+            className="px-4 py-2 rounded-md bg-[var(--color-blue)] text-white hover:bg-[var(--color-blue)]/90 cursor-pointer"
+          >
+            Voltar ao login
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/partials/auth/login/sign-in.tsx
+++ b/src/components/partials/auth/login/sign-in.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { Eye, EyeOff } from "lucide-react";
+import { Eye, EyeOff, Loader2 } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
 
 // --- TYPE DEFINITIONS ---
@@ -13,6 +13,7 @@ interface SignInPageProps {
   onSignIn?: (event: React.FormEvent<HTMLFormElement>) => void;
   onResetPassword?: () => void;
   onCreateAccount?: () => void;
+  isLoading?: boolean;
 }
 
 // --- SUB-COMPONENTS ---
@@ -34,6 +35,7 @@ export const SignInPage: React.FC<SignInPageProps> = ({
   onSignIn,
   onResetPassword,
   onCreateAccount,
+  isLoading,
 }) => {
   const [showPassword, setShowPassword] = useState(false);
   const [documento, setDocumento] = useState("");
@@ -144,9 +146,14 @@ export const SignInPage: React.FC<SignInPageProps> = ({
               />
               <button
                 type="submit"
-                className="animate-element animate-delay-600 w-full rounded-2xl bg-primary py-4 font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+                disabled={isLoading}
+                className="animate-element animate-delay-600 w-full rounded-2xl bg-[var(--color-blue)] text-white py-4 font-medium hover:bg-[var(--color-blue)]/90 transition-colors flex items-center justify-center cursor-pointer disabled:opacity-70 disabled:cursor-not-allowed"
               >
-                Entrar
+                {isLoading ? (
+                  <Loader2 className="w-5 h-5 animate-spin" />
+                ) : (
+                  "Entrar"
+                )}
               </button>
             </form>
 

--- a/src/components/partials/auth/register/sign-up.tsx
+++ b/src/components/partials/auth/register/sign-up.tsx
@@ -1,14 +1,22 @@
 "use client";
 
 import React, { useRef, useState } from "react";
-import { Eye, EyeOff } from "lucide-react";
+import { Eye, EyeOff, Loader2 } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 interface SignUpPageProps {
   title?: React.ReactNode;
   description?: React.ReactNode;
   heroImageSrc?: string;
   onSignUp?: (event: React.FormEvent<HTMLFormElement>) => void;
+  isLoading?: boolean;
 }
 
 const GlassInputWrapper = ({ children }: { children: React.ReactNode }) => (
@@ -26,6 +34,7 @@ export const SignUpPage: React.FC<SignUpPageProps> = ({
   description,
   heroImageSrc,
   onSignUp,
+  isLoading,
 }) => {
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
@@ -35,6 +44,7 @@ export const SignUpPage: React.FC<SignUpPageProps> = ({
   const [documento, setDocumento] = useState("");
   const [telefone, setTelefone] = useState("");
   const [aceitarTermos, setAceitarTermos] = useState(false);
+  const [genero, setGenero] = useState("MASCULINO");
   const [step, setStep] = useState(1);
   const formRef = useRef<HTMLFormElement>(null);
 
@@ -112,20 +122,24 @@ export const SignUpPage: React.FC<SignUpPageProps> = ({
                     Tipo de usuário
                   </label>
                   <GlassInputWrapper>
-                    <select
-                      name="tipoUsuario"
+                    <Select
                       value={tipoUsuario}
-                      onChange={(e) =>
+                      onValueChange={(v) =>
                         setTipoUsuario(
-                          e.target.value as "PESSOA_FISICA" | "PESSOA_JURIDICA"
+                          v as "PESSOA_FISICA" | "PESSOA_JURIDICA"
                         )
                       }
-                      className="w-full bg-transparent text-sm p-4 rounded-2xl focus:outline-none"
                     >
-                      <option value="PESSOA_FISICA">Pessoa Física</option>
-                      <option value="PESSOA_JURIDICA">Pessoa Jurídica</option>
-                    </select>
+                      <SelectTrigger className="w-full bg-transparent text-sm p-4 rounded-2xl focus:outline-none cursor-pointer">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="PESSOA_FISICA">Pessoa Física</SelectItem>
+                        <SelectItem value="PESSOA_JURIDICA">Pessoa Jurídica</SelectItem>
+                      </SelectContent>
+                    </Select>
                   </GlassInputWrapper>
+                  <input type="hidden" name="tipoUsuario" value={tipoUsuario} />
                 </div>
 
                 <div className="animate-element animate-delay-300">
@@ -182,7 +196,7 @@ export const SignUpPage: React.FC<SignUpPageProps> = ({
                 <button
                   type="button"
                   onClick={handleNextStep}
-                  className="animate-element animate-delay-600 w-full rounded-2xl bg-primary py-4 font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+                  className="animate-element animate-delay-600 w-full rounded-2xl bg-[var(--color-blue)] text-white py-4 font-medium hover:bg-[var(--color-blue)]/90 transition-colors cursor-pointer"
                 >
                   Continuar
                 </button>
@@ -210,17 +224,21 @@ export const SignUpPage: React.FC<SignUpPageProps> = ({
                           Gênero
                         </label>
                         <GlassInputWrapper>
-                          <select
-                            name="genero"
-                            required
-                            className="w-full bg-transparent text-sm p-4 rounded-2xl focus:outline-none"
-                          >
-                            <option value="MASCULINO">Masculino</option>
-                            <option value="FEMININO">Feminino</option>
-                            <option value="OUTRO">Outro</option>
-                            <option value="NAO_INFORMAR">Prefiro não informar</option>
-                          </select>
+                          <Select value={genero} onValueChange={setGenero}>
+                            <SelectTrigger className="w-full bg-transparent text-sm p-4 rounded-2xl focus:outline-none cursor-pointer">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="MASCULINO">Masculino</SelectItem>
+                              <SelectItem value="FEMININO">Feminino</SelectItem>
+                              <SelectItem value="OUTRO">Outro</SelectItem>
+                              <SelectItem value="NAO_INFORMAR">
+                                Prefiro não informar
+                              </SelectItem>
+                            </SelectContent>
+                          </Select>
                         </GlassInputWrapper>
+                        <input type="hidden" name="genero" value={genero} />
                       </div>
                     </>
                   )}
@@ -301,12 +319,26 @@ export const SignUpPage: React.FC<SignUpPageProps> = ({
                     value={aceitarTermos ? "true" : "false"}
                   />
 
-                  <button
-                    type="submit"
-                    className="animate-element animate-delay-600 w-full rounded-2xl bg-primary py-4 font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-                  >
-                    Cadastrar
-                  </button>
+                  <div className="flex gap-4">
+                    <button
+                      type="button"
+                      onClick={() => setStep(1)}
+                      className="w-full rounded-2xl bg-muted py-4 font-medium text-muted-foreground hover:bg-muted/90 transition-colors cursor-pointer"
+                    >
+                      Voltar
+                    </button>
+                    <button
+                      type="submit"
+                      disabled={isLoading}
+                      className="w-full rounded-2xl bg-[var(--color-blue)] text-white py-4 font-medium hover:bg-[var(--color-blue)]/90 transition-colors flex items-center justify-center cursor-pointer disabled:opacity-70 disabled:cursor-not-allowed"
+                    >
+                      {isLoading ? (
+                        <Loader2 className="w-5 h-5 animate-spin" />
+                      ) : (
+                        "Cadastrar"
+                      )}
+                    </button>
+                  </div>
                 </div>
               )}
             </form>


### PR DESCRIPTION
## Summary
- enhance register form with custom selects, blue buttons and loading states
- update login form to use blue button with loading indicator
- add `/auth/verify-email` page to handle email confirmation

## Testing
- `pnpm lint`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_689bc060ed0083258682649ec4b84afa