### PR TITLE
Handle email verification redirect and parse non-json responses

### DIFF
--- a/src/app/auth/verify-email/page.tsx
+++ b/src/app/auth/verify-email/page.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { apiFetch } from "@/api/client";
 import { usuarioRoutes } from "@/api/routes";
+import { toastCustom } from "@/components/ui/custom/toast";
 
 export default function VerifyEmailPage() {
   const searchParams = useSearchParams();
+  const router = useRouter();
   const token = searchParams.get("token");
-  const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
+  const [status, setStatus] = useState<"loading" | "error">("loading");
 
   useEffect(() => {
     async function verify() {
@@ -21,13 +23,14 @@ export default function VerifyEmailPage() {
         await apiFetch(usuarioRoutes.verification.verify(token), {
           cache: "no-cache",
         });
-        setStatus("success");
+        toastCustom.success("Conta confirmada com sucesso");
+        router.push("/auth/login");
       } catch (err) {
         setStatus("error");
       }
     }
     verify();
-  }, [token]);
+  }, [token, router]);
 
   return (
     <div className="flex flex-col items-center justify-center min-h-[100dvh] bg-background text-foreground gap-6">
@@ -35,17 +38,6 @@ export default function VerifyEmailPage() {
         <div className="flex flex-col items-center gap-4">
           <Loader2 className="w-8 h-8 animate-spin" />
           <p>Verificando seu email...</p>
-        </div>
-      )}
-      {status === "success" && (
-        <div className="flex flex-col items-center gap-4">
-          <p className="text-lg font-medium">Email verificado com sucesso!</p>
-          <a
-            href="/auth/login"
-            className="px-4 py-2 rounded-md bg-[var(--color-blue)] text-white hover:bg-[var(--color-blue)]/90 cursor-pointer"
-          >
-            Ir para login
-          </a>
         </div>
       )}
       {status === "error" && (


### PR DESCRIPTION
## Summary
- redirect to login after successful email verification with toast
- support parsing non-JSON or empty responses in apiFetch

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4a459273c8325b953f5f6d9887247