### PR TITLE
fix: defer about-image deletion to save action

### DIFF
--- a/src/app/dashboard/config/website/pagina-inicial/sobre/SobreForm.tsx
+++ b/src/app/dashboard/config/website/pagina-inicial/sobre/SobreForm.tsx
@@ -395,6 +395,7 @@ export default function SobreForm({ initialData }: SobreFormProps) {
                     maxFiles={1}
                     validation={{ accept: ["image/*"] }}
                     autoUpload={false}
+                    deleteOnRemove={false}
                     onFilesChange={handleFilesChange}
                     showProgress={false}
                   />


### PR DESCRIPTION
## Summary
- avoid immediate blob deletion by deferring file removal until the form is saved

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aefba60fc88325b747550f4059acc1