### PR TITLE
feat: allow partial slider status update

### DIFF
--- a/src/api/websites/components/index.ts
+++ b/src/api/websites/components/index.ts
@@ -50,6 +50,7 @@ export {
   updateSlider,
   deleteSlider,
   updateSliderOrder,
+  updateSliderStatus,
 } from "./slider";
 export { getBannerData, getBannerDataClient } from "./banner";
 export type {

--- a/src/api/websites/components/slider/index.ts
+++ b/src/api/websites/components/slider/index.ts
@@ -148,6 +148,31 @@ export async function updateSlider(
   });
 }
 
+/**
+ * Atualiza apenas o status do slider
+ * Permite enviar boolean ou string ("PUBLICADO" | "RASCUNHO")
+ * Utiliza JSON ao invés de multipart/form-data para atualizações parciais
+ */
+export async function updateSliderStatus(
+  id: string,
+  status: boolean | string
+): Promise<SlideBackendResponse> {
+  const normalizedStatus =
+    typeof status === "string" ? status.toUpperCase() : status;
+  return apiFetch<SlideBackendResponse>(websiteRoutes.slider.update(id), {
+    init: {
+      method: "PUT",
+      headers: {
+        Accept: apiConfig.headers.Accept,
+        "Content-Type": "application/json",
+        ...getAuthHeader(),
+      },
+      body: JSON.stringify({ status: normalizedStatus }),
+    },
+    cache: "no-cache",
+  });
+}
+
 export async function deleteSlider(id: string): Promise<void> {
   await apiFetch<void>(websiteRoutes.slider.delete(id), {
     init: {

--- a/src/app/dashboard/config/website/pagina-inicial/slider/Desktop.tsx
+++ b/src/app/dashboard/config/website/pagina-inicial/slider/Desktop.tsx
@@ -8,6 +8,7 @@ import {
   listSliders,
   createSlider as apiCreateSlider,
   updateSlider as apiUpdateSlider,
+  updateSliderStatus as apiUpdateSliderStatus,
   deleteSlider as apiDeleteSlider,
   updateSliderOrder as apiUpdateSliderOrder,
 } from "@/api/websites/components";
@@ -73,6 +74,16 @@ export default function DesktopSliderManager() {
 
   const handleUpdate = useCallback(
     async (id: string, updates: Partial<Slider>): Promise<Slider> => {
+      // Atualização simples de status usa endpoint específico
+      if (updates.status !== undefined &&
+          updates.title === undefined &&
+          updates.image === undefined &&
+          updates.url === undefined &&
+          updates.position === undefined) {
+        const updated = await apiUpdateSliderStatus(id, updates.status);
+        return mapFromBackend(updated);
+      }
+
       const updated = await apiUpdateSlider(id, {
         sliderName: updates.title,
         imagemUrl: updates.image,

--- a/src/components/ui/custom/slider-manager/hooks/use-slider-manager.ts
+++ b/src/components/ui/custom/slider-manager/hooks/use-slider-manager.ts
@@ -297,14 +297,32 @@ export function useSliderManager(props: SliderManagerProps = {}) {
       const slider = state.sliders.find((s) => s.id === id);
       if (!slider) return;
 
+      dispatch({ type: "SET_LOADING", payload: true });
+      dispatch({ type: "SET_ERROR", payload: null });
+
       try {
-        await updateSlider(id, { status: !slider.status });
+        if (onUpdateSlider) {
+          await onUpdateSlider(id, { status: !slider.status });
+        }
+
+        dispatch({
+          type: "UPDATE_SLIDER",
+          payload: { id, updates: { status: !slider.status } },
+        });
         toastCustom.success(SLIDER_MESSAGES.SUCCESS_STATUS_TOGGLE);
       } catch (error) {
+        const errorMessage =
+          error instanceof Error
+            ? error.message
+            : SLIDER_MESSAGES.ERROR_GENERIC;
+        toastCustom.error(errorMessage);
+        dispatch({ type: "SET_ERROR", payload: errorMessage });
         console.error("Error toggling slider status:", error);
+      } finally {
+        dispatch({ type: "SET_LOADING", payload: false });
       }
     },
-    [state.sliders, updateSlider]
+    [state.sliders, onUpdateSlider]
   );
 
   /**


### PR DESCRIPTION
## Summary
- support partial status updates via JSON
- handle status toggling with dedicated API call

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b31ba6e8e08325952d8471ddb64ed6