### PR TITLE
fix: adjust auth and app domain redirects

### DIFF
--- a/src/app/auth/middleware.ts
+++ b/src/app/auth/middleware.ts
@@ -9,6 +9,7 @@ export function authMiddleware(request: NextRequest) {
   const [hostname, port] = host.split(":");
   const isLocalhost = hostname === "localhost" || hostname === "127.0.0.1";
   const baseDomain = hostname
+    .replace(/^www\./, "")
     .replace(/^app\./, "")
     .replace(/^auth\./, "");
 
@@ -17,6 +18,7 @@ export function authMiddleware(request: NextRequest) {
   if (!isAuthSubdomain && !isLocalhost) {
     const url = request.nextUrl.clone();
     url.hostname = `auth.${baseDomain}`;
+    url.pathname = pathname.replace(/^\/auth/, "");
     if (port) url.port = port;
     return NextResponse.redirect(url);
   }

--- a/src/app/dashboard/middleware.ts
+++ b/src/app/dashboard/middleware.ts
@@ -26,6 +26,7 @@ export function dashboardMiddleware(request: NextRequest) {
   const [hostname, port] = host.split(":");
   const isLocalhost = hostname === "localhost" || hostname === "127.0.0.1";
   const baseDomain = hostname
+    .replace(/^www\./, "")
     .replace(/^app\./, "")
     .replace(/^auth\./, "");
 
@@ -45,7 +46,7 @@ export function dashboardMiddleware(request: NextRequest) {
   if (!isAuthenticated && !isLocalhost) {
     const authUrl = request.nextUrl.clone();
     authUrl.hostname = `auth.${baseDomain}`;
-    authUrl.pathname = "/auth/login";
+    authUrl.pathname = "/login";
     if (port) authUrl.port = port;
     return NextResponse.redirect(authUrl);
   }


### PR DESCRIPTION
## Summary
- normalize www prefix and handle auth subdomain rewrites
- remove /auth prefix when redirecting between subdomains
- point dashboard auth redirects to new /login path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4b273153483258f0c9305cd958837