### PR TITLE
fix: update auth login url

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -99,7 +99,7 @@ const SignInPageDemo = () => {
   };
 
   const handleCreateAccount = () => {
-    window.location.href = "/auth/register";
+    window.location.href = "https://auth.advancemais.com/register";
   };
 
   return (

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -186,7 +186,7 @@ const RegisterPage = () => {
           "Cadastro realizado com sucesso! Verifique seu email para confirmar."
         );
         setTimeout(() => {
-          window.location.href = "/auth/login";
+          window.location.href = "https://auth.advancemais.com/login";
         }, 1000);
       } catch (error) {
         console.error("Erro ao cadastrar:", error);
@@ -475,7 +475,7 @@ const RegisterPage = () => {
                   <p className="text-xs sm:text-sm text-gray-600">
                     Já possui uma conta?{" "}
                     <a
-                      href="/auth/login"
+                      href="https://auth.advancemais.com/login"
                       className="text-blue-600 hover:text-blue-700 font-medium cursor-pointer hover:underline transition-all duration-200"
                     >
                       Fazer login
@@ -497,7 +497,7 @@ const RegisterPage = () => {
                   <p className="text-xs sm:text-sm text-gray-600">
                     Já possui uma conta?{" "}
                     <a
-                      href="/auth/login"
+                      href="https://auth.advancemais.com/login"
                       className="text-blue-600 hover:text-blue-700 font-medium cursor-pointer hover:underline transition-all duration-200"
                     >
                       Fazer login

--- a/src/app/auth/verify-email/page.tsx
+++ b/src/app/auth/verify-email/page.tsx
@@ -24,7 +24,7 @@ export default function VerifyEmailPage() {
           cache: "no-cache",
         });
         toastCustom.success("Conta confirmada com sucesso");
-        router.push("/auth/login");
+        router.push("https://auth.advancemais.com/login");
       } catch (err) {
         setStatus("error");
       }
@@ -44,7 +44,7 @@ export default function VerifyEmailPage() {
         <div className="flex flex-col items-center gap-4">
           <p className="text-lg font-medium">Token inválido ou expirado.</p>
           <a
-            href="/auth/login"
+            href="https://auth.advancemais.com/login"
             className="px-4 py-2 rounded-md bg-[var(--color-blue)] text-white hover:bg-[var(--color-blue)]/90 cursor-pointer"
           >
             Voltar ao login

--- a/src/theme/website/header/components/ActionButtons.tsx
+++ b/src/theme/website/header/components/ActionButtons.tsx
@@ -21,7 +21,7 @@ export const ActionButtons: React.FC<ActionButtonsProps> = ({
         transition={{ type: "spring", stiffness: 400, damping: 15 }}
       >
         <NavLink
-          href="/auth/login"
+          href="https://auth.advancemais.com/login"
           className="text-base text-[var(--color-blue)] hover:text-[var(--color-blue)]"
         >
           Entrar
@@ -34,7 +34,10 @@ export const ActionButtons: React.FC<ActionButtonsProps> = ({
         whileTap={{ scale: 0.97 }}
         transition={{ type: "spring", stiffness: 400, damping: 15 }}
       >
-        <NavLink href="/auth/register" className="text-base text-white hover:text-white">
+        <NavLink
+          href="https://auth.advancemais.com/register"
+          className="text-base text-white hover:text-white"
+        >
           Cadastre-se
         </NavLink>
       </motion.div>

--- a/src/theme/website/header/components/MobileMenu.tsx
+++ b/src/theme/website/header/components/MobileMenu.tsx
@@ -28,7 +28,7 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose }) => {
               </NavLink>
             ))}
             <hr className="w-full border-t border-gray-700/50 my-2" />
-            <NavLink href="/auth/login" onClick={onClose}>
+            <NavLink href="https://auth.advancemais.com/login" onClick={onClose}>
               Entrar
             </NavLink>
           </div>


### PR DESCRIPTION
## Summary
- update login links to use auth.advancemais.com domain
- redirect registration and verification flows to new login URL
- point register links to auth.advancemais.com/register

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a502b64b148325a7adc25eca3ff115