### PR TITLE
feat: add recrutamento website section

### DIFF
--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -28,6 +28,13 @@ export const websiteRoutes = {
     update: (id: string) => `${prefix}/website/consultoria/${id}`,
     delete: (id: string) => `${prefix}/website/consultoria/${id}`,
   },
+  recrutamento: {
+    list: () => `${prefix}/website/recrutamento`,
+    create: () => `${prefix}/website/recrutamento`,
+    get: (id: string) => `${prefix}/website/recrutamento/${id}`,
+    update: (id: string) => `${prefix}/website/recrutamento/${id}`,
+    delete: (id: string) => `${prefix}/website/recrutamento/${id}`,
+  },
   home: {
     slide: () => `${prefix}/website/slide`,
     banner: () => `${prefix}/website/banner`,

--- a/src/api/websites/components/index.ts
+++ b/src/api/websites/components/index.ts
@@ -16,6 +16,16 @@ export {
   updateConsultoria,
   deleteConsultoria,
 } from "./consultoria";
+export {
+  getRecrutamentoData,
+  getRecrutamentoDataClient,
+  listRecrutamento,
+  getRecrutamentoById,
+  createRecrutamento,
+  updateRecrutamento,
+  deleteRecrutamento,
+} from "./recrutamento";
+
 export { getSliderData, getSliderDataClient } from "./slide";
 export { getBannerData, getBannerDataClient } from "./banner";
 export type {
@@ -35,4 +45,13 @@ export type {
   UpdateConsultoriaPayload,
 } from "./consultoria/types";
 export type { SlideBackendResponse, SlideApiResponse } from "./slide/types";
+export type {
+  RecrutamentoApiResponse,
+  RecrutamentoImageProps,
+  RecrutamentoContentProps,
+  RecrutamentoBackendResponse,
+  CreateRecrutamentoPayload,
+  UpdateRecrutamentoPayload,
+} from "./recrutamento/types";
+
 export type { BannerBackendResponse, BannerApiResponse } from "./banner/types";

--- a/src/api/websites/components/recrutamento/index.ts
+++ b/src/api/websites/components/recrutamento/index.ts
@@ -1,0 +1,161 @@
+/**
+ * API Client para componente Recrutamento Empresarial
+ * Busca dados do componente recrutamento do website
+ */
+
+import { websiteRoutes } from "@/api/routes";
+import { apiFetch } from "@/api/client";
+import { apiConfig, env } from "@/lib/env";
+import { recrutamentoMockData } from "./mock";
+import {
+  RecrutamentoApiResponse,
+  RecrutamentoBackendResponse,
+  CreateRecrutamentoPayload,
+  UpdateRecrutamentoPayload,
+} from "./types";
+
+function mapRecrutamentoResponse(
+  data: RecrutamentoBackendResponse[],
+): RecrutamentoApiResponse {
+  const latest = data[data.length - 1];
+  return {
+    src: latest?.imagemUrl ?? "",
+    title: latest?.titulo ?? "",
+    description: latest?.descricao ?? "",
+    buttonUrl: latest?.buttonUrl ?? "",
+    buttonLabel: latest?.buttonLabel ?? "",
+  };
+}
+
+export async function getRecrutamentoData(): Promise<RecrutamentoApiResponse> {
+  try {
+    const raw = await listRecrutamento({
+      headers: apiConfig.headers,
+      ...apiConfig.cache.medium,
+    });
+    const data = mapRecrutamentoResponse(raw);
+    return data;
+  } catch (error) {
+    if (env.apiFallback === "mock") {
+      return recrutamentoMockData;
+    }
+    throw new Error("Falha ao carregar dados de Recrutamento");
+  }
+}
+
+export async function getRecrutamentoDataClient(): Promise<RecrutamentoApiResponse> {
+  try {
+    const raw = await listRecrutamento({ headers: apiConfig.headers });
+    const data = mapRecrutamentoResponse(raw);
+    return data;
+  } catch (error) {
+    if (env.apiFallback === "mock") {
+      return recrutamentoMockData;
+    }
+    throw new Error("Falha ao carregar dados de Recrutamento");
+  }
+}
+
+export async function listRecrutamento(init?: RequestInit): Promise<RecrutamentoBackendResponse[]> {
+  return apiFetch<RecrutamentoBackendResponse[]>(websiteRoutes.recrutamento.list(), {
+    init: init ?? { headers: apiConfig.headers },
+  });
+}
+
+export async function getRecrutamentoById(id: string): Promise<RecrutamentoBackendResponse> {
+  return apiFetch<RecrutamentoBackendResponse>(
+    websiteRoutes.recrutamento.get(id),
+    { init: { headers: apiConfig.headers } },
+  );
+}
+
+function buildRequest(
+  data: CreateRecrutamentoPayload | UpdateRecrutamentoPayload,
+): { body: BodyInit; headers: Record<string, string> } {
+  const baseHeaders = {
+    Accept: apiConfig.headers.Accept,
+    ...getAuthHeader(),
+  };
+
+  if (data.imagem) {
+    const form = new FormData();
+    if (data.titulo !== undefined) form.append("titulo", data.titulo);
+    if (data.descricao !== undefined) form.append("descricao", data.descricao);
+    if (data.buttonUrl !== undefined) form.append("buttonUrl", data.buttonUrl);
+    if (data.buttonLabel !== undefined)
+      form.append("buttonLabel", data.buttonLabel);
+    form.append("imagem", data.imagem);
+    if (data.imagemUrl) form.append("imagemUrl", data.imagemUrl);
+    if (data.imagemTitulo) form.append("imagemTitulo", data.imagemTitulo);
+    return { body: form, headers: baseHeaders };
+  }
+
+  const jsonPayload: Record<string, unknown> = {};
+  if (data.titulo !== undefined) jsonPayload.titulo = data.titulo;
+  if (data.descricao !== undefined) jsonPayload.descricao = data.descricao;
+  if (data.buttonUrl !== undefined) jsonPayload.buttonUrl = data.buttonUrl;
+  if (data.buttonLabel !== undefined)
+    jsonPayload.buttonLabel = data.buttonLabel;
+  if (data.imagemUrl !== undefined) jsonPayload.imagemUrl = data.imagemUrl;
+  if (data.imagemTitulo !== undefined)
+    jsonPayload.imagemTitulo = data.imagemTitulo;
+
+  return {
+    body: JSON.stringify(jsonPayload),
+    headers: { "Content-Type": "application/json", ...baseHeaders },
+  };
+}
+
+function getAuthHeader(): Record<string, string> {
+  if (typeof document === "undefined") return {};
+  const token = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith("token="))
+    ?.split("=")[1];
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export async function createRecrutamento(
+  data: CreateRecrutamentoPayload,
+): Promise<RecrutamentoBackendResponse> {
+  const { body, headers } = buildRequest(data);
+  return apiFetch<RecrutamentoBackendResponse>(
+    websiteRoutes.recrutamento.create(),
+    {
+      init: {
+        method: "POST",
+        body,
+        headers,
+      },
+      cache: "no-cache",
+    },
+  );
+}
+
+export async function updateRecrutamento(
+  id: string,
+  data: UpdateRecrutamentoPayload,
+): Promise<RecrutamentoBackendResponse> {
+  const { body, headers } = buildRequest(data);
+  return apiFetch<RecrutamentoBackendResponse>(
+    websiteRoutes.recrutamento.update(id),
+    {
+      init: {
+        method: "PUT",
+        body,
+        headers,
+      },
+      cache: "no-cache",
+    },
+  );
+}
+
+export async function deleteRecrutamento(id: string): Promise<void> {
+  await apiFetch<void>(websiteRoutes.recrutamento.delete(id), {
+    init: {
+      method: "DELETE",
+      headers: { Accept: apiConfig.headers.Accept, ...getAuthHeader() },
+    },
+    cache: "no-cache",
+  });
+}

--- a/src/api/websites/components/recrutamento/mock/index.ts
+++ b/src/api/websites/components/recrutamento/mock/index.ts
@@ -1,0 +1,15 @@
+import { RecrutamentoApiResponse } from "../types";
+
+export const recrutamentoMockData: RecrutamentoApiResponse = {
+  src: "/images/recrutamento-placeholder.jpg",
+  title: "Serviços de Recrutamento",
+  description:
+    "Descrição sobre recrutamento empresarial fornecida pela Advance+.",
+  buttonUrl: "https://example.com/recrutamento",
+  buttonLabel: "Saiba mais",
+};
+
+export async function getRecrutamentoDataMock(): Promise<RecrutamentoApiResponse> {
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  return recrutamentoMockData;
+}

--- a/src/api/websites/components/recrutamento/types/index.ts
+++ b/src/api/websites/components/recrutamento/types/index.ts
@@ -1,0 +1,53 @@
+export interface RecrutamentoApiResponse {
+  src: string;
+  title: string;
+  description: string;
+  buttonUrl: string;
+  buttonLabel: string;
+}
+
+export interface RecrutamentoBackendResponse {
+  id: string;
+  imagemUrl: string;
+  imagemTitulo: string;
+  titulo: string;
+  descricao: string;
+  buttonUrl: string;
+  buttonLabel: string;
+  criadoEm: string;
+  atualizadoEm: string;
+}
+
+export interface RecrutamentoImageProps {
+  src: string;
+  alt: string;
+  width: number;
+  height: number;
+}
+
+export interface RecrutamentoContentProps {
+  title: string;
+  description: string;
+  buttonUrl: string;
+  buttonLabel: string;
+}
+
+export interface CreateRecrutamentoPayload {
+  titulo: string;
+  descricao: string;
+  buttonUrl: string;
+  buttonLabel: string;
+  imagem?: File | Blob;
+  imagemUrl?: string;
+  imagemTitulo?: string;
+}
+
+export interface UpdateRecrutamentoPayload {
+  titulo?: string;
+  descricao?: string;
+  buttonUrl?: string;
+  buttonLabel?: string;
+  imagem?: File | Blob;
+  imagemUrl?: string;
+  imagemTitulo?: string;
+}

--- a/src/app/dashboard/config/website/pagina-inicial/page.tsx
+++ b/src/app/dashboard/config/website/pagina-inicial/page.tsx
@@ -5,11 +5,14 @@ import { VerticalTabs, type VerticalTabItem } from "@/components/ui/custom";
 import { Skeleton } from "@/components/ui/skeleton";
 import SobreForm from "./sobre/SobreForm";
 import ConsultoriaForm from "./consultoria/ConsultoriaForm";
+import RecrutamentoForm from "./recrutamento/RecrutamentoForm";
 import {
   listAbout,
   type AboutBackendResponse,
   listConsultoria,
+  listRecrutamento,
   type ConsultoriaBackendResponse,
+  type RecrutamentoBackendResponse,
 } from "@/api/websites/components";
 
 /**
@@ -20,17 +23,20 @@ export default function PaginaInicialPage() {
   const [aboutData, setAboutData] = useState<AboutBackendResponse | null>(null);
   const [consultoriaData, setConsultoriaData] =
     useState<ConsultoriaBackendResponse | null>(null);
+  const [recrutamentoData, setRecrutamentoData] = useState<RecrutamentoBackendResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
       const fetchData = async () => {
         try {
-          const [about, consultoria] = await Promise.all([
+          const [about, consultoria, recrutamento] = await Promise.all([
             listAbout(),
             listConsultoria(),
+            listRecrutamento(),
           ]);
           setAboutData(about[0] ?? null);
           setConsultoriaData(consultoria[0] ?? null);
+          setRecrutamentoData(recrutamento[0] ?? null);
         } finally {
           setIsLoading(false);
         }
@@ -129,20 +135,12 @@ export default function PaginaInicialPage() {
       ),
     },
     {
-      value: "recrutamento-selecao",
+      value: "recrutamento",
       label: "Recrutamento & Seleção",
       icon: "Users",
       content: (
         <div className="space-y-6">
-          <div>
-            <h3 className="text-lg font-semibold mb-2">
-              Recrutamento & Seleção
-            </h3>
-            <p className="text-muted-foreground mb-4">
-              Defina textos, vitrines de vagas, depoimentos e CTAs desta seção.
-            </p>
-            {/* TODO: Substitua por <RecrutamentoSelecaoForm /> quando existir */}
-          </div>
+          <RecrutamentoForm initialData={recrutamentoData ?? undefined} />
         </div>
       ),
     },

