### PR TITLE
feat: improve sidebar and dashboard header

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -70,42 +70,42 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
 
       {/* Container principal de conteúdo */}
       <div className="w-full flex flex-1 flex-col transition-all duration-300 ease-in-out bg-white">
-        {/* Cabeçalho/barra superior */}
-        <header className="h-16 border-b border-gray-200 flex items-center px-4 bg-white z-10">
+        {/* Cabeçalho/barra superior melhorado */}
+        <header className="h-18 border-b border-gray-200 flex items-center px-6 bg-white z-10 shadow-sm">
           {/* Botão de toggle do sidebar */}
           <button
             onClick={toggleSidebar}
-            className="mr-4 p-2 rounded-md hover:bg-gray-100 transition-colors"
+            className="mr-5 p-2.5 rounded-lg hover:bg-gray-100 transition-colors duration-200"
             aria-label={isCollapsed ? "Expandir sidebar" : "Colapsar sidebar"}
           >
             <Icon
               name={isCollapsed ? "PanelLeft" : "PanelLeftClose"}
-              size={20}
+              size={22}
               className="transition-transform duration-300"
             />
           </button>
 
           {/* Título da página */}
-          <h1 className="text-lg font-semibold">Dashboard</h1>
+          <h1 className="text-xl font-semibold text-gray-800">Dashboard</h1>
 
           {/* Espaço flexível */}
           <div className="flex-1"></div>
 
           {/* Ícones e controles de usuário na direita */}
           <div className="flex items-center gap-3">
-            <button className="p-2 rounded-md hover:bg-gray-100 transition-colors relative">
-              <Icon name="Bell" size={20} />
-              <span className="absolute top-1 right-1 w-2 h-2 bg-red-500 rounded-full"></span>
+            <button className="p-2.5 rounded-lg hover:bg-gray-100 transition-colors duration-200 relative">
+              <Icon name="Bell" size={22} />
+              <span className="absolute top-1.5 right-1.5 w-2 h-2 bg-red-500 rounded-full"></span>
             </button>
 
-            <button className="p-2 rounded-md hover:bg-gray-100 transition-colors">
-              <Icon name="User" size={20} />
+            <button className="p-2.5 rounded-lg hover:bg-gray-100 transition-colors duration-200">
+              <Icon name="User" size={22} />
             </button>
           </div>
         </header>
 
         {/* Conteúdo principal */}
-        <main className="flex-1 overflow-auto p-6 bg-white">
+        <main className="flex-1 overflow-auto p-8 bg-white">
           {children}
         </main>
       </div>

--- a/src/theme/dashboard/sidebar/Sidebar.tsx
+++ b/src/theme/dashboard/sidebar/Sidebar.tsx
@@ -36,16 +36,11 @@ export function Sidebar({
           onCloseMobile={() => setIsMobileMenuOpen(false)}
         />
 
-        {/* Linha divisória abaixo da logo */}
-        <div
-          className={cn(
-            "my-2 border-b border-[#314e93]",
-            isCollapsed ? "mx-2" : "mx-4"
-          )}
-        />
+        {/* Linha divisória abaixo da logo - agora pega toda a largura */}
+        <div className="border-b border-[#314e93]" />
 
-        {/* Conteúdo do Menu */}
-        <div className="flex-1 overflow-y-auto overflow-x-hidden scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent">
+        {/* Conteúdo do Menu com espaçamento maior */}
+        <div className="flex-1 overflow-y-auto overflow-x-hidden scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent pt-6">
           <MenuList
             sections={menuSections}
             isCollapsed={isCollapsed}

--- a/src/theme/dashboard/sidebar/components/header/SidebarHeader.tsx
+++ b/src/theme/dashboard/sidebar/components/header/SidebarHeader.tsx
@@ -29,27 +29,35 @@ export function SidebarHeader({
   return (
     <div
       className={cn(
-        "h-16 flex items-center justify-between transition-all duration-300",
-        isCollapsed ? "px-2" : "px-4"
+        "h-20 flex items-center justify-between transition-all duration-300",
+        isCollapsed ? "px-3" : "px-6"
       )}
     >
-      <div onClick={handleLogoClick} className="cursor-pointer flex items-center">
+      <div
+        onClick={handleLogoClick}
+        className="cursor-pointer flex items-center justify-center w-full"
+      >
         <Image
-          src={isCollapsed ? "/images/logos/logo_mobile.webp" : "/images/logos/logo_branco.webp"}
+          src={
+            isCollapsed
+              ? "/images/logos/logo_mobile.webp"
+              : "/images/logos/logo_branco.webp"
+          }
           alt="Logo"
-          width={isCollapsed ? 40 : 150}
-          height={40}
+          width={isCollapsed ? 48 : 180}
+          height={isCollapsed ? 48 : 48}
           priority
+          className="transition-all duration-300"
         />
       </div>
 
       {/* Botão de fechar para mobile - visível apenas em telas pequenas */}
       <button
         onClick={onCloseMobile}
-        className="md:hidden p-1.5 rounded-md text-sidebar-foreground/70 hover:bg-white/10 transition-colors"
+        className="md:hidden p-2 rounded-md text-sidebar-foreground/70 hover:bg-white/10 transition-colors absolute right-4 top-1/2 transform -translate-y-1/2"
         aria-label="Fechar menu"
       >
-        <Icon name="X" size={20} />
+        <Icon name="X" size={22} />
       </button>
     </div>
   );

--- a/src/theme/dashboard/sidebar/components/menu/MenuList.tsx
+++ b/src/theme/dashboard/sidebar/components/menu/MenuList.tsx
@@ -32,7 +32,7 @@ export function MenuList({
   }, [sections, markActiveItems, ready]);
 
   return (
-    <div className="space-y-6 transition-all duration-200">
+    <div className="space-y-2 transition-all duration-200">
       {processedSections.map((section) => (
         <MenuSection
           key={section.title}

--- a/src/theme/dashboard/sidebar/components/menu/MenuSection.tsx
+++ b/src/theme/dashboard/sidebar/components/menu/MenuSection.tsx
@@ -12,11 +12,14 @@ export function MenuSection({
 }: MenuSectionProps) {
   return (
     <div
-      className={cn("px-4 transition-all duration-200", isCollapsed && "px-2")}
+      className={cn(
+        "px-4 mb-8 transition-all duration-200",
+        isCollapsed && "px-2 mb-6"
+      )}
     >
       {/* Título da seção - visível apenas quando não está colapsado */}
       {!isCollapsed && (
-        <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-secondary transition-opacity duration-200">
+        <div className="mb-4 text-xs font-bold uppercase tracking-wider text-[var(--secondary-color)] transition-opacity duration-200">
           {section.title}
         </div>
       )}


### PR DESCRIPTION
## Summary
- enhance sidebar header with larger logo and centered layout
- remove sidebar divider margins and adjust menu spacing
- enforce section title color and spacing
- revamp dashboard header with larger controls and shadow

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a621097488832590e34502e1bef824