### PR TITLE
fix: remove unused preloads

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -75,7 +75,7 @@ const nextConfig = {
 
   // Experimental features
   experimental: {
-    optimizeCss: true,
+    optimizeCss: false,
     scrollRestoration: true,
   },
 

--- a/src/theme/dashboard/sidebar/components/header/SidebarHeader.tsx
+++ b/src/theme/dashboard/sidebar/components/header/SidebarHeader.tsx
@@ -46,7 +46,6 @@ export function SidebarHeader({
           alt="Logo"
           width={isCollapsed ? 48 : 180}
           height={isCollapsed ? 48 : 48}
-          priority
           className="transition-all duration-300"
         />
       </div>

--- a/src/theme/website/header/components/Logo.tsx
+++ b/src/theme/website/header/components/Logo.tsx
@@ -14,7 +14,6 @@ export const Logo: React.FC = () => {
         alt={`Logo ${isMobile ? "Mobile" : "Desktop"}`}
         width={isMobile ? 120 : 240}
         height={40}
-        priority={true}
         quality={100}
         className={isMobile ? "h-3 w-auto" : "h-5 w-auto"}
       />


### PR DESCRIPTION
## Summary
- remove priority preloading from header logos
- disable CSS optimization to avoid unused stylesheet preloads

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af8aafd33483258d1ff86c4f581361