### PR TITLE
feat: add sobre empresa configuration

### DIFF
--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -35,6 +35,13 @@ export const websiteRoutes = {
     update: (id: string) => `${prefix}/website/recrutamento/${id}`,
     delete: (id: string) => `${prefix}/website/recrutamento/${id}`,
   },
+  sobreEmpresa: {
+    list: () => `${prefix}/website/sobre-empresa`,
+    create: () => `${prefix}/website/sobre-empresa`,
+    get: (id: string) => `${prefix}/website/sobre-empresa/${id}`,
+    update: (id: string) => `${prefix}/website/sobre-empresa/${id}`,
+    delete: (id: string) => `${prefix}/website/sobre-empresa/${id}`,
+  },
   home: {
     slide: () => `${prefix}/website/slide`,
     banner: () => `${prefix}/website/banner`,

--- a/src/api/websites/components/index.ts
+++ b/src/api/websites/components/index.ts
@@ -25,6 +25,14 @@ export {
   updateRecrutamento,
   deleteRecrutamento,
 } from "./recrutamento";
+export {
+  getSobreEmpresaDataClient,
+  listSobreEmpresa,
+  getSobreEmpresaById,
+  createSobreEmpresa,
+  updateSobreEmpresa,
+  deleteSobreEmpresa,
+} from "./sobre-empresa";
 
 export { getSliderData, getSliderDataClient } from "./slide";
 export { getBannerData, getBannerDataClient } from "./banner";
@@ -53,5 +61,13 @@ export type {
   CreateRecrutamentoPayload,
   UpdateRecrutamentoPayload,
 } from "./recrutamento/types";
+
+export type {
+  SobreEmpresaBackendResponse,
+  CreateSobreEmpresaPayload,
+  UpdateSobreEmpresaPayload,
+  AccordionSectionData,
+  AccordionItemData,
+} from "./sobre-empresa/types";
 
 export type { BannerBackendResponse, BannerApiResponse } from "./banner/types";

--- a/src/api/websites/components/sobre-empresa/index.ts
+++ b/src/api/websites/components/sobre-empresa/index.ts
@@ -1,0 +1,165 @@
+/**
+ * API Client para componente SobreEmpresa
+ * Fornece operações para gerenciar o conteúdo "Sobre a Empresa"
+ */
+
+import { websiteRoutes } from "@/api/routes";
+import { apiFetch } from "@/api/client";
+import { apiConfig, env } from "@/lib/env";
+import { sobreEmpresaMockData } from "./mock";
+import {
+  type SobreEmpresaBackendResponse,
+  type CreateSobreEmpresaPayload,
+  type UpdateSobreEmpresaPayload,
+  type AccordionSectionData,
+} from "./types";
+
+function mapSobreEmpresa(
+  data: SobreEmpresaBackendResponse[],
+): AccordionSectionData[] {
+  if (!data.length) return [];
+  const latest = data[data.length - 1];
+  return [
+    {
+      id: latest.id,
+      title: latest.titulo,
+      videoUrl: latest.videoUrl || "",
+      videoType: latest.videoUrl?.includes("youtube")
+        ? "youtube"
+        : latest.videoUrl?.includes("vimeo")
+        ? "vimeo"
+        : latest.videoUrl?.endsWith(".mp4")
+        ? "mp4"
+        : "url",
+      items: [
+        {
+          id: `${latest.id}-descricao`,
+          value: "descricao",
+          trigger: latest.titulo,
+          content: latest.descricao,
+          order: 1,
+          isActive: true,
+        },
+        {
+          id: `${latest.id}-visao`,
+          value: "visao",
+          trigger: "Visão",
+          content: latest.descricaoVisao,
+          order: 2,
+          isActive: true,
+        },
+        {
+          id: `${latest.id}-missao`,
+          value: "missao",
+          trigger: "Missão",
+          content: latest.descricaoMissao,
+          order: 3,
+          isActive: true,
+        },
+        {
+          id: `${latest.id}-valores`,
+          value: "valores",
+          trigger: "Valores",
+          content: latest.descricaoValores,
+          order: 4,
+          isActive: true,
+        },
+      ],
+      order: 1,
+      isActive: true,
+    },
+  ];
+}
+
+export async function getSobreEmpresaDataClient(): Promise<AccordionSectionData[]> {
+  try {
+    const raw = await listSobreEmpresa({ headers: apiConfig.headers });
+    return mapSobreEmpresa(raw);
+  } catch (error) {
+    if (env.apiFallback === "mock") {
+      return sobreEmpresaMockData;
+    }
+    throw new Error("Falha ao carregar dados de SobreEmpresa");
+  }
+}
+
+export async function listSobreEmpresa(
+  init?: RequestInit,
+): Promise<SobreEmpresaBackendResponse[]> {
+  return apiFetch<SobreEmpresaBackendResponse[]>(
+    websiteRoutes.sobreEmpresa.list(),
+    { init: init ?? { headers: apiConfig.headers } },
+  );
+}
+
+export async function getSobreEmpresaById(
+  id: string,
+): Promise<SobreEmpresaBackendResponse> {
+  return apiFetch<SobreEmpresaBackendResponse>(
+    websiteRoutes.sobreEmpresa.get(id),
+    { init: { headers: apiConfig.headers } },
+  );
+}
+
+function getAuthHeader(): Record<string, string> {
+  if (typeof document === "undefined") return {};
+  const token = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith("token="))
+    ?.split("=")[1];
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export async function createSobreEmpresa(
+  data: CreateSobreEmpresaPayload,
+): Promise<SobreEmpresaBackendResponse> {
+  return apiFetch<SobreEmpresaBackendResponse>(
+    websiteRoutes.sobreEmpresa.create(),
+    {
+      init: {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: apiConfig.headers.Accept,
+          ...getAuthHeader(),
+        },
+        body: JSON.stringify(data),
+      },
+      cache: "no-cache",
+    },
+  );
+}
+
+export async function updateSobreEmpresa(
+  id: string,
+  data: UpdateSobreEmpresaPayload,
+): Promise<SobreEmpresaBackendResponse> {
+  return apiFetch<SobreEmpresaBackendResponse>(
+    websiteRoutes.sobreEmpresa.update(id),
+    {
+      init: {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: apiConfig.headers.Accept,
+          ...getAuthHeader(),
+        },
+        body: JSON.stringify(data),
+      },
+      cache: "no-cache",
+    },
+  );
+}
+
+export async function deleteSobreEmpresa(id: string): Promise<void> {
+  await apiFetch<void>(websiteRoutes.sobreEmpresa.delete(id), {
+    init: {
+      method: "DELETE",
+      headers: {
+        Accept: apiConfig.headers.Accept,
+        ...getAuthHeader(),
+      },
+    },
+    cache: "no-cache",
+  });
+}

