### PR TITLE
fix: ensure app subdomain routes to dashboard

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -196,7 +196,14 @@ export function middleware(request: NextRequest) {
     return setupDevCookies(NextResponse.rewrite(url));
   }
 
+  // Subdomínio do dashboard (app.)
+  // Garante que todas as rotas sejam servidas a partir de /dashboard
   if (hostname.startsWith("app.")) {
+    if (!pathname.startsWith("/dashboard")) {
+      const url = request.nextUrl.clone();
+      url.pathname = `/dashboard${pathname === "/" ? "" : pathname}`;
+      return setupDevCookies(NextResponse.rewrite(url));
+    }
     return setupDevCookies(NextResponse.next());
   }
 


### PR DESCRIPTION
## Summary
- route app.* requests through /dashboard

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5df1a5b088325bf2a8aa8235aef3c