### PR TITLE
fix: allow deleting characters in masked inputs

### DIFF
--- a/src/services/components/input/maskService.test.ts
+++ b/src/services/components/input/maskService.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import MaskService from './maskService';
+
+describe('MaskService applyMask deletion', () => {
+  const service = MaskService.getInstance();
+
+  it('allows deleting characters in CPF mask', () => {
+    const withDigit = service.processInput('087.015.278-4', 'cpf');
+    expect(withDigit).toBe('087.015.278-4');
+    const withoutDigit = service.processInput('087.015.278-', 'cpf');
+    expect(withoutDigit).toBe('087.015.278');
+  });
+
+  it('allows deleting characters in CNPJ mask', () => {
+    const withDigit = service.processInput('12.345.678/0001-9', 'cnpj');
+    expect(withDigit).toBe('12.345.678/0001-9');
+    const withoutDigit = service.processInput('12.345.678/0001-', 'cnpj');
+    expect(withoutDigit).toBe('12.345.678/0001');
+  });
+});

--- a/src/services/components/input/maskService.ts
+++ b/src/services/components/input/maskService.ts
@@ -156,7 +156,11 @@ class MaskService {
         }
       } else {
         // Caractere fixo da máscara
-        result += maskChar;
+        if (config.alwaysShowMask || valueIndex < value.length) {
+          result += maskChar;
+        } else {
+          break;
+        }
       }
     }
 
@@ -262,8 +266,8 @@ class MaskService {
     if (maskType === "alphanumeric") {
       return value.replace(/[^a-zA-Z0-9]/g, "");
     }
-
-    return this.applyMask(value, maskType, customConfig);
+    const unmaskedValue = this.removeMask(value, maskType);
+    return this.applyMask(unmaskedValue, maskType, customConfig);
   }
 }
 


### PR DESCRIPTION
## Summary
- fix MaskService to drop trailing mask chars when deleting
- unmask input before reapplying mask
- add tests ensuring CPF and CNPJ masks allow deletion

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae0bfecb208325a86812634fac1110