### PR TITLE
fix: add auth header to about mutations

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -59,11 +59,12 @@ export async function apiFetch<T = unknown>(
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), timeout);
 
-      const res = await fetch(url, {
-        cache: "no-store",
-        signal: controller.signal,
-        ...init,
-      });
+        const res = await fetch(url, {
+          cache: "no-store",
+          signal: controller.signal,
+          ...init,
+          credentials: "include",
+        });
 
       clearTimeout(timeoutId);
 

--- a/src/api/websites/components/about/index.ts
+++ b/src/api/websites/components/about/index.ts
@@ -96,6 +96,16 @@ function buildFormData(
   return form;
 }
 
+function getAuthHeader(): Record<string, string> {
+  if (typeof document === "undefined") return {};
+  const token = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith("token="))
+    ?.split("=")[1];
+
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
 export async function createAbout(
   data: CreateAboutPayload,
 ): Promise<AboutBackendResponse> {
@@ -104,7 +114,7 @@ export async function createAbout(
     init: {
       method: "POST",
       body: form,
-      headers: { Accept: apiConfig.headers.Accept },
+      headers: { Accept: apiConfig.headers.Accept, ...getAuthHeader() },
     },
     cache: "no-cache",
   });
@@ -121,7 +131,7 @@ export async function updateAbout(
       init: {
         method: "PUT",
         body: form,
-        headers: { Accept: apiConfig.headers.Accept },
+        headers: { Accept: apiConfig.headers.Accept, ...getAuthHeader() },
       },
       cache: "no-cache",
     },
@@ -132,7 +142,7 @@ export async function deleteAbout(id: string): Promise<void> {
   await apiFetch<void>(websiteRoutes.about.delete(id), {
     init: {
       method: "DELETE",
-      headers: { Accept: apiConfig.headers.Accept },
+      headers: { Accept: apiConfig.headers.Accept, ...getAuthHeader() },
     },
     cache: "no-cache",
   });

--- a/src/components/ui/custom/text-area/components/RichTextarea.tsx
+++ b/src/components/ui/custom/text-area/components/RichTextarea.tsx
@@ -148,7 +148,7 @@ const RichTextarea = React.forwardRef<HTMLDivElement, RichTextareaProps>(
     };
 
     // Função para verificar formatos ativos na posição do cursor
-    const checkActiveFormats = () => {
+    const checkActiveFormats = React.useCallback(() => {
       const selection = window.getSelection();
       if (!selection || selection.rangeCount === 0) {
         setActiveFormats(new Set());
@@ -175,7 +175,7 @@ const RichTextarea = React.forwardRef<HTMLDivElement, RichTextareaProps>(
         // Cursor único - verifica formatações no ponto atual
         setActiveFormats(getAllActiveFormats(range.startContainer));
       }
-    };
+    }, []);
 
     // Função para remover TODAS as formatações de um range
     const clearAllFormatting = (range: Range) => {
@@ -472,12 +472,12 @@ const RichTextarea = React.forwardRef<HTMLDivElement, RichTextareaProps>(
     };
 
     // Event handlers para detectar mudanças na seleção
-    const handleSelectionChange = () => {
+    const handleSelectionChange = React.useCallback(() => {
       // Só executa se o elemento está focado
       if (isFocused) {
         setTimeout(checkActiveFormats, 10);
       }
-    };
+    }, [isFocused, checkActiveFormats]);
 
     // Effect para escutar mudanças de seleção globais
     React.useEffect(() => {
@@ -485,7 +485,7 @@ const RichTextarea = React.forwardRef<HTMLDivElement, RichTextareaProps>(
       return () => {
         document.removeEventListener("selectionchange", handleSelectionChange);
       };
-    }, [isFocused]);
+    }, [handleSelectionChange]);
 
     return (
       <div className="w-full space-y-2">


### PR DESCRIPTION
## Summary
- include auth header in about creation and updates
- send cookies by default in api client and memoize selection handlers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae4708f728832587381816cb9c99c0