### PR TITLE
fix: handle nullable search params

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -21,7 +21,7 @@ const SignInPageDemo = () => {
   }, []);
 
   useEffect(() => {
-    const error = searchParams.get("error");
+    const error = searchParams?.get("error");
     if (error === "unauthorized") {
       toastCustom.error(
         "Você não tem autorização para acessar como visitante. Por favor realize seu cadastro."

--- a/src/app/auth/verify-email/page.tsx
+++ b/src/app/auth/verify-email/page.tsx
@@ -10,7 +10,7 @@ import { toastCustom } from "@/components/ui/custom/toast";
 export default function VerifyEmailPage() {
   const searchParams = useSearchParams();
   const router = useRouter();
-  const token = searchParams.get("token");
+  const token = searchParams?.get("token");
   const [status, setStatus] = useState<"loading" | "error">("loading");
 
   useEffect(() => {

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -23,7 +23,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const searchParams = useSearchParams();
-  const pathname = usePathname();
+  const pathname = usePathname() || "";
   const router = useRouter();
 
   /**
@@ -41,7 +41,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   useEffect(() => {
     setMounted(true);
 
-    if (searchParams.get("denied")) {
+    if (searchParams && searchParams.get("denied")) {
       toastCustom.error("Acesso negado");
       const params = new URLSearchParams(searchParams.toString());
       params.delete("denied");

--- a/src/hooks/use-breadcrumb.ts
+++ b/src/hooks/use-breadcrumb.ts
@@ -3,7 +3,7 @@ import { breadcrumbConfig } from '@/lib/breadcrumb-config';
 import type { BreadcrumbConfig } from '@/config/breadcrumb';
 
 export function useBreadcrumb(): BreadcrumbConfig {
-  const pathname = usePathname();
+  const pathname = usePathname() || "/";
   
   // Busca a configuração exata da rota
   const config = breadcrumbConfig[pathname];

--- a/src/theme/website/components/header-pages/components/HeaderContent.tsx
+++ b/src/theme/website/components/header-pages/components/HeaderContent.tsx
@@ -22,7 +22,7 @@ export const HeaderContent: React.FC<HeaderContentProps> = ({ data }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
   const isMobile = useIsMobile();
-  const pathname = usePathname();
+  const pathname = usePathname() || "";
 
   const breadcrumbs = generateBreadcrumbs(pathname);
   const isExternal = isExternalUrl(data.buttonUrl);

--- a/src/theme/website/components/header-pages/hooks/useHeaderData.ts
+++ b/src/theme/website/components/header-pages/hooks/useHeaderData.ts
@@ -22,7 +22,7 @@ export function useHeaderData(
   staticData?: HeaderPageData,
   currentPage?: string
 ): UseHeaderDataReturn {
-  const pathname = usePathname();
+  const pathname = usePathname() || "";
   const targetPage = currentPage || pathname;
 
   const [data, setData] = useState<HeaderPageData | null>(staticData || null);


### PR DESCRIPTION
## Summary
- guard against missing search params in login and verification flows
- default pathnames in dashboard and header components to avoid null references

## Testing
- `pnpm test`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acbd4171ac832582f1b92426a26b7a