### PR TITLE
feat: add ajuda section to recrutamento config

### DIFF
--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -49,6 +49,13 @@ export const websiteRoutes = {
     update: (id: string) => `${prefix}/website/planinhas/${id}`,
     delete: (id: string) => `${prefix}/website/planinhas/${id}`,
   },
+  advanceAjuda: {
+    list: () => `${prefix}/website/advance-ajuda`,
+    create: () => `${prefix}/website/advance-ajuda`,
+    get: (id: string) => `${prefix}/website/advance-ajuda/${id}`,
+    update: (id: string) => `${prefix}/website/advance-ajuda/${id}`,
+    delete: (id: string) => `${prefix}/website/advance-ajuda/${id}`,
+  },
   sobreEmpresa: {
     list: () => `${prefix}/website/sobre-empresa`,
     create: () => `${prefix}/website/sobre-empresa`,

--- a/src/api/websites/components/advance-ajuda/index.ts
+++ b/src/api/websites/components/advance-ajuda/index.ts
@@ -1,0 +1,76 @@
+import { websiteRoutes } from "@/api/routes";
+import { apiFetch } from "@/api/client";
+import { apiConfig } from "@/lib/env";
+import type {
+  AdvanceAjudaBackendResponse,
+  CreateAdvanceAjudaPayload,
+  UpdateAdvanceAjudaPayload,
+} from "./types";
+
+function getAuthHeader(): Record<string, string> {
+  if (typeof document === "undefined") return {};
+  const token = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith("token="))
+    ?.split("=")[1];
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export async function listAdvanceAjuda(
+  init?: RequestInit,
+): Promise<AdvanceAjudaBackendResponse[]> {
+  return apiFetch<AdvanceAjudaBackendResponse[]>(websiteRoutes.advanceAjuda.list(), {
+    init: init ?? { headers: apiConfig.headers },
+  });
+}
+
+export async function getAdvanceAjudaById(
+  id: string,
+): Promise<AdvanceAjudaBackendResponse> {
+  return apiFetch<AdvanceAjudaBackendResponse>(websiteRoutes.advanceAjuda.get(id), {
+    init: { headers: apiConfig.headers },
+  });
+}
+
+export async function createAdvanceAjuda(
+  data: CreateAdvanceAjudaPayload,
+): Promise<AdvanceAjudaBackendResponse> {
+  const headers = {
+    "Content-Type": "application/json",
+    Accept: apiConfig.headers.Accept,
+    ...getAuthHeader(),
+  } as Record<string, string>;
+  return apiFetch<AdvanceAjudaBackendResponse>(
+    websiteRoutes.advanceAjuda.create(),
+    {
+      init: { method: "POST", body: JSON.stringify(data), headers },
+      cache: "no-cache",
+    },
+  );
+}
+
+export async function updateAdvanceAjuda(
+  id: string,
+  data: UpdateAdvanceAjudaPayload,
+): Promise<AdvanceAjudaBackendResponse> {
+  const headers = {
+    "Content-Type": "application/json",
+    Accept: apiConfig.headers.Accept,
+    ...getAuthHeader(),
+  } as Record<string, string>;
+  return apiFetch<AdvanceAjudaBackendResponse>(
+    websiteRoutes.advanceAjuda.update(id),
+    {
+      init: { method: "PUT", body: JSON.stringify(data), headers },
+      cache: "no-cache",
+    },
+  );
+}
+
+export async function deleteAdvanceAjuda(id: string): Promise<void> {
+  const headers = { Accept: apiConfig.headers.Accept, ...getAuthHeader() } as Record<string, string>;
+  await apiFetch<void>(websiteRoutes.advanceAjuda.delete(id), {
+    init: { method: "DELETE", headers },
+    cache: "no-cache",
+  });
+}

--- a/src/api/websites/components/advance-ajuda/types/index.ts
+++ b/src/api/websites/components/advance-ajuda/types/index.ts
@@ -1,0 +1,41 @@
+export interface AdvanceAjudaBackendResponse {
+  id: string;
+  titulo: string;
+  descricao: string;
+  imagemUrl?: string;
+  imagemTitulo?: string;
+  titulo1: string;
+  descricao1: string;
+  titulo2: string;
+  descricao2: string;
+  titulo3: string;
+  descricao3: string;
+  criadoEm: string;
+  atualizadoEm: string;
+}
+
+export interface CreateAdvanceAjudaPayload {
+  titulo: string;
+  descricao: string;
+  imagemUrl?: string;
+  imagemTitulo?: string;
+  titulo1: string;
+  descricao1: string;
+  titulo2: string;
+  descricao2: string;
+  titulo3: string;
+  descricao3: string;
+}
+
+export interface UpdateAdvanceAjudaPayload {
+  titulo?: string;
+  descricao?: string;
+  imagemUrl?: string;
+  imagemTitulo?: string;
+  titulo1?: string;
+  descricao1?: string;
+  titulo2?: string;
+  descricao2?: string;
+  titulo3?: string;
+  descricao3?: string;
+}

--- a/src/api/websites/components/index.ts
+++ b/src/api/websites/components/index.ts
@@ -52,6 +52,14 @@ export {
 } from "./planinhas";
 
 export {
+  listAdvanceAjuda,
+  getAdvanceAjudaById,
+  createAdvanceAjuda,
+  updateAdvanceAjuda,
+  deleteAdvanceAjuda,
+} from "./advance-ajuda";
+
+export {
   getSliderData,
   getSliderDataClient,
   listSliders,
@@ -129,6 +137,12 @@ export type {
   CreatePlaninhasPayload,
   UpdatePlaninhasPayload,
 } from "./planinhas/types";
+
+export type {
+  AdvanceAjudaBackendResponse,
+  CreateAdvanceAjudaPayload,
+  UpdateAdvanceAjudaPayload,
+} from "./advance-ajuda/types";
 
 export type { BannerBackendResponse, BannerApiResponse } from "./banner/types";
 export {

--- a/src/app/dashboard/config/website/recrutamento/ajuda/AjudaForm.tsx
+++ b/src/app/dashboard/config/website/recrutamento/ajuda/AjudaForm.tsx
@@ -1,0 +1,329 @@
+"use client";
+
+import { useEffect, useState, FormEvent } from "react";
+import {
+  InputCustom,
+  FileUpload,
+  type FileUploadItem,
+  SimpleTextarea,
+  ButtonCustom,
+} from "@/components/ui/custom";
+import { Label } from "@/components/ui/label";
+import { toastCustom } from "@/components/ui/custom/toast";
+import {
+  listAdvanceAjuda,
+  createAdvanceAjuda,
+  updateAdvanceAjuda,
+  type AdvanceAjudaBackendResponse,
+} from "@/api/websites/components";
+import { Skeleton } from "@/components/ui/skeleton";
+import { uploadImage, deleteImage, getImageTitle } from "@/services/upload";
+
+interface AjudaContent {
+  id?: string;
+  titulo: string;
+  descricao: string;
+  imagemUrl?: string;
+  titulo1: string;
+  descricao1: string;
+  titulo2: string;
+  descricao2: string;
+  titulo3: string;
+  descricao3: string;
+}
+
+export default function AjudaForm() {
+  const [content, setContent] = useState<AjudaContent>({
+    titulo: "",
+    descricao: "",
+    imagemUrl: undefined,
+    titulo1: "",
+    descricao1: "",
+    titulo2: "",
+    descricao2: "",
+    titulo3: "",
+    descricao3: "",
+  });
+  const [files, setFiles] = useState<FileUploadItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isFetching, setIsFetching] = useState(true);
+  const [oldImageUrl, setOldImageUrl] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    const applyData = (first: AdvanceAjudaBackendResponse) => {
+      setContent({
+        id: first.id,
+        titulo: first.titulo ?? "",
+        descricao: first.descricao ?? "",
+        imagemUrl: first.imagemUrl ?? undefined,
+        titulo1: first.titulo1 ?? "",
+        descricao1: first.descricao1 ?? "",
+        titulo2: first.titulo2 ?? "",
+        descricao2: first.descricao2 ?? "",
+        titulo3: first.titulo3 ?? "",
+        descricao3: first.descricao3 ?? "",
+      });
+      setOldImageUrl(first.imagemUrl ?? undefined);
+      if (first.imagemUrl) {
+        const item: FileUploadItem = {
+          id: "existing",
+          name: getImageTitle(first.imagemUrl) || "imagem",
+          size: 0,
+          type: "image",
+          status: "completed",
+          uploadDate: new Date(first.criadoEm || Date.now()),
+          previewUrl: first.imagemUrl,
+          uploadedUrl: first.imagemUrl,
+        };
+        setFiles([item]);
+      }
+    };
+
+    const fetchData = async () => {
+      setIsFetching(true);
+      try {
+        const data = await listAdvanceAjuda({ headers: { Accept: "application/json" } });
+        const first = data?.[0];
+        if (first) applyData(first);
+      } catch (err) {
+        toastCustom.error("Erro ao carregar conteúdo");
+      } finally {
+        setIsFetching(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const handleFilesChange = (list: FileUploadItem[]) => {
+    if (list.length === 0) setContent((p) => ({ ...p, imagemUrl: undefined }));
+    setFiles(list);
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (isLoading) return;
+
+    const titulo = content.titulo.trim();
+    const descricao = content.descricao.trim();
+    const t1 = content.titulo1.trim();
+    const d1 = content.descricao1.trim();
+    const t2 = content.titulo2.trim();
+    const d2 = content.descricao2.trim();
+    const t3 = content.titulo3.trim();
+    const d3 = content.descricao3.trim();
+
+    if (!titulo) {
+      toastCustom.error("O título é obrigatório");
+      return;
+    }
+    if (!descricao) {
+      toastCustom.error("A descrição é obrigatória");
+      return;
+    }
+    if (!t1 || !d1 || !t2 || !d2 || !t3 || !d3) {
+      toastCustom.error("Preencha todos os blocos de conteúdo");
+      return;
+    }
+    if (files.length === 0 && !content.imagemUrl) {
+      toastCustom.error("Uma imagem é obrigatória");
+      return;
+    }
+
+    const uploading = files.find((f) => f.status === "uploading");
+    if (uploading) {
+      toastCustom.error("Aguarde o upload da imagem terminar");
+      return;
+    }
+
+    setIsLoading(true);
+    toastCustom.info("Salvando conteúdo...");
+
+    let uploadResult: { url: string; title: string } | undefined;
+    try {
+      const fileItem = files[0];
+      const previousUrl = oldImageUrl;
+      if (fileItem?.file) {
+        try {
+          uploadResult = await uploadImage(fileItem.file, "website/ajuda", previousUrl);
+        } catch (err) {
+          toastCustom.error("Erro no upload da imagem. Tente novamente");
+          return;
+        }
+      } else if (!fileItem && previousUrl) {
+        await deleteImage(previousUrl);
+      } else if (previousUrl) {
+        uploadResult = { url: previousUrl, title: getImageTitle(previousUrl) };
+      }
+
+      const payload = {
+        titulo,
+        descricao,
+        imagemUrl: uploadResult?.url || content.imagemUrl,
+        imagemTitulo: uploadResult?.title,
+        titulo1: t1,
+        descricao1: d1,
+        titulo2: t2,
+        descricao2: d2,
+        titulo3: t3,
+        descricao3: d3,
+      };
+
+      const saved = content.id
+        ? await updateAdvanceAjuda(content.id, payload)
+        : await createAdvanceAjuda(payload);
+
+      toastCustom.success(content.id ? "Conteúdo atualizado com sucesso!" : "Conteúdo criado com sucesso!");
+
+      setContent({
+        id: saved.id,
+        titulo: saved.titulo ?? "",
+        descricao: saved.descricao ?? "",
+        imagemUrl: saved.imagemUrl ?? undefined,
+        titulo1: saved.titulo1 ?? "",
+        descricao1: saved.descricao1 ?? "",
+        titulo2: saved.titulo2 ?? "",
+        descricao2: saved.descricao2 ?? "",
+        titulo3: saved.titulo3 ?? "",
+        descricao3: saved.descricao3 ?? "",
+      });
+
+      if (saved.imagemUrl) {
+        setFiles([
+          {
+            id: saved.id,
+            name: getImageTitle(saved.imagemUrl) || "imagem",
+            size: 0,
+            type: "image",
+            status: "completed",
+            uploadDate: new Date(saved.atualizadoEm || Date.now()),
+            previewUrl: saved.imagemUrl,
+            uploadedUrl: saved.imagemUrl,
+          },
+        ]);
+      } else {
+        setFiles([]);
+      }
+
+      setOldImageUrl(saved.imagemUrl ?? undefined);
+    } catch (err) {
+      const status = (err as any)?.status;
+      let message = "Não foi possível salvar";
+      if (status === 401) message = "Sessão expirada. Faça login novamente";
+      else if (status === 403) message = "Você não tem permissão para esta ação";
+      toastCustom.error(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      {isFetching ? (
+        <div className="space-y-6">
+          <Skeleton className="h-40 w-full" />
+          <Skeleton className="h-10 w-1/3" />
+          <Skeleton className="h-32 w-full" />
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {/* Upload de Imagem */}
+          <div className="space-y-4">
+            <div>
+              <Label className="text-sm font-medium text-gray-700">
+                Imagem <span className="text-red-500">*</span>
+              </Label>
+              <div className="mt-2">
+                <FileUpload
+                  files={files}
+                  multiple={false}
+                  maxFiles={1}
+                  validation={{ accept: [".jpg", ".png", ".webp"] }}
+                  autoUpload={false}
+                  deleteOnRemove={false}
+                  onFilesChange={handleFilesChange}
+                  showProgress={false}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Campos principais */}
+          <div className="space-y-4">
+            <InputCustom
+              label="Título"
+              id="titulo"
+              value={content.titulo}
+              onChange={(e) => setContent((p) => ({ ...p, titulo: e.target.value }))}
+              maxLength={100}
+              required
+            />
+            <div>
+              <Label htmlFor="descricao" className="text-sm font-medium text-gray-700 required">
+                Descrição
+              </Label>
+              <div className="mt-1">
+                <SimpleTextarea
+                  id="descricao"
+                  value={content.descricao}
+                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                    setContent((p) => ({ ...p, descricao: e.target.value }))
+                  }
+                  maxLength={600}
+                  showCharCount
+                  className="min-h-[200px]"
+                  required
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Blocos 1..3 */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="space-y-4">
+                <InputCustom
+                  label={`Título ${i}`}
+                  id={`titulo${i}`}
+                  value={(content as any)[`titulo${i}`]}
+                  onChange={(e) =>
+                    setContent((p) => ({ ...p, [`titulo${i}`]: e.target.value } as any))
+                  }
+                  maxLength={80}
+                  required
+                />
+                <SimpleTextarea
+                  id={`descricao${i}`}
+                  value={(content as any)[`descricao${i}`]}
+                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                    setContent((p) => ({ ...p, [`descricao${i}`]: e.target.value } as any))
+                  }
+                  maxLength={300}
+                  showCharCount
+                  className="min-h-[120px]"
+                  required
+                />
+              </div>
+            ))}
+          </div>
+
+          <div className="pt-4 flex justify-end">
+            <ButtonCustom
+              type="submit"
+              isLoading={isLoading}
+              disabled={
+                isLoading || (!content.imagemUrl && files.length === 0) || files.some((f) => f.status === "uploading")
+              }
+              size="lg"
+              variant="default"
+              className="w-40"
+              withAnimation
+            >
+              Salvar
+            </ButtonCustom>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/config/website/recrutamento/page.tsx
+++ b/src/app/dashboard/config/website/recrutamento/page.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { VerticalTabs, type VerticalTabItem } from "@/components/ui/custom";
 import HeaderForm from "./header/HeaderForm";
 import PlaninhasForm from "./planinhas/PlaninhasForm";
+import AjudaForm from "./ajuda/AjudaForm";
 
 export default function RecrutamentoPage() {
   const items: VerticalTabItem[] = [
@@ -24,6 +25,16 @@ export default function RecrutamentoPage() {
       content: (
         <div className="space-y-6">
           <PlaninhasForm />
+        </div>
+      ),
+    },
+    {
+      value: "ajuda",
+      label: "Ajuda",
+      icon: "HelpCircle",
+      content: (
+        <div className="space-y-6">
+          <AjudaForm />
         </div>
       ),
     },


### PR DESCRIPTION
## Summary
- add API client and routes for AdvanceAjuda content
- create Ajuda form with image upload and fields
- expose Ajuda tab in recrutamento config page
- fix naming to use advanceAjuda across API and form

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b8a056fba8832593b27d36ab7e15c8