### PR TITLE
feat(vertical-tabs): support nested submenus

### DIFF
--- a/src/app/dashboard/config/website/pagina-inicial/page.tsx
+++ b/src/app/dashboard/config/website/pagina-inicial/page.tsx
@@ -7,7 +7,20 @@ export default function PaginaInicialPage() {
       value: "slider",
       label: "Slider",
       icon: "Images",
-      content: <SliderList />,
+      submenu: [
+        {
+          value: "slider-desktop",
+          label: "Desktop",
+          icon: "Monitor",
+          content: <SliderList initialFormat="web" />,
+        },
+        {
+          value: "slider-mobile",
+          label: "Tablet/Mobile",
+          icon: "Smartphone",
+          content: <SliderList initialFormat="mobile" />,
+        },
+      ],
     },
     {
       value: "sobre",
@@ -63,9 +76,9 @@ export default function PaginaInicialPage() {
     <div className="bg-white rounded-3xl p-5 h-full min-h-[calc(100vh-8rem)] flex flex-col">
       {/* Conteúdo principal com VerticalTabs */}
       <div className="flex-1 min-h-0">
-        <VerticalTabs 
-          items={items} 
-          defaultValue="slider"
+        <VerticalTabs
+          items={items}
+          defaultValue="slider-desktop"
           variant="spacious"
           size="md"
           withAnimation={true}

--- a/src/app/dashboard/config/website/pagina-inicial/slider/SliderList.tsx
+++ b/src/app/dashboard/config/website/pagina-inicial/slider/SliderList.tsx
@@ -107,12 +107,16 @@ const FormatSelector = ({
   );
 };
 
-export default function SliderList() {
-  const [format, setFormat] = useState<"web" | "mobile">("web");
+interface SliderListProps {
+  initialFormat?: "web" | "mobile";
+}
+
+export default function SliderList({ initialFormat = "web" }: SliderListProps) {
+  const [format, setFormat] = useState<"web" | "mobile">(initialFormat);
   const [banners, setBanners] = useState<Banner[]>([]);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingBanner, setEditingBanner] = useState<Banner | null>(null);
-  const [modalFormat, setModalFormat] = useState<"web" | "mobile">("web");
+  const [modalFormat, setModalFormat] = useState<"web" | "mobile">(initialFormat);
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [link, setLink] = useState("");
 
@@ -133,7 +137,7 @@ export default function SliderList() {
 
   const openAddModal = () => {
     setEditingBanner(null);
-    setModalFormat("web");
+    setModalFormat(initialFormat);
     setImageFile(null);
     setLink("");
     setIsModalOpen(true);

--- a/src/components/ui/custom/vertical-tabs/VerticalTabs.tsx
+++ b/src/components/ui/custom/vertical-tabs/VerticalTabs.tsx
@@ -43,9 +43,24 @@ export function VerticalTabs({
   classNames = {},
   onValueChange,
 }: VerticalTabsProps) {
-  const [internalValue, setInternalValue] = React.useState(
-    defaultValue ?? controlledValue ?? items[0]?.value ?? ""
+  const flattenItems = React.useCallback(
+    (list: VerticalTabItem[]): VerticalTabItem[] => {
+      return list.flatMap((item) =>
+        item.submenu && item.submenu.length
+          ? flattenItems(item.submenu)
+          : [item]
+      );
+    },
+    []
   );
+
+  const flatItems = React.useMemo(() => flattenItems(items), [items, flattenItems]);
+
+  const [internalValue, setInternalValue] = React.useState(
+    defaultValue ?? controlledValue ?? flatItems[0]?.value ?? ""
+  );
+
+  const [openSubmenus, setOpenSubmenus] = React.useState<Record<string, boolean>>({});
 
   // Estado controlado vs não controlado
   const isControlled = controlledValue !== undefined;
@@ -63,12 +78,144 @@ export function VerticalTabs({
     switch(variant) {
       case "minimal":
         return "minimal";
-      case "spacious": 
+      case "spacious":
         return "spacious";
       default:
         return "default";
     }
   };
+
+  const renderTriggers = (
+    list: VerticalTabItem[],
+    level = 0,
+    parentId = ""
+  ): React.ReactNode => {
+    return list.map((item) => {
+      const hasSubmenu = item.submenu && item.submenu.length > 0;
+      const itemId = parentId ? `${parentId}-${item.value}` : item.value;
+
+      if (hasSubmenu) {
+        const isOpen = openSubmenus[itemId];
+        return (
+          <div key={itemId} className="w-full">
+            <button
+              type="button"
+              onClick={() =>
+                setOpenSubmenus((prev) => ({ ...prev, [itemId]: !isOpen }))
+              }
+              className={cn(
+                tabsTriggerVariants({ variant, size }),
+                "flex items-center justify-between",
+                classNames.tabsTrigger
+              )}
+              style={level ? { marginLeft: level * 16 } : undefined}
+            >
+              <div className="flex items-center gap-3 w-full">
+                {item.icon && (
+                  <Icon
+                    name={item.icon}
+                    className={cn(tabsIconVariants({ variant, size }))}
+                  />
+                )}
+                <span className="flex-1 truncate">{item.label}</span>
+              </div>
+              <ChevronDown
+                className={cn(
+                  "w-4 h-4 transition-transform",
+                  isOpen && "rotate-180"
+                )}
+              />
+            </button>
+            <div
+              className={cn(
+                "pl-4 border-l border-gray-200",
+                isOpen ? "mt-2" : "hidden"
+              )}
+            >
+              {renderTriggers(item.submenu!, level + 1, itemId)}
+            </div>
+          </div>
+        );
+      }
+
+      return (
+        <TabsPrimitive.Trigger
+          key={itemId}
+          value={item.value}
+          disabled={item.disabled}
+          className={cn(
+            tabsTriggerVariants({ variant, size }),
+            classNames.tabsTrigger
+          )}
+          style={level ? { marginLeft: level * 16 } : undefined}
+        >
+          {showIndicator && (
+            <motion.div
+              className={cn(
+                tabsIndicatorVariants({ variant, size }),
+                classNames.indicator
+              )}
+              layout
+              transition={{ duration: 0.3, ease: [0.32, 0.72, 0, 1] }}
+            />
+          )}
+          <div className="flex items-center gap-3 w-full relative z-10">
+            {item.icon && (
+              <Icon
+                name={item.icon}
+                className={cn(tabsIconVariants({ variant, size }))}
+              />
+            )}
+            <span className="flex-1 truncate">{item.label}</span>
+            {item.badge && (
+              <span
+                className={cn(
+                  "px-2 py-0.5 text-xs rounded-full font-medium",
+                  "bg-gray-100 text-gray-600 transition-all duration-300",
+                  "group-data-[state=active]:bg-blue-100 group-data-[state=active]:text-blue-700",
+                  variant === "spacious" &&
+                    "group-data-[state=active]:bg-white/20 group-data-[state=active]:text-white"
+                )}
+              >
+                {item.badge}
+              </span>
+            )}
+          </div>
+        </TabsPrimitive.Trigger>
+      );
+    });
+  };
+
+  React.useEffect(() => {
+    const findPath = (
+      list: VerticalTabItem[],
+      target: string,
+      path: string[] = []
+    ): string[] | null => {
+      for (const item of list) {
+        const newPath = [...path, item.value];
+        if (item.value === target) return newPath;
+        if (item.submenu) {
+          const result = findPath(item.submenu, target, newPath);
+          if (result) return result;
+        }
+      }
+      return null;
+    };
+
+    const path = findPath(items, value);
+    if (path) {
+      setOpenSubmenus((prev) => {
+        const updated = { ...prev };
+        let current = "";
+        path.slice(0, -1).forEach((part) => {
+          current = current ? `${current}-${part}` : part;
+          updated[current] = true;
+        });
+        return updated;
+      });
+    }
+  }, [value, items]);
 
   return (
     <TabsPrimitive.Root
@@ -90,59 +237,7 @@ export function VerticalTabs({
           classNames.tabsList
         )}
       >
-        {items.map((item) => (
-          <TabsPrimitive.Trigger
-            key={item.value}
-            value={item.value}
-            disabled={item.disabled}
-            className={cn(
-              tabsTriggerVariants({ variant, size }),
-              classNames.tabsTrigger
-            )}
-          >
-            {/* Indicador Visual Sutil */}
-            {showIndicator && (
-              <motion.div
-                className={cn(
-                  tabsIndicatorVariants({ variant, size }),
-                  classNames.indicator
-                )}
-                layout
-                transition={{ duration: 0.3, ease: [0.32, 0.72, 0, 1] }}
-              />
-            )}
-
-            {/* Conteúdo da Aba */}
-            <div className="flex items-center gap-3 w-full relative z-10">
-              {/* Ícone */}
-              {item.icon && (
-                <Icon 
-                  name={item.icon} 
-                  className={cn(
-                    tabsIconVariants({ variant, size })
-                  )}
-                />
-              )}
-
-              {/* Label */}
-              <span className="flex-1 truncate">
-                {item.label}
-              </span>
-
-              {/* Badge (opcional) */}
-              {item.badge && (
-                <span className={cn(
-                  "px-2 py-0.5 text-xs rounded-full font-medium",
-                  "bg-gray-100 text-gray-600 transition-all duration-300",
-                  "group-data-[state=active]:bg-blue-100 group-data-[state=active]:text-blue-700",
-                  variant === "spacious" && "group-data-[state=active]:bg-white/20 group-data-[state=active]:text-white"
-                )}>
-                  {item.badge}
-                </span>
-              )}
-            </div>
-          </TabsPrimitive.Trigger>
-        ))}
+        {renderTriggers(items)}
       </TabsPrimitive.List>
 
       {/* Mobile Select Dropdown */}
@@ -159,7 +254,7 @@ export function VerticalTabs({
             )}
             aria-label="Select tab"
           >
-            {items.map((item) => (
+            {flatItems.map((item) => (
               <option key={item.value} value={item.value} disabled={item.disabled}>
                 {item.label} {item.badge && `(${item.badge})`}
               </option>
@@ -176,7 +271,7 @@ export function VerticalTabs({
         tabsContentVariants({ variant: getContentVariant(), padding: "md" }),
         classNames.contentWrapper
       )}>
-        {items.map((item) => (
+        {flatItems.map((item) => (
           <TabsPrimitive.Content
             key={item.value}
             value={item.value}
@@ -189,22 +284,22 @@ export function VerticalTabs({
               <motion.div
                 initial={{ opacity: 0 }}
                 animate={{ opacity: value === item.value ? 1 : 0 }}
-                transition={{ 
-                  duration: 0.2, 
+                transition={{
+                  duration: 0.2,
                   ease: [0.32, 0.72, 0, 1] as const
                 }}
                 className="h-full"
-                style={{ 
-                  display: value === item.value ? 'block' : 'none' 
+                style={{
+                  display: value === item.value ? 'block' : 'none'
                 }}
               >
                 {item.content}
               </motion.div>
             ) : (
-              <div 
+              <div
                 className="h-full"
-                style={{ 
-                  display: value === item.value ? 'block' : 'none' 
+                style={{
+                  display: value === item.value ? 'block' : 'none'
                 }}
               >
                 {item.content}

--- a/src/components/ui/custom/vertical-tabs/types/index.ts
+++ b/src/components/ui/custom/vertical-tabs/types/index.ts
@@ -14,11 +14,13 @@ export interface VerticalTabItem {
   /** Ícone exibido antes do rótulo. */
   icon?: IconName;
   /** Conteúdo a ser renderizado quando a aba estiver ativa. */
-  content: ReactNode;
+  content?: ReactNode;
   /** Se o item está desabilitado */
   disabled?: boolean;
   /** Badge ou contador a ser exibido */
   badge?: string | number;
+  /** Lista de subitens para criação de submenus */
+  submenu?: VerticalTabItem[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- allow VerticalTabItem to define nested `submenu` items
- render submenus recursively with toggle state and mobile selection
- flatten tab items for content rendering
- add slider submenu for desktop and tablet/mobile
- allow SliderList to accept `initialFormat`

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_68ac741ee1b483259c8347b6a0785f94