### PR TITLE
feat: add about section management

### DIFF
--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -16,6 +16,7 @@ export const websiteRoutes = {
   delete: (id: string) => `${prefix}/website/${id}`,
   home: {
     about: () => `${prefix}/website/sobre`,
+    aboutById: (id: string) => `${prefix}/website/sobre/${id}`,
     slide: () => `${prefix}/website/slide`,
     banner: () => `${prefix}/website/banner`,
   },

--- a/src/app/dashboard/config/website/pagina-inicial/page.tsx
+++ b/src/app/dashboard/config/website/pagina-inicial/page.tsx
@@ -1,5 +1,6 @@
 import { VerticalTabs, type VerticalTabItem } from "@/components/ui/custom";
 import SliderList from "./slider/SliderList";
+import SobreForm from "./sobre/SobreForm";
 
 export default function PaginaInicialPage() {
   const items: VerticalTabItem[] = [
@@ -26,17 +27,7 @@ export default function PaginaInicialPage() {
       value: "sobre",
       label: "Sobre",
       icon: "Info",
-      content: (
-        <div className="space-y-6">
-          <div>
-            <h3 className="text-lg font-semibold mb-4">Seção Sobre</h3>
-            <p className="text-muted-foreground">
-              Configure o conteúdo da seção sobre da página inicial.
-            </p>
-          </div>
-          {/* Aqui você pode adicionar formulários para configurar a seção sobre */}
-        </div>
-      ),
+      content: <SobreForm />,
     },
     {
       value: "banners",

--- a/src/app/dashboard/config/website/pagina-inicial/sobre/SobreForm.tsx
+++ b/src/app/dashboard/config/website/pagina-inicial/sobre/SobreForm.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useEffect, useState, FormEvent } from "react";
+import {
+  InputCustom,
+  ButtonCustom,
+  FileUpload,
+  type FileUploadItem,
+} from "@/components/ui/custom";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { toastCustom } from "@/components/ui/custom/toast";
+
+interface SobreContent {
+  id?: string;
+  titulo: string;
+  descricao: string;
+  imagemUrl?: string;
+}
+
+export default function SobreForm() {
+  const [content, setContent] = useState<SobreContent>({
+    titulo: "",
+    descricao: "",
+  });
+  const [files, setFiles] = useState<FileUploadItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch("/api/v1/website/sobre");
+        if (!res.ok) return;
+        const data: any[] = await res.json();
+        const first = data[0];
+        if (first) {
+          setContent({
+            id: first.id,
+            titulo: first.titulo ?? "",
+            descricao: first.descricao ?? "",
+            imagemUrl: first.imagemUrl ?? undefined,
+          });
+          if (first.imagemUrl) {
+            const item: FileUploadItem = {
+              id: "existing",
+              name: first.imagemTitulo || "imagem",
+              size: 0,
+              type: "image",
+              status: "completed",
+              uploadDate: new Date(first.criadoEm || Date.now()),
+              previewUrl: first.imagemUrl,
+            };
+            setFiles([item]);
+          }
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchData();
+  }, []);
+
+  const handleFilesChange = (list: FileUploadItem[]) => {
+    setFiles(list);
+    if (list.length === 0) {
+      setContent((prev) => ({ ...prev, imagemUrl: undefined }));
+    }
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const title = content.titulo.trim();
+    const description = content.descricao.trim();
+
+    if (title.length < 10 || title.length > 50) {
+      toastCustom.error("O título deve ter entre 10 e 50 caracteres.");
+      return;
+    }
+    if (description.length < 10 || description.length > 500) {
+      toastCustom.error("A descrição deve ter entre 10 e 500 caracteres.");
+      return;
+    }
+    if (files.length === 0) {
+      toastCustom.error("Selecione uma imagem.");
+      return;
+    }
+
+    setIsLoading(true);
+    const formData = new FormData();
+    formData.append("titulo", title);
+    formData.append("descricao", description);
+
+    const file = files[0];
+    if (file.file) {
+      formData.append("imagem", file.file);
+    } else if (content.imagemUrl) {
+      formData.append("imagemUrl", content.imagemUrl);
+    }
+
+    try {
+      const method = content.id ? "PUT" : "POST";
+      const url = content.id
+        ? `/api/v1/website/sobre/${content.id}`
+        : "/api/v1/website/sobre";
+      const res = await fetch(url, { method, body: formData });
+      if (!res.ok) throw new Error("Erro ao salvar");
+      const saved = await res.json();
+      toastCustom.success("Conteúdo salvo com sucesso.");
+      setContent({
+        id: saved.id,
+        titulo: saved.titulo,
+        descricao: saved.descricao,
+        imagemUrl: saved.imagemUrl,
+      });
+      setFiles([
+        {
+          id: saved.id,
+          name: saved.imagemTitulo || "imagem",
+          size: 0,
+          type: "image",
+          status: "completed",
+          uploadDate: new Date(saved.atualizadoEm || Date.now()),
+          previewUrl: saved.imagemUrl,
+        },
+      ]);
+    } catch (err) {
+      console.error(err);
+      toastCustom.error("Erro ao salvar o conteúdo.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6 max-w-2xl">
+      <div className="space-y-2">
+        <Label>Imagem</Label>
+        <FileUpload
+          files={files}
+          multiple={false}
+          validation={{
+            maxSize: 5 * 1024 * 1024,
+            acceptedTypes: ["image/*"],
+            maxFiles: 1,
+          }}
+          onFilesChange={handleFilesChange}
+          showProgress={false}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <InputCustom
+          label="Título"
+          id="titulo"
+          value={content.titulo}
+          onChange={(e) =>
+            setContent((prev) => ({ ...prev, titulo: e.target.value }))
+          }
+          maxLength={50}
+          required
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="descricao">Descrição</Label>
+        <Textarea
+          id="descricao"
+          value={content.descricao}
+          onChange={(e) =>
+            setContent((prev) => ({ ...prev, descricao: e.target.value }))
+          }
+          className="min-h-[120px] resize-none"
+          maxLength={500}
+          required
+        />
+      </div>
+
+      <ButtonCustom type="submit" icon="Save" isLoading={isLoading}>
+        Salvar
+      </ButtonCustom>
+    </form>
+  );
+}
+

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -4,7 +4,7 @@ import { ReactNode, useEffect, useState } from "react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { DashboardSidebar, DashboardHeader } from "@/theme";
-import { toastCustom } from "@/components/ui/custom/toast/CustomToast";
+import { toastCustom } from "@/components/ui/custom/toast";
 import { DashboardHeader as Breadcrumb } from '@/components/layout';
 
 interface DashboardLayoutProps {


### PR DESCRIPTION
## Summary
- add About section form with image upload and validation
- show About form in dashboard tabs
- expose route helper for website "sobre" items
- consolidate custom component imports via unified index
- ensure toast helpers are imported from toast barrel

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68acaffbc7e08325b62af5b7a73a7cde