### PR TITLE
fix: send email verification token via post

### DIFF
--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -43,8 +43,7 @@ export const usuarioRoutes = {
     reset: () => `${prefix}/usuarios/recuperar-senha/redefinir`,
   },
   verification: {
-    verify: (token: string) =>
-      `${prefix}/usuarios/verificar-email?token=${token}`,
+    verify: () => `${prefix}/usuarios/verificar-email`,
     resend: () => `${prefix}/usuarios/reenviar-verificacao`,
     status: (userId: string) =>
       `${prefix}/usuarios/status-verificacao/${userId}`,

--- a/src/app/auth/verify-email/page.tsx
+++ b/src/app/auth/verify-email/page.tsx
@@ -18,8 +18,15 @@ export default function VerifyEmailPage() {
         return;
       }
       try {
-        await apiFetch(usuarioRoutes.verification.verify(token), {
+        await apiFetch(usuarioRoutes.verification.verify(), {
           cache: "no-cache",
+          init: {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ token }),
+          },
         });
         setStatus("success");
       } catch (err) {


### PR DESCRIPTION
## Summary
- fix email verification route usage
- send verification token via POST request

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a495dbcb3c83258885401cbd831f59