### PR TITLE
style: enhance sidebar headings and layout

### DIFF
--- a/src/theme/dashboard/sidebar/Sidebar.tsx
+++ b/src/theme/dashboard/sidebar/Sidebar.tsx
@@ -36,6 +36,14 @@ export function Sidebar({
           onCloseMobile={() => setIsMobileMenuOpen(false)}
         />
 
+        {/* Linha divisória abaixo da logo */}
+        <div
+          className={cn(
+            "my-2 border-b border-[#314e93]",
+            isCollapsed ? "mx-2" : "mx-4"
+          )}
+        />
+
         {/* Conteúdo do Menu */}
         <div className="flex-1 overflow-y-auto overflow-x-hidden scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent">
           <MenuList

--- a/src/theme/dashboard/sidebar/components/header/SidebarHeader.tsx
+++ b/src/theme/dashboard/sidebar/components/header/SidebarHeader.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Image from "next/image";
 import { Icon } from "@/components/ui/custom/Icons";
+import { cn } from "@/lib/utils";
 import { SidebarHeaderProps } from "../../types/sidebar.types";
 import { toastCustom } from "@/components/ui/custom/toast";
 
@@ -26,13 +27,18 @@ export function SidebarHeader({
   };
 
   return (
-    <div className="h-16 px-4 flex items-center justify-between border-b border-[var(--color-blue)] transition-all duration-300">
+    <div
+      className={cn(
+        "h-16 flex items-center justify-between transition-all duration-300",
+        isCollapsed ? "px-2" : "px-4"
+      )}
+    >
       <div onClick={handleLogoClick} className="cursor-pointer flex items-center">
         <Image
           src={isCollapsed ? "/images/logos/logo_mobile.webp" : "/images/logos/logo_branco.webp"}
           alt="Logo"
-          width={isCollapsed ? 32 : 120}
-          height={32}
+          width={isCollapsed ? 40 : 150}
+          height={40}
           priority
         />
       </div>

--- a/src/theme/dashboard/sidebar/components/menu/MenuSection.tsx
+++ b/src/theme/dashboard/sidebar/components/menu/MenuSection.tsx
@@ -16,7 +16,7 @@ export function MenuSection({
     >
       {/* Título da seção - visível apenas quando não está colapsado */}
       {!isCollapsed && (
-        <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-500 transition-opacity duration-200">
+        <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-secondary transition-opacity duration-200">
           {section.title}
         </div>
       )}


### PR DESCRIPTION
## Summary
- color sidebar section headers using secondary red palette
- increase logo size and adjust sidebar header spacing
- add padded divider beneath logo for cleaner separation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6072e53008325b361c123e215d025