### PR TITLE
feat: add diferenciais config and integration

### DIFF
--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -35,6 +35,13 @@ export const websiteRoutes = {
     update: (id: string) => `${prefix}/website/recrutamento/${id}`,
     delete: (id: string) => `${prefix}/website/recrutamento/${id}`,
   },
+  diferenciais: {
+    list: () => `${prefix}/website/diferenciais`,
+    create: () => `${prefix}/website/diferenciais`,
+    get: (id: string) => `${prefix}/website/diferenciais/${id}`,
+    update: (id: string) => `${prefix}/website/diferenciais/${id}`,
+    delete: (id: string) => `${prefix}/website/diferenciais/${id}`,
+  },
   sobreEmpresa: {
     list: () => `${prefix}/website/sobre-empresa`,
     create: () => `${prefix}/website/sobre-empresa`,

--- a/src/api/websites/components/diferenciais/index.ts
+++ b/src/api/websites/components/diferenciais/index.ts
@@ -1,0 +1,89 @@
+import { websiteRoutes } from "@/api/routes";
+import { apiFetch } from "@/api/client";
+import { apiConfig } from "@/lib/env";
+import type {
+  DiferenciaisBackendResponse,
+  CreateDiferenciaisPayload,
+  UpdateDiferenciaisPayload,
+} from "./types";
+
+export async function listDiferenciais(
+  init?: RequestInit,
+): Promise<DiferenciaisBackendResponse[]> {
+  return apiFetch<DiferenciaisBackendResponse[]>(
+    websiteRoutes.diferenciais.list(),
+    { init: init ?? { headers: apiConfig.headers } },
+  );
+}
+
+export async function getDiferenciaisById(
+  id: string,
+): Promise<DiferenciaisBackendResponse> {
+  return apiFetch<DiferenciaisBackendResponse>(
+    websiteRoutes.diferenciais.get(id),
+    { init: { headers: apiConfig.headers } },
+  );
+}
+
+function getAuthHeader(): Record<string, string> {
+  if (typeof document === "undefined") return {};
+  const token = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith("token="))
+    ?.split("=")[1];
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export async function createDiferenciais(
+  data: CreateDiferenciaisPayload,
+): Promise<DiferenciaisBackendResponse> {
+  return apiFetch<DiferenciaisBackendResponse>(
+    websiteRoutes.diferenciais.create(),
+    {
+      init: {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: apiConfig.headers.Accept,
+          ...getAuthHeader(),
+        },
+        body: JSON.stringify(data),
+      },
+      cache: "no-cache",
+    },
+  );
+}
+
+export async function updateDiferenciais(
+  id: string,
+  data: UpdateDiferenciaisPayload,
+): Promise<DiferenciaisBackendResponse> {
+  return apiFetch<DiferenciaisBackendResponse>(
+    websiteRoutes.diferenciais.update(id),
+    {
+      init: {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: apiConfig.headers.Accept,
+          ...getAuthHeader(),
+        },
+        body: JSON.stringify(data),
+      },
+      cache: "no-cache",
+    },
+  );
+}
+
+export async function deleteDiferenciais(id: string): Promise<void> {
+  await apiFetch<void>(websiteRoutes.diferenciais.delete(id), {
+    init: {
+      method: "DELETE",
+      headers: {
+        Accept: apiConfig.headers.Accept,
+        ...getAuthHeader(),
+      },
+    },
+    cache: "no-cache",
+  });
+}

