### PR TITLE
fix slider status typing to allow boolean

### DIFF
--- a/src/api/websites/components/slider/types/index.ts
+++ b/src/api/websites/components/slider/types/index.ts
@@ -26,7 +26,7 @@ export interface CreateSliderPayload {
   imagemTitulo?: string;
   link?: string;
   orientacao: SliderOrientation;
-  status: SliderStatus;
+  status: SliderStatus | boolean;
   ordem?: number;
   imagem?: File;
 }
@@ -37,7 +37,7 @@ export interface UpdateSliderPayload {
   imagemTitulo?: string;
   link?: string;
   orientacao?: SliderOrientation;
-  status?: SliderStatus;
+  status?: SliderStatus | boolean;
   ordem?: number;
   imagem?: File;
 }


### PR DESCRIPTION
## Summary
- allow boolean status in slider payload types to resolve build errors

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b316a0c3408325b6ff5a1ad673eb11