### PR TITLE
Fix slider status toggle using FormData

### DIFF
--- a/src/app/dashboard/config/website/pagina-inicial/slider/Desktop.tsx
+++ b/src/app/dashboard/config/website/pagina-inicial/slider/Desktop.tsx
@@ -75,12 +75,14 @@ export default function DesktopSliderManager() {
   const handleUpdate = useCallback(
     async (id: string, updates: Partial<Slider>): Promise<Slider> => {
       // Atualização simples de status usa endpoint específico
-      if (updates.status !== undefined &&
-          updates.title === undefined &&
-          updates.image === undefined &&
-          updates.url === undefined &&
-          updates.position === undefined) {
-        const updated = await apiUpdateSliderStatus(id, updates.status);
+      if (
+        updates.status !== undefined &&
+        updates.title === undefined &&
+        updates.image === undefined &&
+        updates.url === undefined &&
+        updates.position === undefined
+      ) {
+        const updated = await apiUpdateSliderStatus(id, updates.status, "DESKTOP");
         return mapFromBackend(updated);
       }
 


### PR DESCRIPTION
## Summary
- fix slider status toggle to send FormData and orientation
- update desktop slider manager to use new status update API

## Testing
- `pnpm lint`
- `pnpm type-check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b38f48eae88325b63ac2fa502d7d67