--- a/src/app/dashboard/config/website/pagina-inicial/recrutamento/RecrutamentoForm.tsx
+++ b/src/app/dashboard/config/website/pagina-inicial/recrutamento/RecrutamentoForm.tsx
@@ -1,0 +1,500 @@
+"use client";
+
+import { useEffect, useState, FormEvent } from "react";
+import {
+  InputCustom,
+  FileUpload,
+  type FileUploadItem,
+  RichTextarea,
+  ButtonCustom,
+} from "@/components/ui/custom";
+import { Label } from "@/components/ui/label";
+import { toastCustom } from "@/components/ui/custom/toast";
+import {
+  listRecrutamento,
+  createRecrutamento,
+  updateRecrutamento,
+  type RecrutamentoBackendResponse,
+} from "@/api/websites/components";
+import { Skeleton } from "@/components/ui/skeleton";
+import { uploadImage, deleteImage, getImageTitle } from "@/services/upload";
+
+interface RecrutamentoContent {
+  id?: string;
+  titulo: string;
+  descricao: string;
+  buttonUrl: string;
+  buttonLabel: string;
+  imagemUrl?: string;
+}
+
+interface RecrutamentoFormProps {
+  initialData?: RecrutamentoBackendResponse;
+}
+
+export default function RecrutamentoForm({ initialData }: RecrutamentoFormProps) {
+  const [content, setContent] = useState<RecrutamentoContent>({
+    titulo: "",
+    descricao: "",
+    buttonUrl: "",
+    buttonLabel: "",
+  });
+  const [files, setFiles] = useState<FileUploadItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [logs, setLogs] = useState<string[]>([]);
+  const [isFetching, setIsFetching] = useState(!initialData);
+  const [oldImageUrl, setOldImageUrl] = useState<string | undefined>(
+    initialData?.imagemUrl
+  );
+
+  const addLog = (message: string) =>
+    setLogs((prev) => [
+      ...prev,
+      `[${new Date().toLocaleTimeString()}] ${message}`,
+    ]);
+
+  useEffect(() => {
+    const applyData = (first: RecrutamentoBackendResponse) => {
+      setContent({
+        id: first.id,
+        titulo: first.titulo ?? "",
+        descricao: first.descricao ?? "",
+        buttonUrl: first.buttonUrl ?? "",
+        buttonLabel: first.buttonLabel ?? "",
+        imagemUrl: first.imagemUrl ?? undefined,
+      });
+      setOldImageUrl(first.imagemUrl ?? undefined);
+
+      if (first.imagemUrl) {
+        const item: FileUploadItem = {
+          id: "existing",
+          name: first.imagemTitulo || "imagem",
+          size: 0,
+          type: "image",
+          status: "completed",
+          uploadDate: new Date(first.criadoEm || Date.now()),
+          previewUrl: first.imagemUrl,
+          uploadedUrl: first.imagemUrl,
+        };
+        setFiles([item]);
+      }
+    };
+
+    if (initialData) {
+      applyData(initialData);
+      setIsFetching(false);
+      return;
+    }
+
+    const fetchData = async () => {
+      setIsFetching(true);
+      try {
+        const data = await listRecrutamento();
+        const first = data[0];
+
+        if (first) {
+          applyData(first);
+        }
+      } catch (err) {
+        addLog(`Erro ao carregar dados: ${String(err)}`);
+        const status = (err as any)?.status;
+        switch (status) {
+          case 401:
+            toastCustom.error("Sessão expirada. Faça login novamente");
+            break;
+          case 403:
+            toastCustom.error(
+              "Você não tem permissão para acessar este conteúdo"
+            );
+            break;
+          case 500:
+            toastCustom.error("Erro do servidor ao carregar dados existentes");
+            break;
+          default:
+            toastCustom.error("Erro ao carregar dados existentes");
+        }
+      } finally {
+        setIsFetching(false);
+      }
+    };
+
+    fetchData();
+  }, [initialData]);
+
+  const handleFilesChange = (list: FileUploadItem[]) => {
+    const previousCount = files.length;
+    const currentCount = list.length;
+
+    // Feedback quando arquivo é adicionado
+    if (currentCount > previousCount) {
+      addLog(`Arquivo selecionado: ${list.map((f) => f.name).join(", ")}`);
+    }
+
+    if (currentCount < previousCount) {
+      setContent((prev) => ({ ...prev, imagemUrl: undefined }));
+      addLog("Arquivo removido");
+    }
+
+    if (currentCount === 0) {
+      setContent((prev) => ({ ...prev, imagemUrl: undefined }));
+    }
+
+    setFiles(list);
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+
+    // Bloqueia múltiplos cliques
+    if (isLoading) return;
+
+    const title = content.titulo.trim();
+    const description = content.descricao.trim();
+    const buttonUrl = content.buttonUrl.trim();
+    const buttonLabel = content.buttonLabel.trim();
+
+    // Validações com toasts específicos
+    if (!title) {
+      toastCustom.error("O título é obrigatório");
+      return;
+    }
+    if (title.length < 10) {
+      toastCustom.error("O título deve ter pelo menos 10 caracteres");
+      return;
+    }
+    if (title.length > 50) {
+      toastCustom.error("O título deve ter no máximo 50 caracteres");
+      return;
+    }
+
+    if (!description) {
+      toastCustom.error("A descrição é obrigatória");
+      return;
+    }
+    if (description.length < 10) {
+      toastCustom.error("A descrição deve ter pelo menos 10 caracteres");
+      return;
+    }
+
+    if (!buttonUrl) {
+      toastCustom.error("A URL do botão é obrigatória");
+      return;
+    }
+    if (!buttonLabel) {
+      toastCustom.error("O texto do botão é obrigatório");
+      return;
+    }
+
+    if (files.length === 0 && !content.imagemUrl) {
+      toastCustom.error("Uma imagem é obrigatória");
+      return;
+    }
+
+    const uploading = files.find((f) => f.status === "uploading");
+    if (uploading) {
+      toastCustom.error("Aguarde o upload da imagem terminar");
+      return;
+    }
+
+    const failed = files.find((f) => f.status === "failed");
+    if (failed) {
+      toastCustom.error("Erro no upload da imagem. Tente novamente");
+      return;
+    }
+
+    setIsLoading(true);
+
+    // Toast de loading
+    toastCustom.info("Salvando conteúdo...");
+
+    let uploadResult: { url: string; title: string } | undefined;
+
+    try {
+      const payload: {
+        titulo: string;
+        descricao: string;
+        buttonUrl: string;
+        buttonLabel: string;
+        imagemUrl?: string;
+        imagemTitulo?: string;
+      } = {
+        titulo: title,
+        descricao: description,
+        buttonUrl,
+        buttonLabel,
+      };
+
+      const fileItem = files[0];
+      const previousUrl = oldImageUrl;
+
+      if (fileItem?.file) {
+        addLog(`Upload iniciado: ${fileItem.name}`);
+        try {
+          uploadResult = await uploadImage(
+            fileItem.file,
+            "recrutamento",
+            previousUrl,
+          );
+          addLog(`Upload concluído: ${uploadResult.url}`);
+        } catch (err) {
+          addLog(`Upload erro: ${String(err)}`);
+          toastCustom.error("Erro no upload da imagem. Tente novamente");
+          return;
+        }
+      } else if (!fileItem && previousUrl) {
+        await deleteImage(previousUrl);
+        addLog(`Arquivo antigo removido: ${previousUrl}`);
+      } else if (previousUrl) {
+        uploadResult = { url: previousUrl, title: getImageTitle(previousUrl) };
+        addLog(`Usando imagem existente: ${previousUrl}`);
+      }
+
+      if (uploadResult) {
+        payload.imagemUrl = uploadResult.url;
+        payload.imagemTitulo = uploadResult.title;
+      }
+
+      addLog(`Payload enviado: ${JSON.stringify(payload)}`);
+
+      const saved = content.id
+        ? await updateRecrutamento(content.id, payload)
+        : await createRecrutamento(payload);
+
+      addLog(`Resposta da API: ${JSON.stringify(saved)}`);
+
+      if (!saved || !saved.id) {
+        toastCustom.error("Resposta inválida do servidor");
+        return;
+      }
+
+      if (content.id) {
+        toastCustom.success("Informações atualizadas com sucesso!");
+      } else {
+        toastCustom.success("Informações criadas com sucesso!");
+      }
+
+      const finalImageUrl = payload.imagemUrl || saved.imagemUrl;
+      const finalImageTitle = payload.imagemTitulo || saved.imagemTitulo;
+
+      if (payload.imagemUrl && payload.imagemUrl !== saved.imagemUrl) {
+        addLog(
+          `Forçando uso da imagem enviada: ${payload.imagemUrl} (API retornou ${saved.imagemUrl})`
+        );
+      }
+
+      setContent({
+        id: saved.id,
+        titulo: saved.titulo,
+        descricao: saved.descricao,
+        buttonUrl: saved.buttonUrl,
+        buttonLabel: saved.buttonLabel,
+        imagemUrl: finalImageUrl,
+      });
+
+      if (finalImageUrl) {
+        setFiles([
+          {
+            id: saved.id,
+            name: finalImageTitle || "imagem",
+            size: 0,
+            type: "image",
+            status: "completed",
+            uploadDate: new Date(saved.atualizadoEm || Date.now()),
+            previewUrl: finalImageUrl,
+            uploadedUrl: finalImageUrl,
+          },
+        ]);
+      } else {
+        setFiles([]);
+      }
+
+      setOldImageUrl(finalImageUrl);
+    } catch (err) {
+      addLog(`Erro ao salvar: ${String(err)}`);
+      const status = (err as any)?.status;
+      let errorMessage: string;
+      switch (status) {
+        case 400:
+          errorMessage =
+            (err as Error).message ||
+            "Dados inválidos. Verifique os campos e tente novamente";
+          break;
+        case 401:
+          errorMessage = "Sessão expirada. Faça login novamente";
+          break;
+        case 403:
+          errorMessage = "Você não tem permissão para esta ação";
+          break;
+        case 413:
+          errorMessage =
+            "Arquivo muito grande. Selecione uma imagem menor que 5MB";
+          break;
+        case 422:
+          errorMessage =
+            (err as Error).message || "Erro de validação nos dados enviados";
+          break;
+        case 500:
+          errorMessage =
+            "Erro interno do servidor. Tente novamente em alguns minutos";
+          break;
+        case 503:
+          errorMessage =
+            "Serviço temporariamente indisponível. Tente novamente";
+          break;
+        default:
+          errorMessage =
+            err instanceof TypeError
+              ? "Erro de conexão. Verifique sua internet e tente novamente"
+              : `Erro ao salvar${
+                  status ? ` (${status})` : ""
+                }. Tente novamente`;
+      }
+      toastCustom.error(
+        errorMessage ||
+          "Não foi possível salvar as informações. Tente novamente"
+      );
+      addLog(`Erro da API: ${errorMessage}`);
+
+      if (uploadResult?.url) {
+        await deleteImage(uploadResult.url);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      {isFetching ? (
+        <div className="space-y-6">
+          <Skeleton className="h-40 w-full" />
+          <Skeleton className="h-10 w-1/3" />
+          <Skeleton className="h-10 w-1/2" />
+          <Skeleton className="h-10 w-1/2" />
+          <Skeleton className="h-32 w-full" />
+        </div>
+      ) : (
+        <>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            {/* Upload de Imagem */}
+            <div className="space-y-4">
+              <div>
+                <Label className="text-sm font-medium text-gray-700">
+                  Imagem de Destaque <span className="text-red-500">*</span>
+                </Label>
+                <div className="mt-2">
+                  <FileUpload
+                    files={files}
+                    multiple={false}
+                    maxFiles={1}
+                    validation={{ accept: ["image/*"] }}
+                    autoUpload={false}
+                    deleteOnRemove={false}
+                    onFilesChange={handleFilesChange}
+                    showProgress={false}
+                  />
+                </div>
+              </div>
+            </div>
+
+            {/* Conteúdo Básico */}
+            <div className="space-y-3">
+              <div>
+                <InputCustom
+                  label="Título"
+                  id="titulo"
+                  value={content.titulo}
+                  onChange={(e) =>
+                    setContent((prev) => ({ ...prev, titulo: e.target.value }))
+                  }
+                  maxLength={50}
+                  placeholder="Digite o título da seção de recrutamento"
+                  required
+                />
+              </div>
+
+              <div>
+                <InputCustom
+                  label="URL do Botão"
+                  id="buttonUrl"
+                  type="url"
+                  value={content.buttonUrl}
+                  onChange={(e) =>
+                    setContent((prev) => ({
+                      ...prev,
+                      buttonUrl: e.target.value,
+                    }))
+                  }
+                  placeholder="https://exemplo.com/recrutamento"
+                  required
+                />
+              </div>
+
+              <div>
+                <InputCustom
+                  label="Texto do Botão"
+                  id="buttonLabel"
+                  value={content.buttonLabel}
+                  onChange={(e) =>
+                    setContent((prev) => ({
+                      ...prev,
+                      buttonLabel: e.target.value,
+                    }))
+                  }
+                  maxLength={50}
+                  placeholder="Digite o texto do botão"
+                  required
+                />
+              </div>
+
+              <div>
+                <Label
+                  htmlFor="descricao"
+                  className="text-sm font-medium text-gray-700"
+                >
+                  Descrição <span className="text-red-500">*</span>
+                </Label>
+                <div className="mt-1">
+                  <RichTextarea
+                    id="descricao"
+                    value={content.descricao}
+                    onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                      setContent((prev) => ({
+                        ...prev,
+                        descricao: e.target.value,
+                      }))
+                    }
+                    maxLength={500}
+                    showCharCount={true}
+                    placeholder="Descreva a seção de recrutamento."
+                    className="min-h-[250px]"
+                    required
+                  />
+                </div>
+              </div>
+            </div>
+
+            {/* Botão de Salvar */}
+            <div className="pt-4 flex justify-end">
+              <ButtonCustom
+                type="submit"
+                isLoading={isLoading}
+                disabled={
+                  isLoading ||
+                  (!content.imagemUrl && files.length === 0) ||
+                  files.some((f) => f.status === "uploading")
+                }
+                size="lg"
+                variant="default"
+                className="w-40"
+                withAnimation={true}
+              >
+                Salvar
+              </ButtonCustom>
+            </div>
+          </form>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/website/page.tsx
+++ b/src/app/website/page.tsx
@@ -6,6 +6,7 @@ import Slider from "@/theme/website/components/slider";
 import AboutSection from "@/theme/website/components/about";
 import BannersGroup from "@/theme/website/components/banners";
 import ConsultoriaSection from "@/theme/website/components/consultoria-empresarial";
+import RecrutamentoSection from "@/theme/website/components/recrutamento";
 
 /**
  * Página Inicial do Website Institucional
@@ -39,6 +40,11 @@ export default function WebsiteHomePage() {
       <ConsultoriaSection
         onDataLoaded={() => handleComponentLoaded("Consultoria")}
         onError={(error) => handleComponentError("Consultoria", error)}
+      />
+
+      <RecrutamentoSection
+        onDataLoaded={() => handleComponentLoaded("Recrutamento")}
+        onError={(error) => handleComponentError("Recrutamento", error)}
       />
 
       {/* Banners de Destaque */}

--- a/src/theme/website/components/recrutamento/components/RecrutamentoContent.tsx
+++ b/src/theme/website/components/recrutamento/components/RecrutamentoContent.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import Link from "next/link";
+import { ButtonCustom } from "@/components/ui/custom";
+import type { RecrutamentoContentProps } from "@/api/websites/components";
+
+const RecrutamentoContent = ({ title, description, buttonUrl, buttonLabel }: RecrutamentoContentProps) => {
+  return (
+    <div className="w-full lg:w-1/2 lg:text-left">
+      <h1 className="text-[var(--primary-color)] font-bold !leading-tight">{title}</h1>
+      <p className="!leading-relaxed !text-justify">{description}</p>
+      <Link href={buttonUrl}>
+        <ButtonCustom size="lg" variant="secondary" withAnimation>
+          {buttonLabel}
+        </ButtonCustom>
+      </Link>
+    </div>
+  );
+};
+
+export default RecrutamentoContent;

--- a/src/theme/website/components/recrutamento/components/RecrutamentoImage.tsx
+++ b/src/theme/website/components/recrutamento/components/RecrutamentoImage.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import React, { useState } from "react";
+import Image from "next/image";
+import { ImageNotFound } from "@/components/ui/custom/image-not-found";
+import type { RecrutamentoImageProps } from "@/api/websites/components";
+
+const RecrutamentoImage = ({ src, alt, width, height }: RecrutamentoImageProps) => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+
+  const handleImageLoad = () => {
+    setIsLoading(false);
+  };
+
+  const handleImageError = () => {
+    setIsLoading(false);
+    setHasError(true);
+  };
+
+  return (
+    <div className="w-full lg:w-1/2 relative">
+      {isLoading && (
+        <div className="aspect-[3/2] bg-gray-200 animate-pulse rounded-lg flex items-center justify-center">
+          <div className="w-8 h-8 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+        </div>
+      )}
+
+      {hasError && (
+        <ImageNotFound
+          size="full"
+          variant="muted"
+          aspectRatio="landscape"
+          message="Imagem indisponível"
+          icon="ImageOff"
+          className="aspect-[3/2] rounded-lg shadow-lg"
+          showMessage={true}
+        />
+      )}
+
+      {!hasError && (
+        <Image
+          src={src}
+          alt={alt}
+          width={width}
+          height={height}
+          className={`
+            rounded-lg shadow-lg object-cover w-full
+            transition-opacity duration-500
+            ${isLoading ? "opacity-0 absolute inset-0" : "opacity-100"}
+          `}
+          style={{ aspectRatio: `${width}/${height}` }}
+          onLoad={handleImageLoad}
+          onError={handleImageError}
+          priority={true}
+          quality={90}
+          sizes="(max-width: 1024px) 100vw, 50vw"
+        />
+      )}
+    </div>
+  );
+};
+
+export default RecrutamentoImage;

--- a/src/theme/website/components/recrutamento/index.tsx
+++ b/src/theme/website/components/recrutamento/index.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { getRecrutamentoDataClient } from "@/api/websites/components/recrutamento";
+import type { RecrutamentoApiResponse } from "@/api/websites/components";
+import RecrutamentoImage from "./components/RecrutamentoImage";
+import RecrutamentoContent from "./components/RecrutamentoContent";
+import { useLoadingStatus } from "@/hooks/use-loading-status";
+
+function RecrutamentoSkeleton({ className = "" }: { className?: string }) {
+  return (
+    <section className={className}>
+      <div className="container mx-auto py-16 px-4 flex flex-col lg:flex-row items-center gap-20 mt-5">
+        <div className="w-full lg:w-1/2">
+          <div className="aspect-[3/2] bg-gray-200 animate-pulse rounded-lg" />
+        </div>
+        <div className="w-full lg:w-1/2 space-y-4">
+          <div className="h-8 bg-gray-200 rounded animate-pulse" />
+          <div className="h-8 bg-gray-200 rounded animate-pulse w-3/4" />
+          <div className="space-y-2">
+            <div className="h-4 bg-gray-200 rounded animate-pulse" />
+            <div className="h-4 bg-gray-200 rounded animate-pulse" />
+            <div className="h-4 bg-gray-200 rounded animate-pulse w-5/6" />
+          </div>
+          <div className="h-10 bg-gray-200 rounded animate-pulse w-32" />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+interface RecrutamentoSectionProps {
+  className?: string;
+  onDataLoaded?: (data: RecrutamentoApiResponse) => void;
+  onError?: (error: string) => void;
+}
+
+function useRecrutamentoLoading() {
+  const [data, setData] = useState<RecrutamentoApiResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [retryCount, setRetryCount] = useState(0);
+
+  const fetchData = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await getRecrutamentoDataClient();
+      setData(result);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "Erro desconhecido";
+      setError(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const retry = useCallback(() => {
+    setRetryCount((prev) => prev + 1);
+    fetchData();
+  }, [fetchData]);
+
+  useEffect(() => {
+    if (error && retryCount < 2) {
+      const timer = setTimeout(() => {
+        retry();
+      }, 2000 * (retryCount + 1));
+      return () => clearTimeout(timer);
+    }
+  }, [error, retryCount, retry]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return {
+    data,
+    error,
+    isLoading,
+    retry,
+    hasAutoRetried: retryCount >= 2,
+  };
+}
+
+export default function RecrutamentoSection({
+  className = "",
+  onDataLoaded,
+  onError,
+}: RecrutamentoSectionProps) {
+  const { data, error, isLoading, hasAutoRetried } = useRecrutamentoLoading();
+  const { markAsLoaded, reportError } = useLoadingStatus({
+    componentName: "Recrutamento",
+  });
+
+  useEffect(() => {
+    if (data && !isLoading) {
+      onDataLoaded?.(data);
+      markAsLoaded();
+    }
+  }, [data, isLoading, onDataLoaded, markAsLoaded]);
+
+  useEffect(() => {
+    if (error && hasAutoRetried && !isLoading) {
+      onError?.(error);
+      reportError(error);
+      markAsLoaded();
+    }
+  }, [error, hasAutoRetried, isLoading, onError, reportError, markAsLoaded]);
+
+  if (isLoading) {
+    return <RecrutamentoSkeleton className={className} />;
+  }
+
+  if (error || !data) {
+    return null;
+  }
+
+  return (
+    <section className={className}>
+      <div className="container mx-auto py-16 px-4 flex flex-col lg:flex-row items-center gap-10 mt-5 lg:gap-20 md:gap-20">
+        <RecrutamentoImage
+          src={data.src}
+          alt={data.title || "Recrutamento"}
+          width={600}
+          height={400}
+        />
+        <RecrutamentoContent
+          title={data.title}
+          description={data.description}
+          buttonUrl={data.buttonUrl}
+          buttonLabel={data.buttonLabel}
+        />
+      </div>
+    </section>
+  );
+}
+
+export { RecrutamentoSkeleton };


### PR DESCRIPTION
## Summary
- add frontend Recrutamento section with loading support
- enable Recrutamento content management in dashboard
- expose Recrutamento API client and routes

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b03e515860832595819e6967c703e4