### PR TITLE
Centralize dashboard route permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "lucide-react": "^0.503.0",
     "next": "15.3.1",
     "nookies": "^2.5.2",
+    "path-to-regexp": "^8.2.0",
     "react": "^19.1.0",
     "react-day-picker": "8.10.1",
     "react-dom": "^19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       nookies:
         specifier: ^2.5.2
         version: 2.5.2
+      path-to-regexp:
+        specifier: ^8.2.0
+        version: 8.2.0
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -2837,6 +2840,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-to-regexp@8.2.0:
+    resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
+    engines: {node: '>=16'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -6099,6 +6106,8 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-to-regexp@8.2.0: {}
 
   pathe@2.0.3: {}
 

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { ReactNode, useEffect, useState } from "react";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { DashboardSidebar, DashboardHeader } from "@/theme";
+import { toastCustom } from "@/components/ui/custom/toast/CustomToast";
 
 interface DashboardLayoutProps {
   children: ReactNode;
@@ -19,6 +21,9 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   const [mounted, setMounted] = useState(false);
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
 
   /**
    * Alterna o estado de colapso do sidebar
@@ -31,9 +36,19 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
     }
   }
 
-  // Efeito para manipulação do estado inicial
+  // Efeito para manipulação do estado inicial e notificações
   useEffect(() => {
     setMounted(true);
+
+    if (searchParams.get("denied")) {
+      toastCustom.error("Acesso negado");
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete("denied");
+      const query = params.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname, {
+        scroll: false,
+      });
+    }
 
     // Reset collapsed state when switching to mobile
     if (isMobileDevice && isCollapsed) {
@@ -51,7 +66,14 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
     return () => {
       document.body.style.overflow = "";
     };
-  }, [isMobileDevice, isCollapsed, isMobileMenuOpen]);
+  }, [
+    isMobileDevice,
+    isCollapsed,
+    isMobileMenuOpen,
+    searchParams,
+    pathname,
+    router,
+  ]);
 
   // Evita problemas de hidratação SSR
   if (!mounted) {

--- a/src/config/dashboardRoutes.ts
+++ b/src/config/dashboardRoutes.ts
@@ -1,0 +1,64 @@
+import { match } from "path-to-regexp";
+import { UserRole } from "./roles";
+
+/** Regra individual de permissão de rota */
+interface RouteRule {
+  /** Padrão de rota compatível com path-to-regexp */
+  pattern: string;
+  /** Papeis autorizados */
+  roles: readonly UserRole[];
+}
+
+/** Lista imutável de regras de acesso do dashboard */
+export const DASHBOARD_ROUTE_RULES: readonly RouteRule[] = Object.freeze([
+  { pattern: "/admin/financeiro/:path*", roles: [UserRole.ADMIN] },
+  { pattern: "/admin/audit/:path*", roles: [UserRole.ADMIN] },
+  { pattern: "/admin/:path*", roles: [UserRole.ADMIN, UserRole.MODERADOR] },
+  { pattern: "/pedagogico/:path*", roles: [UserRole.PEDAGOGICO] },
+  { pattern: "/empresa/:path*", roles: [UserRole.EMPRESA] },
+  { pattern: "/recrutador/:path*", roles: [UserRole.RECRUTADOR] },
+  { pattern: "/professor/:path*", roles: [UserRole.PROFESSOR] },
+  { pattern: "/aluno/:path*", roles: [UserRole.ALUNO_CANDIDATO] },
+  { pattern: "/psicologo/:path*", roles: [UserRole.PSICOLOGO] },
+  { pattern: "/financeiro/:path*", roles: [UserRole.FINANCEIRO] },
+]);
+
+const matchers = DASHBOARD_ROUTE_RULES.map((rule) => ({
+  roles: rule.roles,
+  match: match(rule.pattern, { decode: decodeURIComponent, end: false }),
+}));
+
+/**
+ * Retorna os papéis permitidos para uma determinada rota.
+ */
+export function getRoutePermissions(path: string): readonly UserRole[] {
+  const normalized = path.split("?")[0];
+  const rule = matchers.find((r) => r.match(normalized));
+  return rule?.roles ?? [];
+}
+
+/** Verifica se um papel possui acesso à rota informada */
+export function canAccessRoute(path: string, role: UserRole): boolean {
+  return getRoutePermissions(path).includes(role);
+}
+
+/** Lista de módulos de primeiro nível do dashboard */
+export const SYSTEM_MODULES = Array.from(
+  new Set(
+    DASHBOARD_ROUTE_RULES.map((rule) => rule.pattern.split("/")[1])
+  )
+);
+
+/** Mapeamento inverso: módulos permitidos por papel */
+export const ROLE_PERMISSIONS: Record<UserRole, string[]> = Object.values(
+  UserRole
+).reduce(
+  (acc, role) => {
+    acc[role] = SYSTEM_MODULES.filter((module) =>
+      canAccessRoute(`/${module}`, role)
+    );
+    return acc;
+  },
+  {} as Record<UserRole, string[]>
+);
+

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -25,7 +25,6 @@ const SYSTEM_CONFIG = {
     "/projects",
     "/users",
     "/settings",
-    "/unauthorized",
   ],
 
   // Rotas que pertencem ao website

--- a/src/theme/dashboard/sidebar/config/menuConfig.ts
+++ b/src/theme/dashboard/sidebar/config/menuConfig.ts
@@ -1,49 +1,20 @@
 // src/theme/sidebar/config/menuConfig.ts
 import { MenuSection } from "../types/sidebar.types";
-import { UserRole } from "@/config/roles";
+import { getRoutePermissions } from "@/config/dashboardRoutes";
 
 /**
  * Permissões compartilhadas por itens administrativos.
  * Definidas como somente leitura para evitar mutações acidentais.
  */
-const ADMIN_PERMISSIONS: readonly UserRole[] = Object.freeze([
-  UserRole.ADMIN,
-  UserRole.MODERADOR,
-]);
-
-/** Permissões exclusivas para o administrador */
-const ADMIN_ONLY_PERMISSIONS: readonly UserRole[] = Object.freeze([
-  UserRole.ADMIN,
-]);
-
-/** Permissões exclusivas para o papel pedagógico */
-const PEDAGOGICO_PERMISSIONS: readonly UserRole[] = Object.freeze([
-  UserRole.PEDAGOGICO,
-]);
-
-const EMPRESA_PERMISSIONS: readonly UserRole[] = Object.freeze([
-  UserRole.EMPRESA,
-]);
-
-const RECRUTADOR_PERMISSIONS: readonly UserRole[] = Object.freeze([
-  UserRole.RECRUTADOR,
-]);
-
-const PROFESSOR_PERMISSIONS: readonly UserRole[] = Object.freeze([
-  UserRole.PROFESSOR,
-]);
-
-const ALUNO_PERMISSIONS: readonly UserRole[] = Object.freeze([
-  UserRole.ALUNO_CANDIDATO,
-]);
-
-const PSICOLOGO_PERMISSIONS: readonly UserRole[] = Object.freeze([
-  UserRole.PSICOLOGO,
-]);
-
-const FINANCEIRO_PERMISSIONS: readonly UserRole[] = Object.freeze([
-  UserRole.FINANCEIRO,
-]);
+const ADMIN_PERMISSIONS = getRoutePermissions("/admin");
+const ADMIN_ONLY_PERMISSIONS = getRoutePermissions("/admin/financeiro");
+const PEDAGOGICO_PERMISSIONS = getRoutePermissions("/pedagogico");
+const EMPRESA_PERMISSIONS = getRoutePermissions("/empresa");
+const RECRUTADOR_PERMISSIONS = getRoutePermissions("/recrutador");
+const PROFESSOR_PERMISSIONS = getRoutePermissions("/professor");
+const ALUNO_PERMISSIONS = getRoutePermissions("/aluno");
+const PSICOLOGO_PERMISSIONS = getRoutePermissions("/psicologo");
+const FINANCEIRO_PERMISSIONS = getRoutePermissions("/financeiro");
 
 /**
  * Congela recursivamente um objeto, garantindo sua imutabilidade.


### PR DESCRIPTION
## Summary
- replace route prefix map with pattern-based rules using `path-to-regexp`
- redirect unauthorized dashboard visits to home and surface toast message
- drop unused unauthorized page and update dashboard layout to handle denied flag

## Testing
- `pnpm lint`
- `pnpm type-check`
- `NEXT_PUBLIC_API_BASE_URL=http://localhost pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa203d6d488325b221380416c566eb