--- a/src/api/websites/components/sobre-empresa/mock/index.ts
+++ b/src/api/websites/components/sobre-empresa/mock/index.ts
@@ -1,0 +1,46 @@
+import type { AccordionSectionData } from "../types";
+
+export const sobreEmpresaMockData: AccordionSectionData[] = [
+  {
+    id: "sobreempresa-uuid",
+    title: "Sobre a Empresa",
+    videoUrl: "https://example.com/video",
+    videoType: "url",
+    items: [
+      {
+        id: "sobreempresa-descricao",
+        value: "descricao",
+        trigger: "Descrição",
+        content: "Descrição sobre a empresa",
+        order: 1,
+        isActive: true,
+      },
+      {
+        id: "sobreempresa-visao",
+        value: "visao",
+        trigger: "Visão",
+        content: "Nossa visão",
+        order: 2,
+        isActive: true,
+      },
+      {
+        id: "sobreempresa-missao",
+        value: "missao",
+        trigger: "Missão",
+        content: "Nossa missão",
+        order: 3,
+        isActive: true,
+      },
+      {
+        id: "sobreempresa-valores",
+        value: "valores",
+        trigger: "Valores",
+        content: "Nossos valores",
+        order: 4,
+        isActive: true,
+      },
+    ],
+    order: 1,
+    isActive: true,
+  },
+];

--- a/src/api/websites/components/sobre-empresa/types.ts
+++ b/src/api/websites/components/sobre-empresa/types.ts
@@ -1,0 +1,34 @@
+export interface SobreEmpresaBackendResponse {
+  id: string;
+  titulo: string;
+  descricao: string;
+  descricaoVisao: string;
+  descricaoMissao: string;
+  descricaoValores: string;
+  videoUrl: string;
+  criadoEm?: string;
+  atualizadoEm?: string;
+}
+
+export type CreateSobreEmpresaPayload = Omit<SobreEmpresaBackendResponse, "id" | "criadoEm" | "atualizadoEm">;
+
+export type UpdateSobreEmpresaPayload = Partial<CreateSobreEmpresaPayload>;
+
+export interface AccordionItemData {
+  id: string;
+  value: string;
+  trigger: string;
+  content: string;
+  order: number;
+  isActive: boolean;
+}
+
+export interface AccordionSectionData {
+  id: string;
+  title: string;
+  videoUrl: string;
+  videoType: "youtube" | "vimeo" | "mp4" | "url";
+  items: AccordionItemData[];
+  order: number;
+  isActive: boolean;
+}

