### PR TITLE
Hide dropzone when max file limit reached

### DIFF
--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -65,6 +65,16 @@ export const brevoRoutes = {
 };
 
 /**
+ * Endpoints for uploading files.
+ * Allows pages to specify the correct destination for each upload.
+ */
+export const uploadRoutes = {
+  base: () => `${prefix}/upload`,
+  slider: () => `${prefix}/upload/slider`,
+  banner: () => `${prefix}/upload/banner`,
+};
+
+/**
  * Collection of all API route groups.
  * Extend this object as new microservices are added.
  */
@@ -73,6 +83,7 @@ export const routes = {
   usuarios: usuarioRoutes,
   mercadopago: mercadoPagoRoutes,
   brevo: brevoRoutes,
+  upload: uploadRoutes,
 };
 
 export type Routes = typeof routes;

--- a/src/components/ui/custom/file-upload/types/index.ts
+++ b/src/components/ui/custom/file-upload/types/index.ts
@@ -51,6 +51,8 @@ export interface FileUploadItem {
   error?: string;
   /** Arquivo original do navegador */
   file?: File;
+  /** URL retornada pelo servidor após upload */
+  uploadedUrl?: string;
 }
 
 /**
@@ -82,6 +84,8 @@ export interface FileUploadProps extends VariantProps<typeof fileUploadVariants>
   files?: FileUploadItem[];
   /** Configuração de validação */
   validation?: Partial<FileValidationConfig>;
+  /** Número máximo de arquivos permitidos */
+  maxFiles?: number;
   /** Se permite múltiplos arquivos */
   multiple?: boolean;
   /** Se está desabilitado */
@@ -124,6 +128,8 @@ export interface FileUploadProps extends VariantProps<typeof fileUploadVariants>
   onUploadError?: (fileId: string, error: string) => void;
   /** Callback personalizado de upload */
   onUpload?: (file: File) => Promise<{ url?: string; error?: string }>;
+  /** Endpoint para upload automático */
+  uploadUrl?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add centralized `upload` routes for file endpoints
- support automatic uploads via new `uploadUrl` prop in FileUpload
- update SobreForm to use route-driven uploads and returned file URLs

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68acc70b7e048325a1816ac437abfbdc