### PR TITLE
fix: adjust email verification endpoint

### DIFF
--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -43,7 +43,7 @@ export const usuarioRoutes = {
     reset: () => `${prefix}/usuarios/recuperar-senha/redefinir`,
   },
   verification: {
-    verify: () => `${prefix}/usuarios/verificar-email`,
+    verify: (token: string) => `${prefix}/auth/verify-email?token=${token}`,
     resend: () => `${prefix}/usuarios/reenviar-verificacao`,
     status: (userId: string) =>
       `${prefix}/usuarios/status-verificacao/${userId}`,

--- a/src/app/auth/verify-email/page.tsx
+++ b/src/app/auth/verify-email/page.tsx
@@ -18,15 +18,8 @@ export default function VerifyEmailPage() {
         return;
       }
       try {
-        await apiFetch(usuarioRoutes.verification.verify(), {
+        await apiFetch(usuarioRoutes.verification.verify(token), {
           cache: "no-cache",
-          init: {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({ token }),
-          },
         });
         setStatus("success");
       } catch (err) {


### PR DESCRIPTION
## Summary
- point email verification to auth service endpoint
- simplify verify-email page to send GET request with token query

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a49a9bcb0c8325b5ca89af8399b1a4