--- a/src/app/dashboard/config/website/sobre/SobreEmpresaForm.tsx
+++ b/src/app/dashboard/config/website/sobre/SobreEmpresaForm.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import { useEffect, useState, FormEvent } from "react";
+import {
+  InputCustom,
+  RichTextarea,
+  ButtonCustom,
+} from "@/components/ui/custom";
+import { Label } from "@/components/ui/label";
+import { toastCustom } from "@/components/ui/custom/toast";
+import {
+  listSobreEmpresa,
+  createSobreEmpresa,
+  updateSobreEmpresa,
+  type SobreEmpresaBackendResponse,
+} from "@/api/websites/components";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface SobreEmpresaContent {
+  id?: string;
+  titulo: string;
+  descricao: string;
+  descricaoVisao: string;
+  descricaoMissao: string;
+  descricaoValores: string;
+  videoUrl: string;
+}
+
+interface SobreEmpresaFormProps {
+  initialData?: SobreEmpresaBackendResponse;
+}
+
+export default function SobreEmpresaForm({ initialData }: SobreEmpresaFormProps) {
+  const [content, setContent] = useState<SobreEmpresaContent>({
+    titulo: "",
+    descricao: "",
+    descricaoVisao: "",
+    descricaoMissao: "",
+    descricaoValores: "",
+    videoUrl: "",
+  });
+  const [isLoading, setIsLoading] = useState(false);
+  const [logs, setLogs] = useState<string[]>([]);
+  const [isFetching, setIsFetching] = useState(!initialData);
+
+  const addLog = (message: string) =>
+    setLogs((prev) => [
+      ...prev,
+      `[${new Date().toLocaleTimeString()}] ${message}`,
+    ]);
+
+  useEffect(() => {
+    const applyData = (data: SobreEmpresaBackendResponse) => {
+      setContent({
+        id: data.id,
+        titulo: data.titulo ?? "",
+        descricao: data.descricao ?? "",
+        descricaoVisao: data.descricaoVisao ?? "",
+        descricaoMissao: data.descricaoMissao ?? "",
+        descricaoValores: data.descricaoValores ?? "",
+        videoUrl: data.videoUrl ?? "",
+      });
+    };
+
+    if (initialData) {
+      applyData(initialData);
+      setIsFetching(false);
+      return;
+    }
+
+    const fetchData = async () => {
+      setIsFetching(true);
+      try {
+        const data = await listSobreEmpresa();
+        const first = data[0];
+        if (first) {
+          applyData(first);
+        }
+      } catch (err) {
+        addLog(`Erro ao carregar dados: ${String(err)}`);
+        const status = (err as any)?.status;
+        switch (status) {
+          case 401:
+            toastCustom.error("Sessão expirada. Faça login novamente");
+            break;
+          case 403:
+            toastCustom.error("Você não tem permissão para acessar este conteúdo");
+            break;
+          case 500:
+            toastCustom.error("Erro do servidor ao carregar dados existentes");
+            break;
+          default:
+            toastCustom.error("Erro ao carregar dados existentes");
+        }
+      } finally {
+        setIsFetching(false);
+      }
+    };
+
+    fetchData();
+  }, [initialData]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    try {
+      if (content.id) {
+        await updateSobreEmpresa(content.id, content);
+        toastCustom.success("Conteúdo atualizado com sucesso");
+        addLog("Conteúdo atualizado com sucesso");
+      } else {
+        const result = await createSobreEmpresa(content);
+        setContent((prev) => ({ ...prev, id: result.id }));
+        toastCustom.success("Conteúdo criado com sucesso");
+        addLog("Conteúdo criado com sucesso");
+      }
+    } catch (err) {
+      const status = (err as any)?.status;
+      let errorMessage = "";
+      switch (status) {
+        case 400:
+          errorMessage = "Dados inválidos. Verifique os campos";
+          break;
+        case 401:
+          errorMessage = "Sessão expirada. Faça login novamente";
+          break;
+        case 403:
+          errorMessage = "Você não tem permissão para realizar esta ação";
+          break;
+        case 500:
+          errorMessage = "Erro interno do servidor";
+          break;
+        default:
+          errorMessage =
+            err instanceof TypeError
+              ? "Erro de conexão. Verifique sua internet e tente novamente"
+              : "Erro ao salvar. Tente novamente";
+      }
+      toastCustom.error(errorMessage);
+      addLog(`Erro da API: ${errorMessage}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      {isFetching ? (
+        <div className="space-y-6">
+          <Skeleton className="h-10 w-1/3" />
+          <Skeleton className="h-32 w-full" />
+          <Skeleton className="h-32 w-full" />
+          <Skeleton className="h-32 w-full" />
+          <Skeleton className="h-10 w-1/3" />
+        </div>
+      ) : (
+        <>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="space-y-3">
+              <div>
+                <InputCustom
+                  label="Título"
+                  id="titulo"
+                  value={content.titulo}
+                  onChange={(e) =>
+                    setContent((prev) => ({ ...prev, titulo: e.target.value }))
+                  }
+                  maxLength={100}
+                  placeholder="Digite o título principal"
+                  required
+                />
+              </div>
+
+              <div>
+                <Label
+                  htmlFor="descricao"
+                  className="text-sm font-medium text-gray-700"
+                >
+                  Descrição <span className="text-red-500">*</span>
+                </Label>
+                <div className="mt-1">
+                  <RichTextarea
+                    id="descricao"
+                    value={content.descricao}
+                    onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                      setContent((prev) => ({
+                        ...prev,
+                        descricao: e.target.value,
+                      }))
+                    }
+                    maxLength={1000}
+                    showCharCount={true}
+                    placeholder="Descreva sobre a empresa"
+                    className="min-h-[150px]"
+                    required
+                  />
+                </div>
+              </div>
+
+              <div>
+                <Label
+                  htmlFor="descricaoVisao"
+                  className="text-sm font-medium text-gray-700"
+                >
+                  Visão <span className="text-red-500">*</span>
+                </Label>
+                <div className="mt-1">
+                  <RichTextarea
+                    id="descricaoVisao"
+                    value={content.descricaoVisao}
+                    onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                      setContent((prev) => ({
+                        ...prev,
+                        descricaoVisao: e.target.value,
+                      }))
+                    }
+                    maxLength={1000}
+                    showCharCount={true}
+                    placeholder="Descreva a visão da empresa"
+                    className="min-h-[150px]"
+                    required
+                  />
+                </div>
+              </div>
+
+              <div>
+                <Label
+                  htmlFor="descricaoMissao"
+                  className="text-sm font-medium text-gray-700"
+                >
+                  Missão <span className="text-red-500">*</span>
+                </Label>
+                <div className="mt-1">
+                  <RichTextarea
+                    id="descricaoMissao"
+                    value={content.descricaoMissao}
+                    onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                      setContent((prev) => ({
+                        ...prev,
+                        descricaoMissao: e.target.value,
+                      }))
+                    }
+                    maxLength={1000}
+                    showCharCount={true}
+                    placeholder="Descreva a missão da empresa"
+                    className="min-h-[150px]"
+                    required
+                  />
+                </div>
+              </div>
+
+              <div>
+                <Label
+                  htmlFor="descricaoValores"
+                  className="text-sm font-medium text-gray-700"
+                >
+                  Valores <span className="text-red-500">*</span>
+                </Label>
+                <div className="mt-1">
+                  <RichTextarea
+                    id="descricaoValores"
+                    value={content.descricaoValores}
+                    onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                      setContent((prev) => ({
+                        ...prev,
+                        descricaoValores: e.target.value,
+                      }))
+                    }
+                    maxLength={1000}
+                    showCharCount={true}
+                    placeholder="Descreva os valores da empresa"
+                    className="min-h-[150px]"
+                    required
+                  />
+                </div>
+              </div>
+
+              <div>
+                <InputCustom
+                  label="URL do Vídeo"
+                  id="videoUrl"
+                  type="url"
+                  value={content.videoUrl}
+                  onChange={(e) =>
+                    setContent((prev) => ({ ...prev, videoUrl: e.target.value }))
+                  }
+                  placeholder="https://exemplo.com/video"
+                />
+              </div>
+            </div>
+
+            <div className="pt-4 flex justify-end">
+              <ButtonCustom
+                type="submit"
+                isLoading={isLoading}
+                disabled={isLoading}
+                size="lg"
+                variant="default"
+                className="w-40"
+                withAnimation={true}
+              >
+                Salvar
+              </ButtonCustom>
+            </div>
+          </form>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/config/website/sobre/page.tsx
+++ b/src/app/dashboard/config/website/sobre/page.tsx
@@ -1,12 +1,48 @@
 "use client";
 
-import React from "react";
-import {
-  VerticalTabs,
-  type VerticalTabItem,
-} from "@/components/ui/custom";
+import React, { useEffect, useState } from "react";
+import { VerticalTabs, type VerticalTabItem } from "@/components/ui/custom";
+import { Skeleton } from "@/components/ui/skeleton";
+import SobreEmpresaForm from "./SobreEmpresaForm";
+import { listSobreEmpresa, type SobreEmpresaBackendResponse } from "@/api/websites/components";
 
 export default function SobrePage() {
+  const [sobreData, setSobreData] =
+    useState<SobreEmpresaBackendResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const sobre = await listSobreEmpresa();
+        setSobreData(sobre[0] ?? null);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-3xl p-5 h-full min-h-[calc(100vh-8rem)] flex flex-col">
+        <div className="flex-1 min-h-0 flex">
+          <div className="w-48 space-y-2 p-2">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-10 w-full" />
+            ))}
+          </div>
+          <div className="flex-1 p-6 space-y-4">
+            <Skeleton className="h-8 w-1/3" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   const items: VerticalTabItem[] = [
     {
       value: "banner",
@@ -24,7 +60,7 @@ export default function SobrePage() {
       icon: "Info",
       content: (
         <div className="space-y-6">
-          <h3 className="text-lg font-semibold mb-2">Sobre</h3>
+          <SobreEmpresaForm initialData={sobreData ?? undefined} />
         </div>
       ),
     },

--- a/src/theme/website/components/accordion-group-information/constants/index.ts
+++ b/src/theme/website/components/accordion-group-information/constants/index.ts
@@ -49,12 +49,6 @@ export const DEFAULT_ACCORDION_DATA: AccordionSectionData[] = [
  * Configurações do componente
  */
 export const ACCORDION_CONFIG = {
-  api: {
-    endpoint: "/api/accordion/sections",
-    timeout: 5000,
-    retryAttempts: 3,
-    retryDelay: 1000,
-  },
   animation: {
     staggerDelay: 300,
     duration: 600,

--- a/src/theme/website/components/accordion-group-information/hooks/useAccordionData.ts
+++ b/src/theme/website/components/accordion-group-information/hooks/useAccordionData.ts
@@ -3,8 +3,9 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import type { AccordionSectionData, AccordionApiResponse } from "../types";
-import { DEFAULT_ACCORDION_DATA, ACCORDION_CONFIG } from "../constants";
+import type { AccordionSectionData } from "../types";
+import { DEFAULT_ACCORDION_DATA } from "../constants";
+import { getSobreEmpresaDataClient } from "@/api/websites/components";
 
 interface UseAccordionDataReturn {
   data: AccordionSectionData[];
@@ -37,34 +38,10 @@ export function useAccordionData(
       setIsLoading(true);
       setError(null);
 
-      const controller = new AbortController();
-      const timeoutId = setTimeout(
-        () => controller.abort(),
-        ACCORDION_CONFIG.api.timeout
-      );
-
-      const response = await fetch(ACCORDION_CONFIG.api.endpoint, {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        signal: controller.signal,
-      });
-
-      clearTimeout(timeoutId);
-
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-
-      const result: AccordionApiResponse = await response.json();
-
-      if (!result.success || !result.data) {
-        throw new Error(result.message || "Dados inválidos recebidos da API");
-      }
+      const result = await getSobreEmpresaDataClient();
 
       // Filtra apenas dados ativos e ordena
-      const activeData = result.data
+      const activeData = result
         .filter((item) => item.isActive)
         .sort((a, b) => a.order - b.order)
         .map((section) => ({


### PR DESCRIPTION
## Summary
- add API routes and client for SobreEmpresa
- expose admin form and page integration for SobreEmpresa section
- wire accordion group component to fetch SobreEmpresa data

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b05065c320832596dd6aa482d73d76