### PR TITLE
fix: provide labels to InputCustom in slider modal

### DIFF
--- a/src/app/dashboard/admin/website/pagina-inicial/slider/SliderList.tsx
+++ b/src/app/dashboard/admin/website/pagina-inicial/slider/SliderList.tsx
@@ -324,8 +324,8 @@ export default function SliderList() {
           <ModalBody className="space-y-4">
             <FormatSelector value={modalFormat} onChange={setModalFormat} />
             <div className="space-y-2">
-              <Label htmlFor="imagem">Upload do banner</Label>
               <InputCustom
+                label="Upload do banner"
                 id="imagem"
                 type="file"
                 onChange={(e) =>
@@ -334,8 +334,8 @@ export default function SliderList() {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="link">Link do banner (opcional)</Label>
               <InputCustom
+                label="Link do banner (opcional)"
                 id="link"
                 value={link}
                 onChange={(e) => setLink(e.target.value)}


### PR DESCRIPTION
## Summary
- fix missing `label` props in slider modal inputs to satisfy `InputCustom` requirements

## Testing
- `pnpm test`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab289e47f08325805d0d0ed748d718