--- a/src/api/websites/components/diferenciais/types.ts
+++ b/src/api/websites/components/diferenciais/types.ts
@@ -1,0 +1,59 @@
+export interface DiferenciaisBackendResponse {
+  id: string;
+  icone1: string;
+  titulo1: string;
+  descricao1: string;
+  icone2: string;
+  titulo2: string;
+  descricao2: string;
+  icone3: string;
+  titulo3: string;
+  descricao3: string;
+  icone4: string;
+  titulo4: string;
+  descricao4: string;
+  titulo: string;
+  descricao: string;
+  botaoUrl: string;
+  botaoLabel: string;
+  criadoEm: string;
+  atualizadoEm: string;
+}
+
+export interface CreateDiferenciaisPayload {
+  icone1: string;
+  titulo1: string;
+  descricao1: string;
+  icone2: string;
+  titulo2: string;
+  descricao2: string;
+  icone3: string;
+  titulo3: string;
+  descricao3: string;
+  icone4: string;
+  titulo4: string;
+  descricao4: string;
+  titulo: string;
+  descricao: string;
+  botaoUrl: string;
+  botaoLabel: string;
+}
+
+export interface UpdateDiferenciaisPayload {
+  icone1?: string;
+  titulo1?: string;
+  descricao1?: string;
+  icone2?: string;
+  titulo2?: string;
+  descricao2?: string;
+  icone3?: string;
+  titulo3?: string;
+  descricao3?: string;
+  icone4?: string;
+  titulo4?: string;
+  descricao4?: string;
+  titulo?: string;
+  descricao?: string;
+  botaoUrl?: string;
+  botaoLabel?: string;
+}

--- a/src/api/websites/components/index.ts
+++ b/src/api/websites/components/index.ts
@@ -33,6 +33,13 @@ export {
   updateSobreEmpresa,
   deleteSobreEmpresa,
 } from "./sobre-empresa";
+export {
+  listDiferenciais,
+  getDiferenciaisById,
+  createDiferenciais,
+  updateDiferenciais,
+  deleteDiferenciais,
+} from "./diferenciais";
 
 export { getSliderData, getSliderDataClient } from "./slide";
 export { getBannerData, getBannerDataClient } from "./banner";
@@ -69,5 +76,10 @@ export type {
   AccordionSectionData,
   AccordionItemData,
 } from "./sobre-empresa/types";
+export type {
+  DiferenciaisBackendResponse,
+  CreateDiferenciaisPayload,
+  UpdateDiferenciaisPayload,
+} from "./diferenciais/types";
 
 export type { BannerBackendResponse, BannerApiResponse } from "./banner/types";

