### PR TITLE
refactor service benefits component

### DIFF
--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -35,6 +35,13 @@ export const websiteRoutes = {
     update: (id: string) => `${prefix}/website/recrutamento/${id}`,
     delete: (id: string) => `${prefix}/website/recrutamento/${id}`,
   },
+  treinamento: {
+    list: () => `${prefix}/website/treinamento`,
+    create: () => `${prefix}/website/treinamento`,
+    get: (id: string) => `${prefix}/website/treinamento/${id}`,
+    update: (id: string) => `${prefix}/website/treinamento/${id}`,
+    delete: (id: string) => `${prefix}/website/treinamento/${id}`,
+  },
   diferenciais: {
     list: () => `${prefix}/website/diferenciais`,
     create: () => `${prefix}/website/diferenciais`,

--- a/src/api/websites/components/index.ts
+++ b/src/api/websites/components/index.ts
@@ -62,6 +62,12 @@ export {
 } from "./advance-ajuda";
 
 export {
+  getServiceBenefitsData,
+  getServiceBenefitsDataClient,
+  listServiceBenefits,
+} from "./service-benefits";
+
+export {
   listRecrutamentoSelecao,
   getRecrutamentoSelecaoById,
   createRecrutamentoSelecao,

--- a/src/api/websites/components/service-benefits/index.ts
+++ b/src/api/websites/components/service-benefits/index.ts
@@ -1,0 +1,52 @@
+import { websiteRoutes } from "@/api/routes";
+import { apiFetch } from "@/api/client";
+import { apiConfig, env } from "@/lib/env";
+import type {
+  ServiceBenefitsData,
+  ServiceType,
+} from "@/theme/website/components/service-benefits/types";
+
+const serviceEndpoints: Record<ServiceType, () => string> = {
+  recrutamento: websiteRoutes.recrutamento.list,
+  treinamento: websiteRoutes.treinamento.list,
+};
+
+export async function listServiceBenefits(
+  service: ServiceType,
+  init?: RequestInit,
+): Promise<ServiceBenefitsData[]> {
+  const endpoint = serviceEndpoints[service]();
+  return apiFetch<ServiceBenefitsData[]>(endpoint, {
+    init: init ?? { headers: apiConfig.headers },
+  });
+}
+
+export async function getServiceBenefitsData(
+  service: ServiceType,
+): Promise<ServiceBenefitsData[]> {
+  try {
+    return await listServiceBenefits(service, {
+      headers: apiConfig.headers,
+      ...apiConfig.cache.medium,
+    });
+  } catch (error) {
+    if (env.apiFallback === "mock") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+export async function getServiceBenefitsDataClient(
+  service: ServiceType,
+): Promise<ServiceBenefitsData[]> {
+  try {
+    return await listServiceBenefits(service, { headers: apiConfig.headers });
+  } catch (error) {
+    if (env.apiFallback === "mock") {
+      return [];
+    }
+    throw error;
+  }
+}
+

--- a/src/app/website/recrutamento/page.tsx
+++ b/src/app/website/recrutamento/page.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import HeaderPages from "@/theme/website/components/header-pages";
 import ProblemSolutionSection from "@/theme/website/components/problem-solution-section";
 import AdvanceAjuda from "@/theme/website/components/advance-ajuda";
+import ServiceBenefits from "@/theme/website/components/service-benefits";
 
 export const metadata = {
   title: "Recrutamento & Seleção",
@@ -13,6 +14,7 @@ export default function RecrutamentoPage() {
       <HeaderPages fetchFromApi={true} currentPage="/recrutamento" />
       <ProblemSolutionSection fetchFromApi={true} />
       <AdvanceAjuda fetchFromApi={true} />
+      <ServiceBenefits fetchFromApi={true} service="recrutamento" />
     </div>
   );
 }

--- a/src/app/website/solucoes/recrutamento-selecao/page.tsx
+++ b/src/app/website/solucoes/recrutamento-selecao/page.tsx
@@ -103,6 +103,7 @@ export default function RecrutamentoPage() {
 
       <ServiceBenefits
         fetchFromApi={false}
+        service="recrutamento"
         onDataLoaded={(data) => {
           console.log("Benefícios dos serviços carregados:", data);
         }}

--- a/src/app/website/solucoes/treinamento-company/page.tsx
+++ b/src/app/website/solucoes/treinamento-company/page.tsx
@@ -77,7 +77,7 @@ export default function TreinamentoPage() {
       />
       <TrainingResults fetchFromApi={true} />
 
-      <ServiceBenefits fetchFromApi={true} />
+      <ServiceBenefits fetchFromApi={true} service="treinamento" />
 
       <CommunicationHighlights fetchFromApi={true} />
 

--- a/src/app/website/treinamento/page.tsx
+++ b/src/app/website/treinamento/page.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import HeaderPages from "@/theme/website/components/header-pages";
+import ServiceBenefits from "@/theme/website/components/service-benefits";
+
+export const metadata = {
+  title: "Treinamento",
+};
+
+export default function TreinamentoPage() {
+  return (
+    <div className="min-h-screen">
+      <HeaderPages fetchFromApi={true} currentPage="/treinamento" />
+      <ServiceBenefits fetchFromApi={true} service="treinamento" />
+    </div>
+  );
+}
+

--- a/src/theme/website/components/service-benefits/ServiceBenefits.tsx
+++ b/src/theme/website/components/service-benefits/ServiceBenefits.tsx
@@ -17,7 +17,7 @@ import type { ServiceBenefitsProps } from "./types";
  * @example
  * ```tsx
  * // Uso básico com dados da API
- * <ServiceBenefits />
+ * <ServiceBenefits service="recrutamento" />
  *
  * // Com dados estáticos
  * <ServiceBenefits
@@ -28,14 +28,16 @@ import type { ServiceBenefitsProps } from "./types";
  */
 const ServiceBenefits: React.FC<ServiceBenefitsProps> = ({
   className,
+  service,
   fetchFromApi = true,
   staticData,
   onDataLoaded,
   onError,
 }) => {
   const { data, isLoading, error, refetch } = useServiceBenefits(
+    service,
     fetchFromApi,
-    staticData
+    staticData,
   );
 
   // Callbacks quando dados são carregados ou há erro

--- a/src/theme/website/components/service-benefits/constants/index.ts
+++ b/src/theme/website/components/service-benefits/constants/index.ts
@@ -92,12 +92,6 @@ export const DEFAULT_SERVICE_BENEFITS_DATA: ServiceBenefitsData[] = [
  * Configurações do componente
  */
 export const SERVICE_BENEFITS_CONFIG = {
-  api: {
-    endpoint: "/api/service-benefits",
-    timeout: 5000,
-    retryAttempts: 3,
-    retryDelay: 1000,
-  },
   animation: {
     staggerDelay: 150, // Delay entre benefícios
     duration: 400,

--- a/src/theme/website/components/service-benefits/index.ts
+++ b/src/theme/website/components/service-benefits/index.ts
@@ -15,6 +15,7 @@ export type {
   ServiceBenefitsData,
   ServiceBenefitsProps,
   ServiceBenefitsItemProps,
+  ServiceType,
 } from "./types";
 export {
   DEFAULT_SERVICE_BENEFITS_DATA,

--- a/src/theme/website/components/service-benefits/types/index.ts
+++ b/src/theme/website/components/service-benefits/types/index.ts
@@ -12,6 +12,11 @@ export interface ServiceBenefit {
 }
 
 /**
+ * Tipos de serviços suportados pelo componente
+ */
+export type ServiceType = "recrutamento" | "treinamento";
+
+/**
  * Interface para dados da seção de benefícios vindos da API
  */
 export interface ServiceBenefitsData {
@@ -40,6 +45,10 @@ export interface ServiceBenefitsApiResponse {
  */
 export interface ServiceBenefitsProps {
   className?: string;
+  /**
+   * Tipo do serviço para buscar os benefícios correspondentes
+   */
+  service: ServiceType;
   /**
    * Se deve carregar dados da API
    * @default true


### PR DESCRIPTION
## Summary
- refactor ServiceBenefits to accept service-specific API fetch
- add training API route and client
- use ServiceBenefits on recrutamento and new treinamento pages

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b9db40b6988325bfe7a7536b01f12c