### PR TITLE
feat: add loading skeleton for homepage config

### DIFF
--- a/src/app/dashboard/config/website/pagina-inicial/page.tsx
+++ b/src/app/dashboard/config/website/pagina-inicial/page.tsx
@@ -1,14 +1,52 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { VerticalTabs, type VerticalTabItem } from "@/components/ui/custom";
+import { Skeleton } from "@/components/ui/skeleton";
 import SobreForm from "./sobre/SobreForm";
+import { listAbout, type AboutBackendResponse } from "@/api/websites/components";
 
 /**
  * Página principal de configuração da página inicial
  * Usa VerticalTabs para organizar as diferentes seções
  */
 export default function PaginaInicialPage() {
+  const [aboutData, setAboutData] = useState<AboutBackendResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await listAbout();
+        setAboutData(data[0] ?? null);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-3xl p-5 h-full min-h-[calc(100vh-8rem)] flex flex-col">
+        <div className="flex-1 min-h-0 flex">
+          <div className="w-48 space-y-2 p-2">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-10 w-full" />
+            ))}
+          </div>
+          <div className="flex-1 p-6 space-y-4">
+            <Skeleton className="h-8 w-1/3" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   const items: VerticalTabItem[] = [
     {
       value: "slider",
@@ -49,7 +87,7 @@ export default function PaginaInicialPage() {
       icon: "Info",
       content: (
         <div className="space-y-6">
-          <SobreForm />
+          <SobreForm initialData={aboutData ?? undefined} />
         </div>
       ),
     },


### PR DESCRIPTION
## Summary
- add skeleton while homepage config data loads
- pass prefetched data to Sobre form and remove console logs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae59e0e9a88325a22d3fe06dac94ab