--- a/src/app/dashboard/config/website/sobre/DiferenciaisForm.tsx
+++ b/src/app/dashboard/config/website/sobre/DiferenciaisForm.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useEffect, useState, FormEvent } from "react";
+import { InputCustom, RichTextarea, ButtonCustom } from "@/components/ui/custom";
+import { Label } from "@/components/ui/label";
+import { toastCustom } from "@/components/ui/custom/toast";
+import {
+  listDiferenciais,
+  createDiferenciais,
+  updateDiferenciais,
+  type DiferenciaisBackendResponse,
+} from "@/api/websites/components";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface DiferenciaisContent {
+  id?: string;
+  titulo: string;
+  descricao: string;
+  botaoUrl: string;
+  botaoLabel: string;
+  icone1: string;
+  titulo1: string;
+  descricao1: string;
+  icone2: string;
+  titulo2: string;
+  descricao2: string;
+  icone3: string;
+  titulo3: string;
+  descricao3: string;
+  icone4: string;
+  titulo4: string;
+  descricao4: string;
+}
+
+interface DiferenciaisFormProps {
+  initialData?: DiferenciaisBackendResponse;
+}
+
+export default function DiferenciaisForm({ initialData }: DiferenciaisFormProps) {
+  const [content, setContent] = useState<DiferenciaisContent>({
+    titulo: "",
+    descricao: "",
+    botaoUrl: "",
+    botaoLabel: "",
+    icone1: "",
+    titulo1: "",
+    descricao1: "",
+    icone2: "",
+    titulo2: "",
+    descricao2: "",
+    icone3: "",
+    titulo3: "",
+    descricao3: "",
+    icone4: "",
+    titulo4: "",
+    descricao4: "",
+  });
+  const [isLoading, setIsLoading] = useState(false);
+  const [isFetching, setIsFetching] = useState(!initialData);
+  const [logs, setLogs] = useState<string[]>([]);
+
+  const addLog = (message: string) =>
+    setLogs((prev) => [...prev, `[${new Date().toLocaleTimeString()}] ${message}`]);
+
+  useEffect(() => {
+    const applyData = (data: DiferenciaisBackendResponse) => {
+      setContent({
+        id: data.id,
+        titulo: data.titulo ?? "",
+        descricao: data.descricao ?? "",
+        botaoUrl: data.botaoUrl ?? "",
+        botaoLabel: data.botaoLabel ?? "",
+        icone1: data.icone1 ?? "",
+        titulo1: data.titulo1 ?? "",
+        descricao1: data.descricao1 ?? "",
+        icone2: data.icone2 ?? "",
+        titulo2: data.titulo2 ?? "",
+        descricao2: data.descricao2 ?? "",
+        icone3: data.icone3 ?? "",
+        titulo3: data.titulo3 ?? "",
+        descricao3: data.descricao3 ?? "",
+        icone4: data.icone4 ?? "",
+        titulo4: data.titulo4 ?? "",
+        descricao4: data.descricao4 ?? "",
+      });
+    };
+
+    if (initialData) {
+      applyData(initialData);
+      setIsFetching(false);
+      return;
+    }
+
+    const fetchData = async () => {
+      setIsFetching(true);
+      try {
+        const data = await listDiferenciais();
+        if (data[0]) {
+          applyData(data[0]);
+        }
+      } catch (err) {
+        addLog(`Erro ao carregar dados: ${String(err)}`);
+        const status = (err as any)?.status;
+        switch (status) {
+          case 401:
+            toastCustom.error("Sessão expirada. Faça login novamente");
+            break;
+          case 403:
+            toastCustom.error("Você não tem permissão para acessar este conteúdo");
+            break;
+          case 500:
+            toastCustom.error("Erro do servidor ao carregar dados existentes");
+            break;
+          default:
+            toastCustom.error("Erro ao carregar dados existentes");
+        }
+      } finally {
+        setIsFetching(false);
+      }
+    };
+
+    fetchData();
+  }, [initialData]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    try {
+      const payload = { ...content };
+      if (content.id) {
+        await updateDiferenciais(content.id, payload);
+        toastCustom.success("Conteúdo atualizado com sucesso");
+      } else {
+        await createDiferenciais(payload);
+        toastCustom.success("Conteúdo criado com sucesso");
+      }
+    } catch (err) {
+      addLog(`Erro ao salvar: ${String(err)}`);
+      const status = (err as any)?.status;
+      switch (status) {
+        case 401:
+          toastCustom.error("Sessão expirada. Faça login novamente");
+          break;
+        case 403:
+          toastCustom.error("Você não tem permissão para realizar esta ação");
+          break;
+        case 500:
+          toastCustom.error("Erro do servidor ao salvar os dados");
+          break;
+        default:
+          toastCustom.error("Erro ao salvar os dados");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (isFetching) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-1/3" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-2/3" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="space-y-3">
+          <InputCustom
+            label="Título Geral"
+            id="titulo"
+            value={content.titulo}
+            onChange={(e) => setContent((p) => ({ ...p, titulo: e.target.value }))}
+            maxLength={100}
+            placeholder="Digite o título geral"
+            required
+          />
+          <InputCustom
+            label="Descrição Geral"
+            id="descricao"
+            value={content.descricao}
+            onChange={(e) => setContent((p) => ({ ...p, descricao: e.target.value }))}
+            maxLength={255}
+            placeholder="Digite a descrição geral"
+            required
+          />
+          <InputCustom
+            label="URL do Botão"
+            id="botaoUrl"
+            type="url"
+            value={content.botaoUrl}
+            onChange={(e) => setContent((p) => ({ ...p, botaoUrl: e.target.value }))}
+            placeholder="https://exemplo.com"
+            required
+          />
+          <InputCustom
+            label="Texto do Botão"
+            id="botaoLabel"
+            value={content.botaoLabel}
+            onChange={(e) => setContent((p) => ({ ...p, botaoLabel: e.target.value }))}
+            maxLength={50}
+            placeholder="Digite o texto do botão"
+            required
+          />
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="border rounded-md p-4 space-y-3">
+              <Label>Card {i}</Label>
+              <InputCustom
+                label={`Ícone ${i}`}
+                id={`icone${i}`}
+                value={(content as any)[`icone${i}`]}
+                onChange={(e) =>
+                  setContent((p) => ({ ...p, [`icone${i}`]: e.target.value }))
+                }
+                placeholder="Nome do ícone Lucide"
+                required
+              />
+              <InputCustom
+                label={`Título ${i}`}
+                id={`titulo${i}`}
+                value={(content as any)[`titulo${i}`]}
+                onChange={(e) =>
+                  setContent((p) => ({ ...p, [`titulo${i}`]: e.target.value }))
+                }
+                maxLength={50}
+                placeholder="Título do card"
+                required
+              />
+              <RichTextarea
+                id={`descricao${i}`}
+                value={(content as any)[`descricao${i}`]}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  setContent((p) => ({ ...p, [`descricao${i}`]: e.target.value }))
+                }
+                maxLength={200}
+                showCharCount={true}
+                placeholder="Descrição do card"
+                required
+              />
+            </div>
+          ))}
+        </div>
+
+        <div className="pt-4 flex justify-end">
+          <ButtonCustom
+            type="submit"
+            isLoading={isLoading}
+            disabled={isLoading}
+            size="lg"
+            variant="default"
+            className="w-40"
+            withAnimation={true}
+          >
+            Salvar
+          </ButtonCustom>
+        </div>
+      </form>
+
+      {logs.length > 0 && (
+        <div className="mt-4">
+          <Label>Logs</Label>
+          <div className="bg-gray-100 rounded-md p-3 text-xs space-y-1 max-h-40 overflow-y-auto">
+            {logs.map((log, idx) => (
+              <div key={idx}>{log}</div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/app/dashboard/config/website/sobre/page.tsx
+++ b/src/app/dashboard/config/website/sobre/page.tsx
@@ -4,18 +4,30 @@ import React, { useEffect, useState } from "react";
 import { VerticalTabs, type VerticalTabItem } from "@/components/ui/custom";
 import { Skeleton } from "@/components/ui/skeleton";
 import SobreEmpresaForm from "./SobreEmpresaForm";
-import { listSobreEmpresa, type SobreEmpresaBackendResponse } from "@/api/websites/components";
+import DiferenciaisForm from "./DiferenciaisForm";
+import {
+  listSobreEmpresa,
+  listDiferenciais,
+  type SobreEmpresaBackendResponse,
+  type DiferenciaisBackendResponse,
+} from "@/api/websites/components";
 
 export default function SobrePage() {
   const [sobreData, setSobreData] =
     useState<SobreEmpresaBackendResponse | null>(null);
+  const [diferenciaisData, setDiferenciaisData] =
+    useState<DiferenciaisBackendResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const sobre = await listSobreEmpresa();
+        const [sobre, diferenciais] = await Promise.all([
+          listSobreEmpresa(),
+          listDiferenciais(),
+        ]);
         setSobreData(sobre[0] ?? null);
+        setDiferenciaisData(diferenciais[0] ?? null);
       } finally {
         setIsLoading(false);
       }
@@ -76,11 +88,11 @@ export default function SobrePage() {
     },
     {
       value: "escolha",
-      label: "Escolha",
+      label: "Diferenciais",
       icon: "CheckCircle",
       content: (
         <div className="space-y-6">
-          <h3 className="text-lg font-semibold mb-2">Escolha</h3>
+          <DiferenciaisForm initialData={diferenciaisData ?? undefined} />
         </div>
       ),
     },

--- a/src/theme/website/components/about-advantages/constants/index.ts
+++ b/src/theme/website/components/about-advantages/constants/index.ts
@@ -78,7 +78,7 @@ export const DEFAULT_ABOUT_ADVANTAGES_DATA: AboutAdvantagesApiData = {
  */
 export const ABOUT_ADVANTAGES_CONFIG = {
   api: {
-    endpoint: websiteRoutes.about.list(),
+    endpoint: websiteRoutes.diferenciais.list(),
     timeout: 5000,
     retryAttempts: 3,
     retryDelay: 1000,


### PR DESCRIPTION
## Summary
- add diferenciais API routes and client helpers
- configure dashboard Sobre page with Diferenciais form
- hook AboutAdvantages component to backend icons

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b05a9485e8832599e45c5c3b7e58c6