### PR TITLE
fix: add banner reorder route and handle missing banner dates

### DIFF
--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -63,6 +63,7 @@ export const websiteRoutes = {
     get: (id: string) => `${prefix}/website/banner/${id}`,
     update: (id: string) => `${prefix}/website/banner/${id}`,
     delete: (id: string) => `${prefix}/website/banner/${id}`,
+    reorder: (id: string) => `${prefix}/website/banner/${id}/reorder`,
   },
 };
 

--- a/src/app/dashboard/config/website/pagina-inicial/banners/BannersForm.tsx
+++ b/src/app/dashboard/config/website/pagina-inicial/banners/BannersForm.tsx
@@ -24,7 +24,7 @@ function mapFromBackend(item: BannerBackendResponse): Slider {
     content: "",
     status: (typeof item.status === "string" ? item.status : item.status ? "PUBLICADO" : "RASCUNHO") === "PUBLICADO",
     position: item.ordem,
-    createdAt: item.criadoEm,
+    createdAt: item.criadoEm ?? "",
     updatedAt: item.atualizadoEm,
   };
 }


### PR DESCRIPTION
## Summary
- add reorder endpoint for banner routes
- ensure banners form handles missing creation date

## Testing
- `pnpm test`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b63aca87d0832589ce6ae6b83682e5