### PR TITLE
Rename Advancemais references to Advance+

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # =============================================================================
-# CONFIGURAÇÕES DE AMBIENTE - ADVANCEMAIS
+# CONFIGURAÇÕES DE AMBIENTE - ADVANCE+
 # =============================================================================
 
 # API Configuration
@@ -12,7 +12,7 @@ NEXT_PUBLIC_SUPPORT_PHONE=82994360962
 
 # Application Settings
 NEXT_PUBLIC_BASE_URL=https://advancemais.com.br
-NEXT_PUBLIC_APP_NAME=AdvanceMais
+NEXT_PUBLIC_APP_NAME=Advance+
 
 # =============================================================================
 # AMBIENTES ESPECÍFICOS

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,12 +11,12 @@ import "@/styles/globals.css";
 
 export const metadata: Metadata = {
   title: {
-    template: "%s | AdvanceMais",
-    default: "AdvanceMais - Educação e Tecnologia",
+    template: "%s | Advance+",
+    default: "Advance+ - Educação e Tecnologia",
   },
   description: "Plataforma integrada de educação, tecnologia e gestão",
-  keywords: ["educação", "tecnologia", "gestão", "cursos", "AdvanceMais"],
-  authors: [{ name: "AdvanceMais" }],
+  keywords: ["educação", "tecnologia", "gestão", "cursos", "Advance+"],
+  authors: [{ name: "Advance+" }],
   robots: "index, follow",
   metadataBase: new URL(
     process.env.NEXT_PUBLIC_BASE_URL || "https://advancemais.com.br"

--- a/src/app/website/cookies/page.tsx
+++ b/src/app/website/cookies/page.tsx
@@ -18,14 +18,14 @@ export default function CookiesPage() {
   // Dados mockados específicos para esta página
   const headerData: HeaderPageData = {
     id: "sobre-custom",
-    title: "Sobre a AdvanceMais",
+    title: "Sobre a Advance+",
     subtitle: "Nossa História",
     description:
       "Conheça nossa trajetória, missão e valores. Há mais de 10 anos transformando empresas e desenvolvendo talentos com soluções inovadoras e personalizadas.",
     buttonText: "Nossa equipe",
     buttonUrl: "/sobre/equipe",
     imageUrl: "/images/headers/sobre-header.webp",
-    imageAlt: "Sobre a AdvanceMais - Nossa História",
+    imageAlt: "Sobre a Advance+ - Nossa História",
     isActive: true,
     targetPages: ["/sobre"],
   };

--- a/src/app/website/fale-conosco/page.tsx
+++ b/src/app/website/fale-conosco/page.tsx
@@ -18,14 +18,14 @@ export default function FaleConoscoPage() {
   // Dados mockados específicos para esta página
   const headerData: HeaderPageData = {
     id: "sobre-custom",
-    title: "Sobre a AdvanceMais",
+    title: "Sobre a Advance+",
     subtitle: "Nossa História",
     description:
       "Conheça nossa trajetória, missão e valores. Há mais de 10 anos transformando empresas e desenvolvendo talentos com soluções inovadoras e personalizadas.",
     buttonText: "Nossa equipe",
     buttonUrl: "/sobre/equipe",
     imageUrl: "/images/headers/sobre-header.webp",
-    imageAlt: "Sobre a AdvanceMais - Nossa História",
+    imageAlt: "Sobre a Advance+ - Nossa História",
     isActive: true,
     targetPages: ["/sobre"],
   };

--- a/src/app/website/faq/page.tsx
+++ b/src/app/website/faq/page.tsx
@@ -18,14 +18,14 @@ export default function OuvidoriaPage() {
   // Dados mockados específicos para esta página
   const headerData: HeaderPageData = {
     id: "sobre-custom",
-    title: "Sobre a AdvanceMais",
+    title: "Sobre a Advance+",
     subtitle: "Nossa História",
     description:
       "Conheça nossa trajetória, missão e valores. Há mais de 10 anos transformando empresas e desenvolvendo talentos com soluções inovadoras e personalizadas.",
     buttonText: "Nossa equipe",
     buttonUrl: "/sobre/equipe",
     imageUrl: "/images/headers/sobre-header.webp",
-    imageAlt: "Sobre a AdvanceMais - Nossa História",
+    imageAlt: "Sobre a Advance+ - Nossa História",
     isActive: true,
     targetPages: ["/sobre"],
   };

--- a/src/app/website/layout.tsx
+++ b/src/app/website/layout.tsx
@@ -4,7 +4,7 @@ import { LoadingProvider } from "./loading-context";
 import LayoutClient from "./layout-client";
 
 export const metadata: Metadata = {
-  title: "AdvanceMais - Inovação em Educação e Tecnologia",
+  title: "Advance+ - Inovação em Educação e Tecnologia",
   description:
     "Plataforma integrada de educação, cursos profissionalizantes e soluções tecnológicas para empresas e pessoas",
   keywords: [
@@ -15,29 +15,29 @@ export const metadata: Metadata = {
     "profissionalização",
     "plataforma de ensino",
     "soluções empresariais",
-    "AdvanceMais",
+    "Advance+",
   ],
-  authors: [{ name: "AdvanceMais" }],
+  authors: [{ name: "Advance+" }],
   robots: "index, follow",
   openGraph: {
-    title: "AdvanceMais - Inovação em Educação e Tecnologia",
+    title: "Advance+ - Inovação em Educação e Tecnologia",
     description:
       "Plataforma integrada de educação, cursos profissionalizantes e soluções tecnológicas",
     type: "website",
     locale: "pt_BR",
-    siteName: "AdvanceMais",
+    siteName: "Advance+",
     images: [
       {
         url: "/images/og-image.jpg",
         width: 1200,
         height: 630,
-        alt: "AdvanceMais - Educação e Tecnologia",
+        alt: "Advance+ - Educação e Tecnologia",
       },
     ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "AdvanceMais - Inovação em Educação e Tecnologia",
+    title: "Advance+ - Inovação em Educação e Tecnologia",
     description:
       "Plataforma integrada de educação, cursos profissionalizantes e soluções tecnológicas",
     images: ["/images/og-image.jpg"],

--- a/src/app/website/ouvidoria/page.tsx
+++ b/src/app/website/ouvidoria/page.tsx
@@ -18,14 +18,14 @@ export default function FaqPage() {
   // Dados mockados específicos para esta página
   const headerData: HeaderPageData = {
     id: "sobre-custom",
-    title: "Sobre a AdvanceMais",
+    title: "Sobre a Advance+",
     subtitle: "Nossa História",
     description:
       "Conheça nossa trajetória, missão e valores. Há mais de 10 anos transformando empresas e desenvolvendo talentos com soluções inovadoras e personalizadas.",
     buttonText: "Nossa equipe",
     buttonUrl: "/sobre/equipe",
     imageUrl: "/images/headers/sobre-header.webp",
-    imageAlt: "Sobre a AdvanceMais - Nossa História",
+    imageAlt: "Sobre a Advance+ - Nossa História",
     isActive: true,
     targetPages: ["/sobre"],
   };

--- a/src/app/website/page.tsx
+++ b/src/app/website/page.tsx
@@ -9,7 +9,7 @@ import BannersGroup from "@/theme/website/components/banners";
 /**
  * Página Inicial do Website Institucional
  *
- * Esta é a homepage que representa a AdvanceMais como empresa
+ * Esta é a homepage que representa a Advance+ como empresa
  * e apresenta seus serviços, cursos e soluções.
  */
 export default function WebsiteHomePage() {

--- a/src/app/website/pagebackup.tsx
+++ b/src/app/website/pagebackup.tsx
@@ -14,7 +14,7 @@ import LogoEnterprises from "@/theme/website/components/logo-enterprises";
 /**
  * Página Inicial do Website Institucional
  *
- * Esta é a homepage que representa a AdvanceMais como empresa
+ * Esta é a homepage que representa a Advance+ como empresa
  * e apresenta seus serviços, cursos e soluções.
  */
 export default function WebsiteHomePage() {

--- a/src/app/website/politica-privacidade/page.tsx
+++ b/src/app/website/politica-privacidade/page.tsx
@@ -18,14 +18,14 @@ export default function PoliticaPrivacidadePage() {
   // Dados mockados específicos para esta página
   const headerData: HeaderPageData = {
     id: "sobre-custom",
-    title: "Sobre a AdvanceMais",
+    title: "Sobre a Advance+",
     subtitle: "Nossa História",
     description:
       "Conheça nossa trajetória, missão e valores. Há mais de 10 anos transformando empresas e desenvolvendo talentos com soluções inovadoras e personalizadas.",
     buttonText: "Nossa equipe",
     buttonUrl: "/sobre/equipe",
     imageUrl: "/images/headers/sobre-header.webp",
-    imageAlt: "Sobre a AdvanceMais - Nossa História",
+    imageAlt: "Sobre a Advance+ - Nossa História",
     isActive: true,
     targetPages: ["/sobre"],
   };

--- a/src/app/website/sobre/page.tsx
+++ b/src/app/website/sobre/page.tsx
@@ -25,14 +25,14 @@ export default function SobrePage() {
   // Dados mockados específicos para esta página
   const headerData: HeaderPageData = {
     id: "sobre-custom",
-    title: "Sobre a AdvanceMais",
+    title: "Sobre a Advance+",
     subtitle: "Nossa História",
     description:
       "Conheça nossa trajetória, missão e valores. Há mais de 10 anos transformando empresas e desenvolvendo talentos com soluções inovadoras e personalizadas.",
     buttonText: "Nossa equipe",
     buttonUrl: "/sobre/equipe",
     imageUrl: "/images/headers/sobre-header.webp",
-    imageAlt: "Sobre a AdvanceMais - Nossa História",
+    imageAlt: "Sobre a Advance+ - Nossa História",
     isActive: true,
     targetPages: ["/sobre"],
   };

--- a/src/app/website/solucoes/recrutamento-selecao/page.tsx
+++ b/src/app/website/solucoes/recrutamento-selecao/page.tsx
@@ -27,14 +27,14 @@ export default function RecrutamentoPage() {
   // Dados mockados específicos para esta página
   const headerData: HeaderPageData = {
     id: "sobre-custom",
-    title: "Sobre a AdvanceMais",
+    title: "Sobre a Advance+",
     subtitle: "Nossa História",
     description:
       "Conheça nossa trajetória, missão e valores. Há mais de 10 anos transformando empresas e desenvolvendo talentos com soluções inovadoras e personalizadas.",
     buttonText: "Nossa equipe",
     buttonUrl: "/sobre/equipe",
     imageUrl: "/images/headers/sobre-header.webp",
-    imageAlt: "Sobre a AdvanceMais - Nossa História",
+    imageAlt: "Sobre a Advance+ - Nossa História",
     isActive: true,
     targetPages: ["/sobre"],
   };

--- a/src/app/website/solucoes/treinamento-company/page.tsx
+++ b/src/app/website/solucoes/treinamento-company/page.tsx
@@ -24,14 +24,14 @@ export default function TreinamentoPage() {
   // Dados mockados específicos para esta página
   const headerData: HeaderPageData = {
     id: "sobre-custom",
-    title: "Sobre a AdvanceMais",
+    title: "Sobre a Advance+",
     subtitle: "Nossa História",
     description:
       "Conheça nossa trajetória, missão e valores. Há mais de 10 anos transformando empresas e desenvolvendo talentos com soluções inovadoras e personalizadas.",
     buttonText: "Nossa equipe",
     buttonUrl: "/sobre/equipe",
     imageUrl: "/images/headers/sobre-header.webp",
-    imageAlt: "Sobre a AdvanceMais - Nossa História",
+    imageAlt: "Sobre a Advance+ - Nossa História",
     isActive: true,
     targetPages: ["/sobre"],
   };

--- a/src/app/website/termos-uso/page.tsx
+++ b/src/app/website/termos-uso/page.tsx
@@ -18,14 +18,14 @@ export default function TermosUsoPage() {
   // Dados mockados específicos para esta página
   const headerData: HeaderPageData = {
     id: "sobre-custom",
-    title: "Sobre a AdvanceMais",
+    title: "Sobre a Advance+",
     subtitle: "Nossa História",
     description:
       "Conheça nossa trajetória, missão e valores. Há mais de 10 anos transformando empresas e desenvolvendo talentos com soluções inovadoras e personalizadas.",
     buttonText: "Nossa equipe",
     buttonUrl: "/sobre/equipe",
     imageUrl: "/images/headers/sobre-header.webp",
-    imageAlt: "Sobre a AdvanceMais - Nossa História",
+    imageAlt: "Sobre a Advance+ - Nossa História",
     isActive: true,
     targetPages: ["/sobre"],
   };

--- a/src/config/FooterNavigation.ts
+++ b/src/config/FooterNavigation.ts
@@ -42,5 +42,5 @@ export const FOOTER_CONFIG: FooterConfig = {
     { label: "Termos de Uso", href: "/termos" },
     { label: "Preferências de Cookies", href: "/cookies" },
   ],
-  copyright: "Todos os Direitos Reservados AdvanceMais",
+  copyright: "Todos os Direitos Reservados Advance+",
 };

--- a/src/hooks/usePageTitle.ts
+++ b/src/hooks/usePageTitle.ts
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 export function usePageTitle(title: string) {
   useEffect(() => {
     const originalTitle = document.title;
-    document.title = `${title} | AdvanceMais`;
+    document.title = `${title} | Advance+`;
 
     return () => {
       document.title = originalTitle;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -77,7 +77,7 @@ export const env: AppConfig = {
   appName: getEnvVar(
     process.env.NEXT_PUBLIC_APP_NAME,
     "NEXT_PUBLIC_APP_NAME",
-    "AdvanceMais"
+    "Advance+"
   ),
   supportPhone: getEnvVar(
     process.env.NEXT_PUBLIC_SUPPORT_PHONE,

--- a/src/theme/website/components/about-advantages/constants/index.ts
+++ b/src/theme/website/components/about-advantages/constants/index.ts
@@ -9,7 +9,7 @@ import { websiteRoutes } from "@/api/routes";
 export const DEFAULT_ABOUT_ADVANTAGES_DATA: AboutAdvantagesApiData = {
   whyChoose: {
     id: "why-choose",
-    title: "Por que escolher AdvanceMais?",
+    title: "Por que escolher Advance+?",
     description:
       "Oferecemos soluções inovadoras e personalizadas que transformam desafios em oportunidades reais de crescimento para sua empresa.",
     buttonText: "Conheça nossos serviços",
@@ -18,14 +18,14 @@ export const DEFAULT_ABOUT_ADVANTAGES_DATA: AboutAdvantagesApiData = {
   },
   aboutSection: {
     id: "about-section",
-    title: "Sobre a AdvanceMais",
+    title: "Sobre a Advance+",
     paragraphs: [
-      "A AdvanceMais é uma empresa especializada em soluções de gestão de pessoas e tecnologia, com foco em resultados que impulsionam o crescimento sustentável dos nossos clientes.",
+      "A Advance+ é uma empresa especializada em soluções de gestão de pessoas e tecnologia, com foco em resultados que impulsionam o crescimento sustentável dos nossos clientes.",
       "Com anos de experiência no mercado, desenvolvemos metodologias próprias que combinam inovação tecnológica com expertise em recursos humanos, oferecendo um serviço diferenciado e personalizado.",
       "Nossa missão é conectar talentos e tecnologia para criar soluções que geram valor real para empresas de todos os portes, sempre com foco na excelência e na satisfação do cliente.",
     ],
     imageUrl: "/images/home/about-advantages.webp",
-    imageAlt: "Sobre a AdvanceMais - Transformando desafios em oportunidades",
+    imageAlt: "Sobre a Advance+ - Transformando desafios em oportunidades",
     overlayTitle: "Transformamos desafios em oportunidades reais.",
     overlayDescription:
       "Descubra como podemos conectar talentos, transformar desafios em oportunidades e criar soluções que impulsionam resultados.",

--- a/src/theme/website/components/accordion-group-information/constants/index.ts
+++ b/src/theme/website/components/accordion-group-information/constants/index.ts
@@ -17,7 +17,7 @@ export const DEFAULT_ACCORDION_DATA: AccordionSectionData[] = [
         value: "nossa-historia",
         trigger: "Nossa História",
         content:
-          "Fundada em 2014, a AdvanceMais nasceu com o propósito de transformar a educação e o desenvolvimento empresarial no Brasil. Ao longo dos anos, construímos uma trajetória sólida baseada na inovação, excelência e compromisso com nossos clientes. Nossa jornada é marcada por conquistas significativas e pela constante busca por soluções que realmente fazem a diferença na vida das pessoas e no crescimento das empresas.",
+          "Fundada em 2014, a Advance+ nasceu com o propósito de transformar a educação e o desenvolvimento empresarial no Brasil. Ao longo dos anos, construímos uma trajetória sólida baseada na inovação, excelência e compromisso com nossos clientes. Nossa jornada é marcada por conquistas significativas e pela constante busca por soluções que realmente fazem a diferença na vida das pessoas e no crescimento das empresas.",
         order: 1,
         isActive: true,
       },

--- a/src/theme/website/components/header-pages/constants/index.ts
+++ b/src/theme/website/components/header-pages/constants/index.ts
@@ -16,7 +16,7 @@ export const DEFAULT_HEADER_DATA: HeaderPageData[] = [
     buttonText: "Fale com nossos especialistas",
     buttonUrl: "/sobre/equipe",
     imageUrl: "/images/headers/sobre-header.webp",
-    imageAlt: "Sobre a AdvanceMais - Nossa História",
+    imageAlt: "Sobre a Advance+ - Nossa História",
     isActive: true,
     targetPages: ["/sobre"],
   },

--- a/src/theme/website/components/testimonials-carousel/constants/index.ts
+++ b/src/theme/website/components/testimonials-carousel/constants/index.ts
@@ -9,7 +9,7 @@ export const DEFAULT_TESTIMONIALS_DATA: TestimonialData[] = [
     position: "Gerente de Gente e Gestão",
     company: "Empresa ABC",
     testimonial:
-      "Para a contratação, precisávamos ser assertivos. Com o suporte da AdvanceMais, realizamos contratações mais rápidas e eficazes, otimizando nosso processo.",
+      "Para a contratação, precisávamos ser assertivos. Com o suporte da Advance+, realizamos contratações mais rápidas e eficazes, otimizando nosso processo.",
     imageUrl: "/images/testemonials/face_1.png",
     rating: 5,
     order: 1,
@@ -21,7 +21,7 @@ export const DEFAULT_TESTIMONIALS_DATA: TestimonialData[] = [
     position: "Coordenador de Gente & Cultura",
     company: "Empresa XYZ",
     testimonial:
-      "A AdvanceMais trouxe automação e inovação para nosso processo seletivo. Conseguimos reduzir o tempo de contratação e focar mais no desenvolvimento dos colaboradores.",
+      "A Advance+ trouxe automação e inovação para nosso processo seletivo. Conseguimos reduzir o tempo de contratação e focar mais no desenvolvimento dos colaboradores.",
     imageUrl: "/images/testemonials/face_2.png",
     rating: 5,
     order: 2,
@@ -33,7 +33,7 @@ export const DEFAULT_TESTIMONIALS_DATA: TestimonialData[] = [
     position: "Coordenador Administrativo",
     company: "Empresa 123",
     testimonial:
-      "Com as soluções da AdvanceMais, otimizamos os processos internos e conseguimos atingir resultados que antes pareciam impossíveis.",
+      "Com as soluções da Advance+, otimizamos os processos internos e conseguimos atingir resultados que antes pareciam impossíveis.",
     imageUrl: "/images/testemonials/face_3.png",
     rating: 5,
     order: 3,
@@ -45,7 +45,7 @@ export const DEFAULT_TESTIMONIALS_DATA: TestimonialData[] = [
     position: "Coordenadora de RH",
     company: "Empresa DEF",
     testimonial:
-      "Com a AdvanceMais, otimizamos todo o ciclo de recrutamento e seleção. Um processo que durava 45 dias agora é concluído em apenas 15.",
+      "Com a Advance+, otimizamos todo o ciclo de recrutamento e seleção. Um processo que durava 45 dias agora é concluído em apenas 15.",
     imageUrl: "/images/testemonials/face_4.png",
     rating: 5,
     order: 4,
@@ -57,7 +57,7 @@ export const DEFAULT_TESTIMONIALS_DATA: TestimonialData[] = [
     position: "Diretor de Operações",
     company: "Empresa GHI",
     testimonial:
-      "A parceria com a AdvanceMais transformou nossa forma de trabalhar. Processos que antes eram manuais agora são automatizados e muito mais eficientes.",
+      "A parceria com a Advance+ transformou nossa forma de trabalhar. Processos que antes eram manuais agora são automatizados e muito mais eficientes.",
     imageUrl: "/images/testemonials/face_5.png",
     rating: 5,
     order: 5,

--- a/src/theme/website/footer/components/FooterLogo.tsx
+++ b/src/theme/website/footer/components/FooterLogo.tsx
@@ -13,7 +13,7 @@ export const FooterLogo: React.FC = () => {
     >
       <Image
         src="/images/logos/logo_branco.webp"
-        alt="AdvanceMais Logo"
+        alt="Advance+ Logo"
         width={170}
         height={100}
         className="mb-4"


### PR DESCRIPTION
## Summary
- replace textual uses of Advancemais with Advance+
- update env example and metadata to use new brand name
- adjust testimonial and UI copy for Advance+

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_68ade2989d3883258285053c61ee4cbe