### PR TITLE
Handle Sobre image upload on save

### DIFF
--- a/src/components/ui/custom/file-upload/FileUpload.tsx
+++ b/src/components/ui/custom/file-upload/FileUpload.tsx
@@ -237,6 +237,7 @@ export const FileUpload: React.FC<FileUploadProps> = ({
   uploadUrl,
   publicUrl,
   deleteOnRemove = true,
+  autoUpload = true,
 }) => {
   const [internalFiles, setInternalFiles] = useState<FileUploadItem[]>([]);
   const [isDragOver, setIsDragOver] = useState(false);
@@ -541,8 +542,8 @@ export const FileUpload: React.FC<FileUploadProps> = ({
           name: file.name,
           size: file.size,
           type: file.type,
-          status: "uploading",
-          progress: 0,
+          status: autoUpload ? "uploading" : "idle",
+          progress: autoUpload ? 0 : undefined,
           uploadDate: new Date(),
           previewUrl: generatePreviewUrl(file),
           file,
@@ -569,19 +570,23 @@ export const FileUpload: React.FC<FileUploadProps> = ({
       updateFiles(updatedFiles);
       onFilesAdded?.(validFiles);
 
-      // Start upload for each file
-      validFiles.forEach(file => {
-        uploadFile(file.id);
-      });
+      if (autoUpload) {
+        // Start upload for each file
+        validFiles.forEach(file => {
+          uploadFile(file.id);
+        });
+      }
 
       // Show success message
       toastCustom.success({
         title: "Arquivos adicionados!",
-        description: `${validFiles.length} arquivo(s) sendo enviado(s).`,
+        description: autoUpload
+          ? `${validFiles.length} arquivo(s) sendo enviado(s).`
+          : `${validFiles.length} arquivo(s) pronto(s) para upload.`,
         duration: 3000,
       });
     }
-  }, [maxFilesLimit, validateFile, generatePreviewUrl, updateFiles, onFilesAdded, uploadFile]);
+  }, [maxFilesLimit, validateFile, generatePreviewUrl, updateFiles, onFilesAdded, uploadFile, autoUpload]);
 
   // Drag & Drop handlers
   const handleDragEnter = useCallback((e: React.DragEvent) => {

--- a/src/components/ui/custom/file-upload/types/index.ts
+++ b/src/components/ui/custom/file-upload/types/index.ts
@@ -118,6 +118,8 @@ export interface FileUploadProps extends VariantProps<typeof fileUploadVariants>
   publicUrl?: string;
   /** Se deve remover o arquivo do servidor ao ser excluído do componente */
   deleteOnRemove?: boolean;
+  /** Se deve iniciar upload automaticamente ao adicionar arquivos */
+  autoUpload?: boolean;
   /** Callbacks */
   onFilesChange?: (files: FileUploadItem[]) => void;
   /** Callback para quando arquivos são adicionados */


### PR DESCRIPTION
## Summary
- defer image uploads in Sobre form until save
- add optional autoUpload flag to FileUpload component
- upload new images to Vercel Blob and delete old ones on save

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_68ae6e0cc0b08325adf2f404a1b86ade