### PR TITLE
Fix slider reorder state duplication

### DIFF
--- a/src/components/ui/custom/slider-manager/hooks/use-slider-manager.ts
+++ b/src/components/ui/custom/slider-manager/hooks/use-slider-manager.ts
@@ -65,21 +65,40 @@ function sliderManagerReducer(
         error: null,
       };
 
-    case "REORDER_SLIDER":
+    case "REORDER_SLIDER": {
+      // Reorder local array while keeping all positions consistent
+      const sorted = [...state.sliders].sort(
+        (a, b) => a.position - b.position
+      );
+
+      // Find index of the moved slider (can match either id or orderId)
+      const fromIndex = sorted.findIndex(
+        (slider) =>
+          slider.id === action.payload.id ||
+          (slider as any).orderId === action.payload.id
+      );
+
+      if (fromIndex === -1) {
+        return state;
+      }
+
+      // Remove the slider from its current position
+      const [moved] = sorted.splice(fromIndex, 1);
+      // Insert slider into the new position (1-based -> 0-based index)
+      sorted.splice(action.payload.position - 1, 0, moved);
+
+      // Recalculate the position of every slider to avoid duplicates
+      const recalculated = sorted.map((slider, index) => ({
+        ...slider,
+        position: index + 1,
+      }));
+
       return {
         ...state,
-        sliders: state.sliders
-          .map((slider) => {
-            const matches =
-              slider.id === action.payload.id ||
-              (slider as any).orderId === action.payload.id;
-            return matches
-              ? { ...slider, position: action.payload.position }
-              : slider;
-          })
-          .sort((a, b) => a.position - b.position),
+        sliders: recalculated,
         error: null,
       };
+    }
 
     case "SET_LOADING":
       return {

--- a/src/components/ui/custom/slider-manager/index.tsx
+++ b/src/components/ui/custom/slider-manager/index.tsx
@@ -47,7 +47,6 @@ export function SliderManager({
     cancelEdit,
     setView,
     clearError,
-    refreshSliders,
 
     // Statistics
     activeSliders,
@@ -181,15 +180,12 @@ export function SliderManager({
                 if (slider.image) {
                   await deleteImage(slider.image);
                 }
-                await refreshSliders?.();
               }}
               onToggleStatus={async (id) => {
                 await toggleSliderStatus(id);
-                await refreshSliders?.();
               }}
               onReorder={async (id, pos) => {
                 await reorderSlider(id, pos);
-                await refreshSliders?.();
               }}
               isLoading={isLoading}
             />
@@ -218,9 +214,8 @@ export function SliderManager({
                 showHeader={false}
                 onSubmit={async (formData) => {
                   await handleFormSubmit(formData);
-                  // Close modal and ensure fresh list from API
+                  // Close modal and return to list
                   handleBackToList();
-                  await refreshSliders?.();
                 }}
                 onCancel={handleBackToList}
                 isLoading={isLoading}


### PR DESCRIPTION
## Summary
- ensure REORDER_SLIDER updates positions of all sliders
- remove redundant refresh calls after slider actions

## Testing
- `pnpm test`
- `pnpm lint` *(warns: React Hook useCallback has a missing dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68b6220454448325b5ee5c8c7b195832