### PR TITLE
feat: add treinamento config and API

### DIFF
--- a/src/api/websites/components/index.ts
+++ b/src/api/websites/components/index.ts
@@ -82,6 +82,13 @@ export {
   updateRecrutamentoSelecao,
   deleteRecrutamentoSelecao,
 } from "./recrutamento-selecao";
+export {
+  listTreinamentoCompany,
+  getTreinamentoCompanyById,
+  createTreinamentoCompany,
+  updateTreinamentoCompany,
+  deleteTreinamentoCompany,
+} from "./treinamento-company";
 
 export {
   getSliderData,
@@ -179,6 +186,11 @@ export type {
   CreateRecrutamentoSelecaoPayload,
   UpdateRecrutamentoSelecaoPayload,
 } from "./recrutamento-selecao/types";
+export type {
+  TreinamentoCompanyBackendResponse,
+  CreateTreinamentoCompanyPayload,
+  UpdateTreinamentoCompanyPayload,
+} from "./treinamento-company/types";
 
 export type { BannerBackendResponse, BannerApiResponse } from "./banner/types";
 export {

--- a/src/api/websites/components/service-benefits/index.ts
+++ b/src/api/websites/components/service-benefits/index.ts
@@ -7,6 +7,7 @@ import type {
   ServiceBenefit,
 } from "@/theme/website/components/service-benefits/types";
 import type { RecrutamentoSelecaoBackendResponse } from "../recrutamento-selecao/types";
+import type { TreinamentoCompanyBackendResponse } from "../treinamento-company/types";
 
 function mapRecrutamentoSelecao(
   items: RecrutamentoSelecaoBackendResponse[],
@@ -48,21 +49,45 @@ async function fetchRecrutamentoSelecao(): Promise<ServiceBenefitsData[]> {
   return mapRecrutamentoSelecao(res);
 }
 
+function mapTreinamentoCompany(
+  items: TreinamentoCompanyBackendResponse[],
+): ServiceBenefitsData[] {
+  const first = items?.[0];
+  if (!first) return [];
+
+  const benefits = [first.titulo1, first.titulo2, first.titulo3, first.titulo4]
+    .filter(Boolean)
+    .map((text, idx) => ({
+      id: `benefit-${idx + 1}`,
+      text: text as string,
+      gradientType: (idx % 2 === 0
+        ? "secondary"
+        : "primary") as ServiceBenefit["gradientType"],
+      order: idx + 1,
+      isActive: true,
+    }));
+
+  const data: ServiceBenefitsData = {
+    id: first.id || "treinamento-company",
+    title: first.titulo,
+    subtitle: undefined,
+    description: first.descricao,
+    imageUrl: first.imagemUrl || "/images/home/banner_site_3.webp",
+    imageAlt:
+      first.imagemTitulo || "Profissionais participando de treinamento in company",
+    benefits,
+    order: 1,
+    isActive: true,
+  };
+  return [data];
+}
+
 async function fetchTreinamentoCompany(): Promise<ServiceBenefitsData[]> {
-  // Caso a API de treinamento-company já entregue no formato final,
-  // apenas retornamos os dados. Se não, faremos um mapeamento similar ao acima
-  // quando o contrato estiver definido.
-  const res = await apiFetch<any[]>(websiteRoutes.treinamentoCompany.list(), {
-    init: { headers: apiConfig.headers },
-  });
-
-  // Se já vier no formato esperado, valide superficialmente
-  if (Array.isArray(res) && res.length > 0 && "benefits" in (res[0] || {})) {
-    return res as ServiceBenefitsData[];
-  }
-
-  // Sem dados ou contrato diferente -> lista vazia (hook fará fallback)
-  return [];
+  const res = await apiFetch<TreinamentoCompanyBackendResponse[]>(
+    websiteRoutes.treinamentoCompany.list(),
+    { init: { headers: apiConfig.headers } },
+  );
+  return mapTreinamentoCompany(res);
 }
 
 export async function listServiceBenefits(

--- a/src/api/websites/components/treinamento-company/index.ts
+++ b/src/api/websites/components/treinamento-company/index.ts
@@ -1,0 +1,80 @@
+import { websiteRoutes } from "@/api/routes";
+import { apiFetch } from "@/api/client";
+import { apiConfig } from "@/lib/env";
+import type {
+  TreinamentoCompanyBackendResponse,
+  CreateTreinamentoCompanyPayload,
+  UpdateTreinamentoCompanyPayload,
+} from "./types";
+
+function getAuthHeader(): Record<string, string> {
+  if (typeof document === "undefined") return {};
+  const token = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith("token="))
+    ?.split("=")[1];
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export async function listTreinamentoCompany(
+  init?: RequestInit,
+): Promise<TreinamentoCompanyBackendResponse[]> {
+  return apiFetch<TreinamentoCompanyBackendResponse[]>(
+    websiteRoutes.treinamentoCompany.list(),
+    {
+      init: init ?? { headers: apiConfig.headers },
+    },
+  );
+}
+
+export async function getTreinamentoCompanyById(
+  id: string,
+): Promise<TreinamentoCompanyBackendResponse> {
+  return apiFetch<TreinamentoCompanyBackendResponse>(
+    websiteRoutes.treinamentoCompany.get(id),
+    { init: { headers: apiConfig.headers } },
+  );
+}
+
+export async function createTreinamentoCompany(
+  data: CreateTreinamentoCompanyPayload,
+): Promise<TreinamentoCompanyBackendResponse> {
+  const headers = {
+    "Content-Type": "application/json",
+    Accept: apiConfig.headers.Accept,
+    ...getAuthHeader(),
+  } as Record<string, string>;
+  return apiFetch<TreinamentoCompanyBackendResponse>(
+    websiteRoutes.treinamentoCompany.create(),
+    {
+      init: { method: "POST", body: JSON.stringify(data), headers },
+      cache: "no-cache",
+    },
+  );
+}
+
+export async function updateTreinamentoCompany(
+  id: string,
+  data: UpdateTreinamentoCompanyPayload,
+): Promise<TreinamentoCompanyBackendResponse> {
+  const headers = {
+    "Content-Type": "application/json",
+    Accept: apiConfig.headers.Accept,
+    ...getAuthHeader(),
+  } as Record<string, string>;
+  return apiFetch<TreinamentoCompanyBackendResponse>(
+    websiteRoutes.treinamentoCompany.update(id),
+    {
+      init: { method: "PUT", body: JSON.stringify(data), headers },
+      cache: "no-cache",
+    },
+  );
+}
+
+export async function deleteTreinamentoCompany(id: string): Promise<void> {
+  const headers = { Accept: apiConfig.headers.Accept, ...getAuthHeader() } as Record<string, string>;
+  await apiFetch<void>(websiteRoutes.treinamentoCompany.delete(id), {
+    init: { method: "DELETE", headers },
+    cache: "no-cache",
+  });
+}

--- a/src/api/websites/components/treinamento-company/types.ts
+++ b/src/api/websites/components/treinamento-company/types.ts
@@ -1,0 +1,35 @@
+export interface TreinamentoCompanyBackendResponse {
+  id: string;
+  titulo: string;
+  descricao: string;
+  imagemUrl?: string;
+  imagemTitulo?: string;
+  titulo1: string;
+  titulo2: string;
+  titulo3: string;
+  titulo4: string;
+  criadoEm: string;
+  atualizadoEm: string;
+}
+
+export interface CreateTreinamentoCompanyPayload {
+  titulo: string;
+  descricao: string;
+  imagemUrl?: string;
+  imagemTitulo?: string;
+  titulo1: string;
+  titulo2: string;
+  titulo3: string;
+  titulo4: string;
+}
+
+export interface UpdateTreinamentoCompanyPayload {
+  titulo?: string;
+  descricao?: string;
+  imagemUrl?: string;
+  imagemTitulo?: string;
+  titulo1?: string;
+  titulo2?: string;
+  titulo3?: string;
+  titulo4?: string;
+}

--- a/src/app/dashboard/config/website/treinamento/header/HeaderForm.tsx
+++ b/src/app/dashboard/config/website/treinamento/header/HeaderForm.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import { useEffect, useState, FormEvent } from "react";
+import {
+  InputCustom,
+  FileUpload,
+  type FileUploadItem,
+  SimpleTextarea,
+  ButtonCustom,
+} from "@/components/ui/custom";
+import { Label } from "@/components/ui/label";
+import { toastCustom } from "@/components/ui/custom/toast";
+import {
+  listHeaderPages,
+  createHeaderPage,
+  updateHeaderPage,
+  type HeaderPageBackendResponse,
+} from "@/api/websites/components";
+import { Skeleton } from "@/components/ui/skeleton";
+import { uploadImage, deleteImage, getImageTitle } from "@/services/upload";
+
+interface HeaderContent {
+  id?: string;
+  subtitulo?: string;
+  titulo: string;
+  descricao?: string;
+  imagemUrl?: string;
+  buttonLabel?: string;
+  buttonLink?: string;
+}
+
+const PAGE_KEY = "TREINAMENTO" as const;
+
+export default function HeaderForm() {
+  const [content, setContent] = useState<HeaderContent>({ titulo: "" });
+  const [files, setFiles] = useState<FileUploadItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isFetching, setIsFetching] = useState(true);
+  const [oldImageUrl, setOldImageUrl] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    const applyData = (first: HeaderPageBackendResponse) => {
+      setContent({
+        id: first.id,
+        subtitulo: first.subtitulo ?? "",
+        titulo: first.titulo ?? "",
+        descricao: first.descricao ?? "",
+        imagemUrl: first.imagemUrl ?? undefined,
+        buttonLabel: first.buttonLabel ?? "",
+        buttonLink: first.buttonLink ?? "",
+      });
+      setOldImageUrl(first.imagemUrl ?? undefined);
+
+      if (first.imagemUrl) {
+        const item: FileUploadItem = {
+          id: "existing",
+          name: getImageTitle(first.imagemUrl) || "imagem",
+          size: 0,
+          type: "image",
+          status: "completed",
+          uploadDate: new Date(first.criadoEm || Date.now()),
+          previewUrl: first.imagemUrl,
+          uploadedUrl: first.imagemUrl,
+        };
+        setFiles([item]);
+      }
+    };
+
+    const fetchData = async () => {
+      setIsFetching(true);
+      try {
+        const data = await listHeaderPages({ headers: { Accept: "application/json" } });
+        const first = (data || []).find((h) => (h.page || "").toString().toUpperCase() === PAGE_KEY);
+        if (first) applyData(first);
+      } catch (err) {
+        toastCustom.error("Erro ao carregar cabeçalho");
+      } finally {
+        setIsFetching(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const handleFilesChange = (list: FileUploadItem[]) => {
+    if (list.length === 0) setContent((p) => ({ ...p, imagemUrl: undefined }));
+    setFiles(list);
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (isLoading) return;
+
+    const titulo = content.titulo.trim();
+    const subtitulo = (content.subtitulo || "").trim();
+    const descricao = (content.descricao || "").trim();
+    const buttonLabel = (content.buttonLabel || "").trim();
+    const link = (content.buttonLink || "").trim();
+
+    if (!titulo) {
+      toastCustom.error("O título é obrigatório");
+      return;
+    }
+    if (!subtitulo) {
+      toastCustom.error("O subtítulo é obrigatório");
+      return;
+    }
+    if (!descricao) {
+      toastCustom.error("A descrição é obrigatória");
+      return;
+    }
+    if (!buttonLabel) {
+      toastCustom.error("O texto do botão é obrigatório");
+      return;
+    }
+    if (!link) {
+      toastCustom.error("O link do botão é obrigatório");
+      return;
+    }
+    if (link && !/^https?:\/\//i.test(link)) {
+      toastCustom.error("A URL do botão deve começar com http ou https");
+      return;
+    }
+
+    if (files.length === 0 && !content.imagemUrl) {
+      toastCustom.error("Uma imagem é obrigatória");
+      return;
+    }
+
+    const uploading = files.find((f) => f.status === "uploading");
+    if (uploading) {
+      toastCustom.error("Aguarde o upload da imagem terminar");
+      return;
+    }
+
+    setIsLoading(true);
+    toastCustom.info("Salvando cabeçalho...");
+
+    let uploadResult: { url: string; title: string } | undefined;
+    try {
+      const fileItem = files[0];
+      const previousUrl = oldImageUrl;
+      if (fileItem?.file) {
+        try {
+          uploadResult = await uploadImage(fileItem.file, "website/header-pages", previousUrl);
+        } catch (err) {
+          toastCustom.error("Erro no upload da imagem. Tente novamente");
+          return;
+        }
+      } else if (!fileItem && previousUrl) {
+        await deleteImage(previousUrl);
+      } else if (previousUrl) {
+        uploadResult = { url: previousUrl, title: getImageTitle(previousUrl) };
+      }
+
+      const payload = {
+        subtitulo,
+        titulo,
+        descricao,
+        imagemUrl: uploadResult?.url || content.imagemUrl,
+        buttonLabel,
+        buttonLink: link,
+        page: PAGE_KEY,
+      };
+
+      const saved = content.id
+        ? await updateHeaderPage(content.id, payload)
+        : await createHeaderPage(payload);
+
+      toastCustom.success(content.id ? "Cabeçalho atualizado com sucesso!" : "Cabeçalho criado com sucesso!");
+
+      setContent({
+        id: saved.id,
+        subtitulo: saved.subtitulo ?? "",
+        titulo: saved.titulo ?? "",
+        descricao: saved.descricao ?? "",
+        imagemUrl: saved.imagemUrl ?? undefined,
+        buttonLabel: saved.buttonLabel ?? "",
+        buttonLink: saved.buttonLink ?? "",
+      });
+
+      if (saved.imagemUrl) {
+        setFiles([
+          {
+            id: saved.id,
+            name: getImageTitle(saved.imagemUrl) || "imagem",
+            size: 0,
+            type: "image",
+            status: "completed",
+            uploadDate: new Date(saved.atualizadoEm || Date.now()),
+            previewUrl: saved.imagemUrl,
+            uploadedUrl: saved.imagemUrl,
+          },
+        ]);
+      } else {
+        setFiles([]);
+      }
+
+      setOldImageUrl(saved.imagemUrl ?? undefined);
+    } catch (err) {
+      const status = (err as any)?.status;
+      let message = "Não foi possível salvar";
+      if (status === 401) message = "Sessão expirada. Faça login novamente";
+      else if (status === 403) message = "Você não tem permissão para esta ação";
+      toastCustom.error(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      {isFetching ? (
+        <div className="space-y-6">
+          <Skeleton className="h-40 w-full" />
+          <Skeleton className="h-10 w-1/3" />
+          <Skeleton className="h-32 w-full" />
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {/* Upload de Imagem */}
+          <div className="space-y-4">
+            <div>
+              <Label className="text-sm font-medium text-gray-700">
+                Imagem do Cabeçalho <span className="text-red-500">*</span>
+              </Label>
+              <div className="mt-2">
+                <FileUpload
+                  files={files}
+                  multiple={false}
+                  maxFiles={1}
+                  validation={{ accept: [".jpg", ".png", ".webp"] }}
+                  autoUpload={false}
+                  deleteOnRemove={false}
+                  onFilesChange={handleFilesChange}
+                  showProgress={false}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Campos */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <InputCustom
+              label="Título"
+              id="titulo"
+              value={content.titulo}
+              onChange={(e) => setContent((p) => ({ ...p, titulo: e.target.value }))}
+              maxLength={80}
+              required
+            />
+            <InputCustom
+              label="Subtítulo"
+              id="subtitulo"
+              value={content.subtitulo || ""}
+              onChange={(e) => setContent((p) => ({ ...p, subtitulo: e.target.value }))}
+              maxLength={100}
+              required
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="descricao" className="text-sm font-medium text-gray-700 required">
+              Descrição
+            </Label>
+            <div className="mt-1">
+              <SimpleTextarea
+                id="descricao"
+                value={content.descricao || ""}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  setContent((p) => ({ ...p, descricao: e.target.value }))
+                }
+                maxLength={600}
+                showCharCount
+                className="min-h-[200px]"
+                required
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <InputCustom
+              label="Texto do Botão"
+              id="buttonLabel"
+              value={content.buttonLabel || ""}
+              onChange={(e) => setContent((p) => ({ ...p, buttonLabel: e.target.value }))}
+              maxLength={40}
+              required
+            />
+            <InputCustom
+              label="Link do Botão"
+              id="buttonLink"
+              value={content.buttonLink || ""}
+              onChange={(e) => setContent((p) => ({ ...p, buttonLink: e.target.value }))}
+              maxLength={200}
+              type="url"
+              icon="Link"
+              required
+            />
+          </div>
+
+          <div className="pt-4 flex justify-end">
+            <ButtonCustom
+              type="submit"
+              isLoading={isLoading}
+              disabled={
+                isLoading || (!content.imagemUrl && files.length === 0) || files.some((f) => f.status === "uploading")
+              }
+              size="lg"
+              variant="default"
+              className="w-40"
+              withAnimation
+            >
+              Salvar
+            </ButtonCustom>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}
+

--- a/src/app/dashboard/config/website/treinamento/page.tsx
+++ b/src/app/dashboard/config/website/treinamento/page.tsx
@@ -5,16 +5,18 @@ import {
   VerticalTabs,
   type VerticalTabItem,
 } from "@/components/ui/custom";
+import HeaderForm from "./header/HeaderForm";
+import TreinamentoForm from "./treinamento/TreinamentoForm";
 
 export default function TreinamentoPage() {
   const items: VerticalTabItem[] = [
     {
-      value: "banner",
-      label: "Banner",
-      icon: "Image",
+      value: "header",
+      label: "Cabeçalho",
+      icon: "Type",
       content: (
         <div className="space-y-6">
-          <h3 className="text-lg font-semibold mb-2">Banner</h3>
+          <HeaderForm />
         </div>
       ),
     },
@@ -24,7 +26,7 @@ export default function TreinamentoPage() {
       icon: "BookOpen",
       content: (
         <div className="space-y-6">
-          <h3 className="text-lg font-semibold mb-2">Treinamento</h3>
+          <TreinamentoForm />
         </div>
       ),
     },
@@ -55,7 +57,7 @@ export default function TreinamentoPage() {
       <div className="flex-1 min-h-0">
         <VerticalTabs
           items={items}
-          defaultValue="banner"
+          defaultValue="header"
           variant="spacious"
           size="sm"
           withAnimation={true}

--- a/src/app/dashboard/config/website/treinamento/treinamento/TreinamentoForm.tsx
+++ b/src/app/dashboard/config/website/treinamento/treinamento/TreinamentoForm.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+import { useEffect, useState, FormEvent } from "react";
+import {
+  InputCustom,
+  FileUpload,
+  type FileUploadItem,
+  SimpleTextarea,
+  ButtonCustom,
+} from "@/components/ui/custom";
+import { Label } from "@/components/ui/label";
+import { toastCustom } from "@/components/ui/custom/toast";
+import {
+  listTreinamentoCompany,
+  createTreinamentoCompany,
+  updateTreinamentoCompany,
+  type TreinamentoCompanyBackendResponse,
+} from "@/api/websites/components";
+import { Skeleton } from "@/components/ui/skeleton";
+import { uploadImage, deleteImage, getImageTitle } from "@/services/upload";
+
+interface TreinamentoCompanyContent {
+  id?: string;
+  titulo: string;
+  descricao: string;
+  imagemUrl?: string;
+  titulo1: string;
+  titulo2: string;
+  titulo3: string;
+  titulo4: string;
+}
+
+export default function TreinamentoForm() {
+  const [content, setContent] = useState<TreinamentoCompanyContent>({
+    titulo: "",
+    descricao: "",
+    imagemUrl: undefined,
+    titulo1: "",
+    titulo2: "",
+    titulo3: "",
+    titulo4: "",
+  });
+  const [files, setFiles] = useState<FileUploadItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isFetching, setIsFetching] = useState(true);
+  const [oldImageUrl, setOldImageUrl] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    const applyData = (first: TreinamentoCompanyBackendResponse) => {
+      setContent({
+        id: first.id,
+        titulo: first.titulo ?? "",
+        descricao: first.descricao ?? "",
+        imagemUrl: first.imagemUrl ?? undefined,
+        titulo1: first.titulo1 ?? "",
+        titulo2: first.titulo2 ?? "",
+        titulo3: first.titulo3 ?? "",
+        titulo4: first.titulo4 ?? "",
+      });
+      setOldImageUrl(first.imagemUrl ?? undefined);
+      if (first.imagemUrl) {
+        const item: FileUploadItem = {
+          id: "existing",
+          name: getImageTitle(first.imagemUrl) || "imagem",
+          size: 0,
+          type: "image",
+          status: "completed",
+          uploadDate: new Date(first.criadoEm || Date.now()),
+          previewUrl: first.imagemUrl,
+          uploadedUrl: first.imagemUrl,
+        };
+        setFiles([item]);
+      }
+    };
+
+    const fetchData = async () => {
+      setIsFetching(true);
+      try {
+        const data = await listTreinamentoCompany({
+          headers: { Accept: "application/json" },
+        });
+        const first = data?.[0];
+        if (first) applyData(first);
+      } catch (err) {
+        toastCustom.error("Erro ao carregar conteúdo");
+      } finally {
+        setIsFetching(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const handleFilesChange = (list: FileUploadItem[]) => {
+    if (list.length === 0) setContent((p) => ({ ...p, imagemUrl: undefined }));
+    setFiles(list);
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (isLoading) return;
+
+    const titulo = content.titulo.trim();
+    const descricao = content.descricao.trim();
+    const t1 = content.titulo1.trim();
+    const t2 = content.titulo2.trim();
+    const t3 = content.titulo3.trim();
+    const t4 = content.titulo4.trim();
+
+    if (!titulo) {
+      toastCustom.error("O título é obrigatório");
+      return;
+    }
+    if (!descricao) {
+      toastCustom.error("A descrição é obrigatória");
+      return;
+    }
+    if (!t1 || !t2 || !t3 || !t4) {
+      toastCustom.error("Todos os tópicos são obrigatórios");
+      return;
+    }
+    if (!content.imagemUrl && files.length === 0) {
+      toastCustom.error("A imagem é obrigatória");
+      return;
+    }
+
+    setIsLoading(true);
+
+    let uploadResult: { url: string; title: string } | undefined;
+    const previousUrl = oldImageUrl;
+    const fileItem = files[0];
+    if (fileItem && fileItem.file) {
+      try {
+        uploadResult = await uploadImage(
+          fileItem.file,
+          "website/treinamento-company",
+          previousUrl
+        );
+      } catch (err) {
+        toastCustom.error("Erro no upload da imagem. Tente novamente");
+        setIsLoading(false);
+        return;
+      }
+    } else if (!fileItem && previousUrl) {
+      await deleteImage(previousUrl);
+    } else if (previousUrl) {
+      uploadResult = { url: previousUrl, title: getImageTitle(previousUrl) };
+    }
+
+    const payload = {
+      titulo,
+      descricao,
+      imagemUrl: uploadResult?.url || content.imagemUrl,
+      imagemTitulo: uploadResult?.title,
+      titulo1: t1,
+      titulo2: t2,
+      titulo3: t3,
+      titulo4: t4,
+    };
+
+    try {
+      const saved = content.id
+        ? await updateTreinamentoCompany(content.id, payload)
+        : await createTreinamentoCompany(payload);
+
+      toastCustom.success(
+        content.id
+          ? "Conteúdo atualizado com sucesso!"
+          : "Conteúdo criado com sucesso!"
+      );
+
+      setContent({
+        id: saved.id,
+        titulo: saved.titulo ?? "",
+        descricao: saved.descricao ?? "",
+        imagemUrl: saved.imagemUrl ?? undefined,
+        titulo1: saved.titulo1 ?? "",
+        titulo2: saved.titulo2 ?? "",
+        titulo3: saved.titulo3 ?? "",
+        titulo4: saved.titulo4 ?? "",
+      });
+      setOldImageUrl(saved.imagemUrl ?? undefined);
+      if (saved.imagemUrl) {
+        const item: FileUploadItem = {
+          id: "existing",
+          name: getImageTitle(saved.imagemUrl) || "imagem",
+          size: 0,
+          type: "image",
+          status: "completed",
+          uploadDate: new Date(saved.criadoEm || Date.now()),
+          previewUrl: saved.imagemUrl,
+          uploadedUrl: saved.imagemUrl,
+        };
+        setFiles([item]);
+      }
+    } catch (err) {
+      toastCustom.error("Erro ao salvar conteúdo");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      {isFetching ? (
+        <div className="space-y-6">
+          <Skeleton className="h-40 w-full" />
+          <Skeleton className="h-10 w-1/3" />
+          <Skeleton className="h-32 w-full" />
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {/* Upload de Imagem */}
+          <div className="space-y-4">
+            <div>
+              <Label className="text-sm font-medium text-gray-700">
+                Imagem <span className="text-red-500">*</span>
+              </Label>
+              <div className="mt-2">
+                <FileUpload
+                  files={files}
+                  multiple={false}
+                  maxFiles={1}
+                  validation={{ accept: [".jpg", ".png", ".webp"] }}
+                  autoUpload={false}
+                  deleteOnRemove={false}
+                  onFilesChange={handleFilesChange}
+                  showProgress={false}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Campos principais */}
+          <div className="space-y-4">
+            <InputCustom
+              label="Título"
+              id="titulo"
+              value={content.titulo}
+              onChange={(e) =>
+                setContent((p) => ({ ...p, titulo: e.target.value }))
+              }
+              maxLength={100}
+              required
+            />
+            <div>
+              <Label
+                htmlFor="descricao"
+                className="text-sm font-medium text-gray-700 required"
+              >
+                Descrição
+              </Label>
+              <div className="mt-1">
+                <SimpleTextarea
+                  id="descricao"
+                  value={content.descricao}
+                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                    setContent((p) => ({ ...p, descricao: e.target.value }))
+                  }
+                  maxLength={600}
+                  showCharCount
+                  className="min-h-[200px]"
+                  required
+                />
+              </div>
+            </div>
+          </div>
+
+  {/* Títulos 1..4 */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {[1, 2, 3, 4].map((i) => (
+              <InputCustom
+                key={i}
+                label={`Título ${i}`}
+                id={`titulo${i}`}
+                value={(content as any)[`titulo${i}`]}
+                onChange={(e) =>
+                  setContent(
+                    (p) => ({ ...p, [`titulo${i}`]: e.target.value } as any)
+                  )
+                }
+                maxLength={80}
+                required
+              />
+            ))}
+          </div>
+
+          <div className="pt-4 flex justify-end">
+            <ButtonCustom
+              type="submit"
+              isLoading={isLoading}
+              disabled={
+                isLoading ||
+                (!content.imagemUrl && files.length === 0) ||
+                files.some((f) => f.status === "uploading")
+              }
+              size="lg"
+              variant="default"
+              className="w-40"
+              withAnimation
+            >
+              Salvar
+            </ButtonCustom>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/src/app/website/treinamento/page.tsx
+++ b/src/app/website/treinamento/page.tsx
@@ -2,6 +2,9 @@ import React from "react";
 import HeaderPages from "@/theme/website/components/header-pages";
 import ServiceBenefits from "@/theme/website/components/service-benefits";
 
+/**
+ * Página de Treinamento In Company com cabeçalho e benefícios
+ */
 export const metadata = {
   title: "Treinamento",
 };


### PR DESCRIPTION
## Summary
- add header form for treinamento page
- implement treinamento-company API client and mapping
- wire up Treinamento forms in dashboard
- render Treinamento website header and benefits

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba17de24648325afbb9f9e6e7c77d6