### PR TITLE
fix: add missing breadcrumb icons

### DIFF
--- a/src/config/breadcrumb.ts
+++ b/src/config/breadcrumb.ts
@@ -35,6 +35,8 @@ export type IconName =
   | "AlertCircle"
   | "Info"
   | "HelpCircle"
+  | "Briefcase"
+  | "BookOpen"
   | "ExternalLink";
 
 export interface BreadcrumbItem {


### PR DESCRIPTION
## Summary
- allow breadcrumbs to reference Briefcase and BookOpen icons

## Testing
- `pnpm run lint`
- `pnpm run test`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adf225a6f08325ac011d886edd1fc8