### PR TITLE
feat: add ReDoc API documentation page

### DIFF
--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import Script from "next/script";
+
+export default function ApiDocsPage() {
+  return (
+    <>
+      <Script
+        src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"
+        strategy="afterInteractive"
+        onReady={() => {
+          (window as any).Redoc.init(
+            "https://advancemais-api-7h1q.onrender.com/openapi.json",
+            {},
+            document.getElementById("redoc-container") as HTMLElement,
+          );
+        }}
+      />
+      <div id="redoc-container" className="min-h-screen" />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/docs` page rendering ReDoc with the API's OpenAPI spec

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9dc51f2bc8325b354293d010b0a16