### PR TITLE
refactor advance-ajuda hook to use centralized API

### DIFF
--- a/src/api/websites/components/advance-ajuda/index.ts
+++ b/src/api/websites/components/advance-ajuda/index.ts
@@ -1,11 +1,71 @@
 import { websiteRoutes } from "@/api/routes";
 import { apiFetch } from "@/api/client";
-import { apiConfig } from "@/lib/env";
+import { apiConfig, env } from "@/lib/env";
 import type {
   AdvanceAjudaBackendResponse,
   CreateAdvanceAjudaPayload,
   UpdateAdvanceAjudaPayload,
 } from "./types";
+import type { AdvanceAjudaData } from "@/theme/website/components/advance-ajuda/types";
+
+function mapAdvanceAjudaResponse(
+  data: AdvanceAjudaBackendResponse[],
+): AdvanceAjudaData[] {
+  return (data || []).map((item) => ({
+    id: item.id,
+    title: item.titulo,
+    description: item.descricao,
+    imageUrl: item.imagemUrl || "",
+    imageAlt: item.imagemTitulo || "",
+    benefits: [
+      {
+        id: `${item.id}-1`,
+        title: item.titulo1,
+        description: item.descricao1,
+        order: 1,
+      },
+      {
+        id: `${item.id}-2`,
+        title: item.titulo2,
+        description: item.descricao2,
+        order: 2,
+      },
+      {
+        id: `${item.id}-3`,
+        title: item.titulo3,
+        description: item.descricao3,
+        order: 3,
+      },
+    ],
+  }));
+}
+
+export async function getAdvanceAjudaData(): Promise<AdvanceAjudaData[]> {
+  try {
+    const raw = await listAdvanceAjuda({
+      headers: apiConfig.headers,
+      ...apiConfig.cache.medium,
+    });
+    return mapAdvanceAjudaResponse(raw);
+  } catch (error) {
+    if (env.apiFallback === "mock") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+export async function getAdvanceAjudaDataClient(): Promise<AdvanceAjudaData[]> {
+  try {
+    const raw = await listAdvanceAjuda({ headers: apiConfig.headers });
+    return mapAdvanceAjudaResponse(raw);
+  } catch (error) {
+    if (env.apiFallback === "mock") {
+      return [];
+    }
+    throw error;
+  }
+}
 
 function getAuthHeader(): Record<string, string> {
   if (typeof document === "undefined") return {};

--- a/src/api/websites/components/index.ts
+++ b/src/api/websites/components/index.ts
@@ -52,6 +52,8 @@ export {
 } from "./planinhas";
 
 export {
+  getAdvanceAjudaData,
+  getAdvanceAjudaDataClient,
   listAdvanceAjuda,
   getAdvanceAjudaById,
   createAdvanceAjuda,

--- a/src/theme/website/components/advance-ajuda/hooks/useAdvanceAjudaData.ts
+++ b/src/theme/website/components/advance-ajuda/hooks/useAdvanceAjudaData.ts
@@ -3,14 +3,8 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import type {
-  AdvanceAjudaData,
-  AdvanceAjudaApiResponse,
-  AdvanceAjudaBackendResponse,
-} from "../types";
-
-const API_ENDPOINT = "/api/v1/advance-ajuda";
-const API_TIMEOUT = 5000;
+import { getAdvanceAjudaDataClient } from "@/api/websites/components/advance-ajuda";
+import type { AdvanceAjudaData } from "../types";
 
 interface UseAdvanceAjudaDataReturn {
   data: AdvanceAjudaData[];
@@ -24,7 +18,7 @@ interface UseAdvanceAjudaDataReturn {
  */
 export function useAdvanceAjudaData(
   fetchFromApi: boolean = true,
-  staticData?: AdvanceAjudaData[]
+  staticData?: AdvanceAjudaData[],
 ): UseAdvanceAjudaDataReturn {
   const [data, setData] = useState<AdvanceAjudaData[]>(staticData || []);
   const [isLoading, setIsLoading] = useState(fetchFromApi);
@@ -41,76 +35,13 @@ export function useAdvanceAjudaData(
       setIsLoading(true);
       setError(null);
 
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), API_TIMEOUT);
-
-      const response = await fetch(API_ENDPOINT, {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        signal: controller.signal,
-      });
-
-      clearTimeout(timeoutId);
-
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-
-      const result: AdvanceAjudaApiResponse | AdvanceAjudaBackendResponse[] =
-        await response.json();
-
-      const rawData = Array.isArray(result) ? result : result.data;
-      if (!rawData) {
-        throw new Error(
-          (Array.isArray(result) ? "" : result.message) ||
-            "Dados inválidos recebidos da API"
-        );
-      }
-
-      const mappedData: AdvanceAjudaData[] = rawData.map((item) => ({
-        id: item.id,
-        title: item.titulo,
-        description: item.descricao,
-        imageUrl: item.imagemUrl || "",
-        imageAlt: item.imagemTitulo || "",
-        benefits: [
-          {
-            id: `${item.id}-1`,
-            title: item.titulo1,
-            description: item.descricao1,
-            order: 1,
-          },
-          {
-            id: `${item.id}-2`,
-            title: item.titulo2,
-            description: item.descricao2,
-            order: 2,
-          },
-          {
-            id: `${item.id}-3`,
-            title: item.titulo3,
-            description: item.descricao3,
-            order: 3,
-          },
-        ],
-      }));
-
-      setData(mappedData);
+      const result = await getAdvanceAjudaDataClient();
+      setData(result);
     } catch (err) {
       console.error("Erro ao buscar dados de Advance Ajuda:", err);
-
-      if (err instanceof Error) {
-        if (err.name === "AbortError") {
-          setError("Tempo limite excedido.");
-        } else {
-          setError(`Erro na API: ${err.message}`);
-        }
-      } else {
-        setError("Erro desconhecido.");
-      }
-
+      setError(
+        err instanceof Error ? `Erro na API: ${err.message}` : "Erro desconhecido.",
+      );
       setData([]);
     } finally {
       setIsLoading(false);
@@ -128,3 +59,4 @@ export function useAdvanceAjudaData(
     refetch: fetchData,
   };
 }
+

--- a/src/theme/website/components/advance-ajuda/types.ts
+++ b/src/theme/website/components/advance-ajuda/types.ts
@@ -1,20 +1,5 @@
 // src/theme/website/components/advance-ajuda/types.ts
 
-/** Dados retornados da API de Advance Ajuda */
-export interface AdvanceAjudaBackendResponse {
-  id: string;
-  titulo: string;
-  descricao: string;
-  imagemUrl?: string;
-  imagemTitulo?: string;
-  titulo1: string;
-  descricao1: string;
-  titulo2: string;
-  descricao2: string;
-  titulo3: string;
-  descricao3: string;
-}
-
 /** Itens de benefício exibidos no componente */
 export interface BenefitItem {
   id: string;
@@ -32,13 +17,6 @@ export interface AdvanceAjudaData {
   imageAlt: string;
   highlightText?: string;
   benefits: BenefitItem[];
-}
-
-/** Resposta da API proxy interna */
-export interface AdvanceAjudaApiResponse {
-  data: AdvanceAjudaBackendResponse[];
-  success: boolean;
-  message?: string;
 }
 
 /** Propriedades do componente principal */


### PR DESCRIPTION
## Summary
- centralize Advance Ajuda data fetching with API helpers
- update hook to consume shared client
- clean up Advance Ajuda types

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8b39f3bfc8325bbfa66a9f4662c2e