### PR TITLE
Add admin pages and export website features component

### DIFF
--- a/src/app/dashboard/admin/page.tsx
+++ b/src/app/dashboard/admin/page.tsx
@@ -1,0 +1,4 @@
+export default function AdminPage() {
+  return <div>Hello World</div>;
+}
+

--- a/src/app/dashboard/admin/website/page.tsx
+++ b/src/app/dashboard/admin/website/page.tsx
@@ -1,0 +1,6 @@
+import { WebsiteFeatures } from "@/theme/dashboard/components/admin";
+
+export default function AdminWebsitePage() {
+  return <WebsiteFeatures />;
+}
+

--- a/src/theme/dashboard/components/admin/index.ts
+++ b/src/theme/dashboard/components/admin/index.ts
@@ -1,0 +1,2 @@
+export * from "./website-features";
+


### PR DESCRIPTION
## Summary
- add basic hello world admin page
- wire up admin website page with WebsiteFeatures
- centralize admin component exports

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(fails: Missing parameter name from path-to-regexp when prerendering /dashboard/admin)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2766846883258b7e880ba5ed2274