### PR TITLE
feat: add sistema tab and API

### DIFF
--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -77,6 +77,13 @@ export const websiteRoutes = {
     update: (id: string) => `${prefix}/website/advance-ajuda/${id}`,
     delete: (id: string) => `${prefix}/website/advance-ajuda/${id}`,
   },
+  sistema: {
+    list: () => `${prefix}/website/sistema`,
+    create: () => `${prefix}/website/sistema`,
+    get: (id: string) => `${prefix}/website/sistema/${id}`,
+    update: (id: string) => `${prefix}/website/sistema/${id}`,
+    delete: (id: string) => `${prefix}/website/sistema/${id}`,
+  },
   sobreEmpresa: {
     list: () => `${prefix}/website/sobre-empresa`,
     create: () => `${prefix}/website/sobre-empresa`,

--- a/src/api/websites/components/index.ts
+++ b/src/api/websites/components/index.ts
@@ -62,6 +62,14 @@ export {
 } from "./advance-ajuda";
 
 export {
+  listSistema,
+  getSistemaById,
+  createSistema,
+  updateSistema,
+  deleteSistema,
+} from "./sistema";
+
+export {
   getServiceBenefitsData,
   getServiceBenefitsDataClient,
   listServiceBenefits,
@@ -159,6 +167,12 @@ export type {
   CreateAdvanceAjudaPayload,
   UpdateAdvanceAjudaPayload,
 } from "./advance-ajuda/types";
+
+export type {
+  SistemaBackendResponse,
+  CreateSistemaPayload,
+  UpdateSistemaPayload,
+} from "./sistema/types";
 
 export type {
   RecrutamentoSelecaoBackendResponse,

--- a/src/api/websites/components/sistema/index.ts
+++ b/src/api/websites/components/sistema/index.ts
@@ -1,0 +1,74 @@
+import { websiteRoutes } from "@/api/routes";
+import { apiFetch } from "@/api/client";
+import { apiConfig } from "@/lib/env";
+import type {
+  SistemaBackendResponse,
+  CreateSistemaPayload,
+  UpdateSistemaPayload,
+} from "./types";
+
+function getAuthHeader(): Record<string, string> {
+  if (typeof document === "undefined") return {};
+  const token = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith("token="))
+    ?.split("=")[1];
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export async function listSistema(init?: RequestInit): Promise<SistemaBackendResponse[]> {
+  return apiFetch<SistemaBackendResponse[]>(websiteRoutes.sistema.list(), {
+    init: init ?? { headers: apiConfig.headers },
+  });
+}
+
+export async function getSistemaById(id: string): Promise<SistemaBackendResponse> {
+  return apiFetch<SistemaBackendResponse>(websiteRoutes.sistema.get(id), {
+    init: { headers: apiConfig.headers },
+  });
+}
+
+export async function createSistema(
+  data: CreateSistemaPayload,
+): Promise<SistemaBackendResponse> {
+  return apiFetch<SistemaBackendResponse>(websiteRoutes.sistema.create(), {
+    init: {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: apiConfig.headers.Accept,
+        ...getAuthHeader(),
+      },
+      body: JSON.stringify(data),
+    },
+    cache: "no-cache",
+  });
+}
+
+export async function updateSistema(
+  id: string,
+  data: UpdateSistemaPayload,
+): Promise<SistemaBackendResponse> {
+  return apiFetch<SistemaBackendResponse>(websiteRoutes.sistema.update(id), {
+    init: {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: apiConfig.headers.Accept,
+        ...getAuthHeader(),
+      },
+      body: JSON.stringify(data),
+    },
+    cache: "no-cache",
+  });
+}
+
+export async function deleteSistema(id: string): Promise<void> {
+  await apiFetch<void>(websiteRoutes.sistema.delete(id), {
+    init: {
+      method: "DELETE",
+      headers: { Accept: apiConfig.headers.Accept, ...getAuthHeader() },
+    },
+    cache: "no-cache",
+  });
+}

--- a/src/api/websites/components/sistema/types.ts
+++ b/src/api/websites/components/sistema/types.ts
@@ -1,0 +1,17 @@
+export interface SistemaBackendResponse {
+  id: string;
+  titulo: string;
+  descricao: string;
+  subtitulo: string;
+  etapa1Titulo: string;
+  etapa1Descricao: string;
+  etapa2Titulo: string;
+  etapa2Descricao: string;
+  etapa3Titulo: string;
+  etapa3Descricao: string;
+  criadoEm?: string;
+  atualizadoEm?: string;
+}
+
+export type CreateSistemaPayload = Omit<SistemaBackendResponse, "id" | "criadoEm" | "atualizadoEm">;
+export type UpdateSistemaPayload = CreateSistemaPayload;

--- a/src/app/dashboard/config/website/recrutamento/page.tsx
+++ b/src/app/dashboard/config/website/recrutamento/page.tsx
@@ -6,6 +6,7 @@ import HeaderForm from "./header/HeaderForm";
 import PlaninhasForm from "./planinhas/PlaninhasForm";
 import AjudaForm from "./ajuda/AjudaForm";
 import RecrutamentoForm from "./recrutamento/RecrutamentoForm";
+import SistemaForm from "./sistema/SistemaForm";
 
 export default function RecrutamentoPage() {
   const items: VerticalTabItem[] = [
@@ -43,13 +44,23 @@ export default function RecrutamentoPage() {
         value: "ajuda",
         label: "Ajuda",
         icon: "HelpCircle",
-      content: (
-        <div className="space-y-6">
-          <AjudaForm />
-        </div>
-      ),
-    },
-  ];
+        content: (
+          <div className="space-y-6">
+            <AjudaForm />
+          </div>
+        ),
+      },
+      {
+        value: "sistema",
+        label: "Sistema",
+        icon: "Cog",
+        content: (
+          <div className="space-y-6">
+            <SistemaForm />
+          </div>
+        ),
+      },
+    ];
 
   return (
     <div className="bg-white rounded-3xl p-5 h-full min-h-[calc(100vh-8rem)] flex flex-col">

--- a/src/app/dashboard/config/website/recrutamento/sistema/SistemaForm.tsx
+++ b/src/app/dashboard/config/website/recrutamento/sistema/SistemaForm.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useEffect, useState, FormEvent } from "react";
+import { InputCustom, SimpleTextarea, ButtonCustom } from "@/components/ui/custom";
+import { Label } from "@/components/ui/label";
+import { toastCustom } from "@/components/ui/custom/toast";
+import {
+  listSistema,
+  createSistema,
+  updateSistema,
+  type SistemaBackendResponse,
+} from "@/api/websites/components";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface SistemaContent {
+  id?: string;
+  titulo: string;
+  descricao: string;
+  subtitulo: string;
+  etapa1Titulo: string;
+  etapa1Descricao: string;
+  etapa2Titulo: string;
+  etapa2Descricao: string;
+  etapa3Titulo: string;
+  etapa3Descricao: string;
+}
+
+export default function SistemaForm() {
+  const [content, setContent] = useState<SistemaContent>({
+    titulo: "",
+    descricao: "",
+    subtitulo: "",
+    etapa1Titulo: "",
+    etapa1Descricao: "",
+    etapa2Titulo: "",
+    etapa2Descricao: "",
+    etapa3Titulo: "",
+    etapa3Descricao: "",
+  });
+  const [isLoading, setIsLoading] = useState(false);
+  const [isFetching, setIsFetching] = useState(true);
+
+  useEffect(() => {
+    const applyData = (data: SistemaBackendResponse) => {
+      setContent({
+        id: data.id,
+        titulo: data.titulo ?? "",
+        descricao: data.descricao ?? "",
+        subtitulo: data.subtitulo ?? "",
+        etapa1Titulo: data.etapa1Titulo ?? "",
+        etapa1Descricao: data.etapa1Descricao ?? "",
+        etapa2Titulo: data.etapa2Titulo ?? "",
+        etapa2Descricao: data.etapa2Descricao ?? "",
+        etapa3Titulo: data.etapa3Titulo ?? "",
+        etapa3Descricao: data.etapa3Descricao ?? "",
+      });
+    };
+
+    const fetchData = async () => {
+      setIsFetching(true);
+      try {
+        const list = await listSistema({ headers: { Accept: "application/json" } });
+        const first = list?.[0];
+        if (first) applyData(first);
+      } catch (err) {
+        toastCustom.error("Erro ao carregar conteúdo");
+      } finally {
+        setIsFetching(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (isLoading) return;
+
+    const {
+      titulo,
+      descricao,
+      subtitulo,
+      etapa1Titulo,
+      etapa1Descricao,
+      etapa2Titulo,
+      etapa2Descricao,
+      etapa3Titulo,
+      etapa3Descricao,
+    } = content;
+
+    if (!titulo.trim()) {
+      toastCustom.error("O título é obrigatório");
+      return;
+    }
+    if (!descricao.trim()) {
+      toastCustom.error("A descrição é obrigatória");
+      return;
+    }
+    if (!subtitulo.trim()) {
+      toastCustom.error("O subtítulo é obrigatório");
+      return;
+    }
+
+    const blocks = [
+      { t: etapa1Titulo, d: etapa1Descricao, i: 1 },
+      { t: etapa2Titulo, d: etapa2Descricao, i: 2 },
+      { t: etapa3Titulo, d: etapa3Descricao, i: 3 },
+    ];
+    for (const b of blocks) {
+      if (!b.t.trim() || !b.d.trim()) {
+        toastCustom.error(`Preencha título e descrição da etapa ${b.i}`);
+        return;
+      }
+    }
+
+    setIsLoading(true);
+    try {
+      const payload = {
+        titulo: titulo.trim(),
+        descricao: descricao.trim(),
+        subtitulo: subtitulo.trim(),
+        etapa1Titulo: etapa1Titulo.trim(),
+        etapa1Descricao: etapa1Descricao.trim(),
+        etapa2Titulo: etapa2Titulo.trim(),
+        etapa2Descricao: etapa2Descricao.trim(),
+        etapa3Titulo: etapa3Titulo.trim(),
+        etapa3Descricao: etapa3Descricao.trim(),
+      };
+
+      const saved = content.id
+        ? await updateSistema(content.id, payload)
+        : await createSistema(payload);
+
+      toastCustom.success(
+        content.id
+          ? "Conteúdo atualizado com sucesso!"
+          : "Conteúdo criado com sucesso!",
+      );
+
+      setContent({
+        id: saved.id,
+        titulo: saved.titulo ?? "",
+        descricao: saved.descricao ?? "",
+        subtitulo: saved.subtitulo ?? "",
+        etapa1Titulo: saved.etapa1Titulo ?? "",
+        etapa1Descricao: saved.etapa1Descricao ?? "",
+        etapa2Titulo: saved.etapa2Titulo ?? "",
+        etapa2Descricao: saved.etapa2Descricao ?? "",
+        etapa3Titulo: saved.etapa3Titulo ?? "",
+        etapa3Descricao: saved.etapa3Descricao ?? "",
+      });
+    } catch (err) {
+      toastCustom.error("Erro ao salvar conteúdo");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (isFetching) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-1/2" />
+        <Skeleton className="h-24 w-full" />
+        {[...Array(7)].map((_, i) => (
+          <Skeleton key={i} className="h-10 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <InputCustom
+        label="Título"
+        id="titulo"
+        value={content.titulo}
+        onChange={(e) => setContent((p) => ({ ...p, titulo: e.target.value }))}
+        maxLength={100}
+        required
+      />
+
+      <div>
+        <Label htmlFor="descricao" className="text-sm font-medium text-gray-700 required">
+          Descrição
+        </Label>
+        <div className="mt-1">
+          <SimpleTextarea
+            id="descricao"
+            value={content.descricao}
+            onChange={(e) => setContent((p) => ({ ...p, descricao: e.target.value }))}
+            maxLength={600}
+            showCharCount
+            className="min-h-[200px]"
+            required
+          />
+        </div>
+      </div>
+
+      <InputCustom
+        label="Subtítulo"
+        id="subtitulo"
+        value={content.subtitulo}
+        onChange={(e) => setContent((p) => ({ ...p, subtitulo: e.target.value }))}
+        maxLength={150}
+        required
+      />
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="space-y-4">
+            <InputCustom
+              label={`Etapa ${i} - Título`}
+              id={`etapa${i}Titulo`}
+              value={(content as any)[`etapa${i}Titulo`]}
+              onChange={(e) =>
+                setContent((p) => ({ ...p, [`etapa${i}Titulo`]: e.target.value } as any))
+              }
+              maxLength={80}
+              required
+            />
+            <SimpleTextarea
+              label={`Etapa ${i} - Descrição`}
+              id={`etapa${i}Descricao`}
+              value={(content as any)[`etapa${i}Descricao`]}
+              onChange={(e) =>
+                setContent((p) => ({ ...p, [`etapa${i}Descricao`]: e.target.value } as any))
+              }
+              maxLength={300}
+              showCharCount
+              className="min-h-[120px]"
+              required
+            />
+          </div>
+        ))}
+      </div>
+
+      <div className="pt-4 flex justify-end">
+        <ButtonCustom
+          type="submit"
+          isLoading={isLoading}
+          disabled={isLoading}
+          size="lg"
+          variant="default"
+          className="w-40"
+          withAnimation
+        >
+          Salvar
+        </ButtonCustom>
+      </div>
+    </form>
+  );
+}

--- a/src/app/website/recrutamento/page.tsx
+++ b/src/app/website/recrutamento/page.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import HeaderPages from "@/theme/website/components/header-pages";
 import ProblemSolutionSection from "@/theme/website/components/problem-solution-section";
 import AdvanceAjuda from "@/theme/website/components/advance-ajuda";
+import ProcessSteps from "@/theme/website/components/process-steps";
 import ServiceBenefits from "@/theme/website/components/service-benefits";
 
 export const metadata = {
@@ -14,6 +15,7 @@ export default function RecrutamentoPage() {
       <HeaderPages fetchFromApi={true} currentPage="/recrutamento" />
       <ProblemSolutionSection fetchFromApi={true} />
       <AdvanceAjuda fetchFromApi={true} />
+      <ProcessSteps />
       <ServiceBenefits fetchFromApi={true} service="recrutamentoSelecao" />
     </div>
   );

--- a/src/app/website/solucoes/recrutamento-selecao/page.tsx
+++ b/src/app/website/solucoes/recrutamento-selecao/page.tsx
@@ -112,7 +112,7 @@ export default function RecrutamentoPage() {
         }}
       />
 
-      <ProcessSteps fetchFromApi={false} />
+      <ProcessSteps />
 
       <PricingPlans
         title="Planos de Recrutamento"

--- a/src/theme/website/components/process-steps/ProcessSteps.tsx
+++ b/src/theme/website/components/process-steps/ProcessSteps.tsx
@@ -8,36 +8,18 @@ import { ProcessStepItem } from "./components/ProcessStepItem";
 import { useProcessData } from "./hooks/useProcessData";
 import { ImageNotFound } from "@/components/ui/custom/image-not-found";
 import { ButtonCustom } from "@/components/ui/custom/button";
-import { PROCESS_CONFIG } from "./constants";
 import type { ProcessStepsProps } from "./types";
 
 /**
  * Componente ProcessSteps
  * Exibe um processo em etapas numeradas com título e descrição
- *
- * @example
- * ```tsx
- * // Uso básico com dados da API
- * <ProcessSteps />
- *
- * // Com dados estáticos
- * <ProcessSteps
- *   fetchFromApi={false}
- *   staticData={myProcessData}
- * />
- * ```
  */
 const ProcessSteps: React.FC<ProcessStepsProps> = ({
   className,
-  fetchFromApi = true,
-  staticData,
   onDataLoaded,
   onError,
 }) => {
-  const { data, isLoading, error, refetch } = useProcessData(
-    fetchFromApi,
-    staticData
-  );
+  const { data, isLoading, error, refetch } = useProcessData();
 
   // Callbacks quando dados são carregados ou há erro
   useEffect(() => {
@@ -82,7 +64,7 @@ const ProcessSteps: React.FC<ProcessStepsProps> = ({
   }
 
   // Estado de erro
-  if (error && (!data || !data.steps || data.steps.length === 0)) {
+  if (error || !data || data.steps.length === 0) {
     return (
       <section
         className={cn("bg-[var(--primary-color)] py-20 text-white", className)}
@@ -97,18 +79,15 @@ const ProcessSteps: React.FC<ProcessStepsProps> = ({
           />
           <p className="text-white/80 mb-4 max-w-md mx-auto">
             Não foi possível carregar as etapas do processo.
-            {error.includes("padrão") ? " Exibindo dados de exemplo." : ""}
           </p>
-          {!error.includes("padrão") && (
-            <ButtonCustom
-              onClick={refetch}
-              variant="secondary"
-              icon="RefreshCw"
-              className="bg-white/10 hover:bg-white/20 text-white border-white/30"
-            >
-              Tentar Novamente
-            </ButtonCustom>
-          )}
+          <ButtonCustom
+            onClick={refetch}
+            variant="secondary"
+            icon="RefreshCw"
+            className="bg-white/10 hover:bg-white/20 text-white border-white/30"
+          >
+            Tentar Novamente
+          </ButtonCustom>
         </div>
       </section>
     );
@@ -155,13 +134,6 @@ const ProcessSteps: React.FC<ProcessStepsProps> = ({
           ))}
         </div>
       </div>
-
-      {/* Indicador de erro sutil se houver fallback */}
-      {error && data.steps.length > 0 && (
-        <div className="absolute bottom-4 right-4 text-xs text-white/50">
-          Dados de exemplo
-        </div>
-      )}
     </section>
   );
 };

--- a/src/theme/website/components/process-steps/constants/index.ts
+++ b/src/theme/website/components/process-steps/constants/index.ts
@@ -1,57 +1,9 @@
 // src/theme/website/components/process-steps/constants/index.ts
 
-import type { ProcessSectionData } from "../types";
-
 /**
- * Dados padrão para fallback quando a API falha
- */
-export const DEFAULT_PROCESS_DATA: ProcessSectionData = {
-  id: "recruitment-process",
-  subtitle: "Como Funciona?",
-  title: "Feito para ser simples!",
-  description:
-    "Você não precisa ser um expert para utilizar o nosso sistema de recrutamento.",
-  steps: [
-    {
-      id: "step-1",
-      number: 1,
-      title: "Crie a conta da sua Empresa",
-      description: "Cadastre sua empresa e depois insira outros recrutadores.",
-      icon: "Building2",
-      order: 1,
-      isActive: true,
-    },
-    {
-      id: "step-2",
-      number: 2,
-      title: "Publique sua Primeira Vaga",
-      description: "Em menos de 5 minutos você insere os dados das suas vagas.",
-      icon: "FileText",
-      order: 2,
-      isActive: true,
-    },
-    {
-      id: "step-3",
-      number: 3,
-      title: "Receba seus Candidatos",
-      description: "Tudo estará pronto para que seus talentos se cadastrem.",
-      icon: "Users",
-      order: 3,
-      isActive: true,
-    },
-  ],
-};
-
-/**
- * Configurações do componente
+ * Configurações do componente ProcessSteps
  */
 export const PROCESS_CONFIG = {
-  api: {
-    endpoint: "/api/process/steps",
-    timeout: 5000,
-    retryAttempts: 3,
-    retryDelay: 1000,
-  },
   animation: {
     staggerDelay: 150, // Delay entre etapas
     duration: 600,

--- a/src/theme/website/components/process-steps/hooks/useProcessData.ts
+++ b/src/theme/website/components/process-steps/hooks/useProcessData.ts
@@ -3,11 +3,11 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import type { ProcessSectionData, ProcessApiResponse } from "../types";
-import { DEFAULT_PROCESS_DATA, PROCESS_CONFIG } from "../constants";
+import { listSistema } from "@/api/websites/components/sistema";
+import type { ProcessSectionData } from "../types";
 
 interface UseProcessDataReturn {
-  data: ProcessSectionData;
+  data: ProcessSectionData | null;
   isLoading: boolean;
   error: string | null;
   refetch: () => void;
@@ -16,81 +16,64 @@ interface UseProcessDataReturn {
 /**
  * Hook para buscar dados das etapas do processo da API
  */
-export function useProcessData(
-  fetchFromApi: boolean = true,
-  staticData?: ProcessSectionData
-): UseProcessDataReturn {
-  const [data, setData] = useState<ProcessSectionData>(
-    staticData || DEFAULT_PROCESS_DATA
-  );
-  const [isLoading, setIsLoading] = useState(fetchFromApi);
+export function useProcessData(): UseProcessDataReturn {
+  const [data, setData] = useState<ProcessSectionData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const fetchData = useCallback(async () => {
-    if (!fetchFromApi) {
-      setData(staticData || DEFAULT_PROCESS_DATA);
-      setIsLoading(false);
-      return;
-    }
-
     try {
       setIsLoading(true);
       setError(null);
 
-      const controller = new AbortController();
-      const timeoutId = setTimeout(
-        () => controller.abort(),
-        PROCESS_CONFIG.api.timeout
-      );
+      const result = await listSistema();
+      const first = result?.[0];
 
-      const response = await fetch(PROCESS_CONFIG.api.endpoint, {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        signal: controller.signal,
-      });
-
-      clearTimeout(timeoutId);
-
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      if (!first) {
+        throw new Error("Dados inexistentes");
       }
 
-      const result: ProcessApiResponse = await response.json();
-
-      if (!result.success || !result.data) {
-        throw new Error(result.message || "Dados inválidos recebidos da API");
-      }
-
-      // Filtra apenas etapas ativas e ordena
-      const processData = {
-        ...result.data,
-        steps: result.data.steps
-          .filter((step) => step.isActive)
-          .sort((a, b) => a.order - b.order),
+      const processData: ProcessSectionData = {
+        id: first.id,
+        subtitle: first.subtitulo,
+        title: first.titulo,
+        description: first.descricao,
+        steps: [
+          {
+            id: `${first.id}-step1`,
+            number: 1,
+            title: first.etapa1Titulo,
+            description: first.etapa1Descricao,
+            order: 1,
+            isActive: true,
+          },
+          {
+            id: `${first.id}-step2`,
+            number: 2,
+            title: first.etapa2Titulo,
+            description: first.etapa2Descricao,
+            order: 2,
+            isActive: true,
+          },
+          {
+            id: `${first.id}-step3`,
+            number: 3,
+            title: first.etapa3Titulo,
+            description: first.etapa3Descricao,
+            order: 3,
+            isActive: true,
+          },
+        ].filter((step) => step.title && step.description),
       };
 
       setData(processData);
     } catch (err) {
       console.error("Erro ao buscar dados das etapas do processo:", err);
-
-      if (err instanceof Error) {
-        if (err.name === "AbortError") {
-          setError("Tempo limite excedido. Usando dados padrão.");
-        } else {
-          setError(`Erro na API: ${err.message}. Usando dados padrão.`);
-        }
-      } else {
-        setError("Erro desconhecido. Usando dados padrão.");
-      }
-
-      // Fallback para dados padrão
-      setData(DEFAULT_PROCESS_DATA);
+      setError("Não foi possível carregar os dados.");
     } finally {
       setIsLoading(false);
     }
-  }, [fetchFromApi, staticData]);
+  }, []);
 
   useEffect(() => {
     fetchData();

--- a/src/theme/website/components/process-steps/index.ts
+++ b/src/theme/website/components/process-steps/index.ts
@@ -16,4 +16,4 @@ export type {
   ProcessStepsProps,
   ProcessStepItemProps,
 } from "./types";
-export { DEFAULT_PROCESS_DATA, PROCESS_CONFIG } from "./constants";
+export { PROCESS_CONFIG } from "./constants";

--- a/src/theme/website/components/process-steps/types/index.ts
+++ b/src/theme/website/components/process-steps/types/index.ts
@@ -27,28 +27,10 @@ export interface ProcessSectionData {
 }
 
 /**
- * Interface para resposta da API
- */
-export interface ProcessApiResponse {
-  data: ProcessSectionData;
-  success: boolean;
-  message?: string;
-}
-
-/**
  * Props do componente principal
  */
 export interface ProcessStepsProps {
   className?: string;
-  /**
-   * Se deve carregar dados da API
-   * @default true
-   */
-  fetchFromApi?: boolean;
-  /**
-   * Dados estáticos (usado quando fetchFromApi é false)
-   */
-  staticData?: ProcessSectionData;
   /**
    * Callback quando os dados são carregados
    */


### PR DESCRIPTION
## Summary
- add Sistema tab to recruitment config with form
- expose Sistema API routes and helpers
- load recruitment process steps from Sistema API on website

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9ededabbc8325bd8ef7ad1dd712db