### PR TITLE
fix: load planinhas via client

### DIFF
--- a/src/app/website/recrutamento/page.tsx
+++ b/src/app/website/recrutamento/page.tsx
@@ -1,19 +1,16 @@
 import React from "react";
 import HeaderPages from "@/theme/website/components/header-pages";
 import ProblemSolutionSection from "@/theme/website/components/problem-solution-section";
-import { getPlaninhasSectionData } from "@/api/websites/components";
 
 export const metadata = {
   title: "Recrutamento & Seleção",
 };
 
-export default async function RecrutamentoPage() {
-  const planinhasData = await getPlaninhasSectionData();
-
+export default function RecrutamentoPage() {
   return (
     <div className="min-h-screen">
       <HeaderPages fetchFromApi={true} currentPage="/recrutamento" />
-      <ProblemSolutionSection fetchFromApi={false} staticData={planinhasData} />
+      <ProblemSolutionSection />
     </div>
   );
 }

--- a/src/theme/website/components/problem-solution-section/hooks/useProblemSolutionData.ts
+++ b/src/theme/website/components/problem-solution-section/hooks/useProblemSolutionData.ts
@@ -5,7 +5,7 @@
 import { useState, useEffect, useCallback } from "react";
 import type { SectionData } from "../types";
 import { DEFAULT_SECTION_DATA } from "../constants";
-import { getPlaninhasSectionDataClient } from "@/api/websites/components";
+import { getPlaninhasSectionDataClient } from "@/api/websites/components/planinhas";
 
 interface UseProblemSolutionDataReturn {
   data: SectionData;


### PR DESCRIPTION
## Summary
- simplify recruitment page to fetch planinhas data on client
- point problem solution hook directly at planinhas API module

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b883d8353c8325ad0f82d14995fb2d