### PR TITLE
fix: point email verification routes to brevo module

### DIFF
--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -43,10 +43,11 @@ export const usuarioRoutes = {
     reset: () => `${prefix}/usuarios/recuperar-senha/redefinir`,
   },
   verification: {
-    verify: (token: string) => `${prefix}/auth/verify-email?token=${token}`,
-    resend: () => `${prefix}/usuarios/reenviar-verificacao`,
+    verify: (token: string) =>
+      `${prefix}/brevo/verificar-email?token=${token}`,
+    resend: () => `${prefix}/brevo/reenviar-verificacao`,
     status: (userId: string) =>
-      `${prefix}/usuarios/status-verificacao/${userId}`,
+      `${prefix}/brevo/status-verificacao/${userId}`,
   },
 };
 


### PR DESCRIPTION
## Summary
- point email verification API routes to `/brevo` endpoints

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a10318a48325b75956c2869ddc77