### PR TITLE
feat: manage website logo enterprises

### DIFF
--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -121,6 +121,14 @@ export const websiteRoutes = {
     delete: (id: string) => `${prefix}/website/banner/${id}`,
     reorder: (id: string) => `${prefix}/website/banner/${id}/reorder`,
   },
+  logoEnterprises: {
+    list: () => `${prefix}/website/logo-enterprises`,
+    create: () => `${prefix}/website/logo-enterprises`,
+    get: (id: string) => `${prefix}/website/logo-enterprises/${id}`,
+    update: (id: string) => `${prefix}/website/logo-enterprises/${id}`,
+    delete: (id: string) => `${prefix}/website/logo-enterprises/${id}`,
+    reorder: (id: string) => `${prefix}/website/logo-enterprises/${id}/reorder`,
+  },
   team: {
     list: () => `${prefix}/website/team`,
     create: () => `${prefix}/website/team`,

--- a/src/api/websites/components/index.ts
+++ b/src/api/websites/components/index.ts
@@ -126,6 +126,14 @@ export {
   updateBannerStatus,
 } from "./banner";
 export {
+  listLogoEnterprises,
+  getLogoEnterpriseById,
+  createLogoEnterprise,
+  updateLogoEnterprise,
+  deleteLogoEnterprise,
+  updateLogoEnterpriseOrder,
+} from "./logo-enterprises";
+export {
   listHeaderPages,
   getHeaderPageById,
   createHeaderPage,
@@ -217,6 +225,11 @@ export type {
 } from "./conexao-forte/types";
 
 export type { BannerBackendResponse, BannerApiResponse } from "./banner/types";
+export type {
+  LogoEnterpriseBackendResponse,
+  CreateLogoEnterprisePayload,
+  UpdateLogoEnterprisePayload,
+} from "./logo-enterprises/types";
 export {
   listTeam,
   getTeamById,

--- a/src/api/websites/components/logo-enterprises/index.ts
+++ b/src/api/websites/components/logo-enterprises/index.ts
@@ -1,0 +1,125 @@
+import { websiteRoutes } from "@/api/routes";
+import { apiFetch } from "@/api/client";
+import { apiConfig } from "@/lib/env";
+import type {
+  LogoEnterpriseBackendResponse,
+  CreateLogoEnterprisePayload,
+  UpdateLogoEnterprisePayload,
+  LogoEnterpriseStatus,
+} from "./types";
+
+function getAuthHeader(): Record<string, string> {
+  if (typeof document === "undefined") return {};
+  const token = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith("token="))
+    ?.split("=")[1];
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+function buildRequest(
+  data: CreateLogoEnterprisePayload | UpdateLogoEnterprisePayload
+): { body: BodyInit; headers: Record<string, string> } {
+  const baseHeaders = {
+    Accept: apiConfig.headers.Accept,
+    ...getAuthHeader(),
+  } as Record<string, string>;
+
+  const form = new FormData();
+  if (data.nome !== undefined) form.append("nome", data.nome);
+  if (data.website !== undefined) form.append("website", data.website);
+  if (data.status !== undefined) {
+    const statusValue: LogoEnterpriseStatus =
+      typeof data.status === "boolean"
+        ? data.status
+          ? "PUBLICADO"
+          : "RASCUNHO"
+        : (String(data.status).toUpperCase() as LogoEnterpriseStatus);
+    form.append("status", statusValue);
+  }
+  if (data.ordem !== undefined) form.append("ordem", String(data.ordem));
+  if (data.imagem) form.append("imagem", data.imagem);
+  if (data.imagemUrl) form.append("imagemUrl", data.imagemUrl);
+  if (data.imagemAlt) form.append("imagemAlt", data.imagemAlt);
+
+  return { body: form, headers: baseHeaders };
+}
+
+export async function listLogoEnterprises(
+  init?: RequestInit
+): Promise<LogoEnterpriseBackendResponse[]> {
+  return apiFetch<LogoEnterpriseBackendResponse[]>(
+    websiteRoutes.logoEnterprises.list(),
+    {
+      init: init ?? { headers: apiConfig.headers },
+      cache: "no-cache",
+    }
+  );
+}
+
+export async function getLogoEnterpriseById(
+  orderId: string
+): Promise<LogoEnterpriseBackendResponse> {
+  return apiFetch<LogoEnterpriseBackendResponse>(
+    websiteRoutes.logoEnterprises.get(orderId),
+    { init: { headers: apiConfig.headers }, cache: "no-cache" }
+  );
+}
+
+export async function createLogoEnterprise(
+  data: CreateLogoEnterprisePayload
+): Promise<LogoEnterpriseBackendResponse> {
+  const { body, headers } = buildRequest(data);
+  return apiFetch<LogoEnterpriseBackendResponse>(
+    websiteRoutes.logoEnterprises.create(),
+    {
+      init: { method: "POST", body, headers },
+      cache: "no-cache",
+    }
+  );
+}
+
+export async function updateLogoEnterprise(
+  id: string,
+  data: UpdateLogoEnterprisePayload
+): Promise<LogoEnterpriseBackendResponse> {
+  const { body, headers } = buildRequest(data);
+  return apiFetch<LogoEnterpriseBackendResponse>(
+    websiteRoutes.logoEnterprises.update(id),
+    {
+      init: { method: "PUT", body, headers },
+      cache: "no-cache",
+    }
+  );
+}
+
+export async function deleteLogoEnterprise(id: string): Promise<void> {
+  await apiFetch<void>(websiteRoutes.logoEnterprises.delete(id), {
+    init: {
+      method: "DELETE",
+      headers: { Accept: apiConfig.headers.Accept, ...getAuthHeader() },
+    },
+    cache: "no-cache",
+  });
+}
+
+export async function updateLogoEnterpriseOrder(
+  orderId: string,
+  ordem: number
+): Promise<void> {
+  await apiFetch<LogoEnterpriseBackendResponse>(
+    websiteRoutes.logoEnterprises.reorder(orderId),
+    {
+      init: {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: apiConfig.headers.Accept,
+          ...getAuthHeader(),
+        },
+        body: JSON.stringify({ ordem: Number(ordem) }),
+      },
+      cache: "no-cache",
+    }
+  );
+}

--- a/src/api/websites/components/logo-enterprises/types/index.ts
+++ b/src/api/websites/components/logo-enterprises/types/index.ts
@@ -1,0 +1,35 @@
+export type LogoEnterpriseStatus = "PUBLICADO" | "RASCUNHO" | string;
+
+export interface LogoEnterpriseBackendResponse {
+  id: string; // ID da ordem
+  logoId: string; // ID do recurso logo
+  nome: string;
+  imagemUrl: string;
+  imagemAlt?: string;
+  website?: string;
+  status?: LogoEnterpriseStatus | boolean;
+  ordem: number;
+  ordemCriadoEm?: string;
+  criadoEm?: string;
+  atualizadoEm?: string;
+}
+
+export interface CreateLogoEnterprisePayload {
+  nome?: string;
+  website?: string;
+  imagemUrl?: string;
+  imagem?: File;
+  status?: LogoEnterpriseStatus | boolean;
+  imagemAlt?: string;
+  ordem?: number;
+}
+
+export interface UpdateLogoEnterprisePayload {
+  nome?: string;
+  website?: string;
+  imagemUrl?: string;
+  imagem?: File;
+  status?: LogoEnterpriseStatus | boolean;
+  imagemAlt?: string;
+  ordem?: number;
+}

--- a/src/app/dashboard/config/website/geral/logos/LogosForm.tsx
+++ b/src/app/dashboard/config/website/geral/logos/LogosForm.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { SliderManager, type Slider } from "@/components/ui/custom";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toastCustom } from "@/components/ui/custom/toast";
+import {
+  listLogoEnterprises,
+  createLogoEnterprise as apiCreateLogo,
+  updateLogoEnterprise as apiUpdateLogo,
+  deleteLogoEnterprise as apiDeleteLogo,
+  updateLogoEnterpriseOrder as apiUpdateLogoOrder,
+} from "@/api/websites/components/logo-enterprises";
+import type { LogoEnterpriseBackendResponse } from "@/api/websites/components/logo-enterprises/types";
+
+function mapFromBackend(item: LogoEnterpriseBackendResponse): Slider {
+  return {
+    id: item.logoId,
+    orderId: item.id,
+    title: item.nome,
+    image: item.imagemUrl,
+    url: item.website || "",
+    content: "",
+    status:
+      (typeof item.status === "string" ? item.status : item.status
+        ? "PUBLICADO"
+        : "RASCUNHO") === "PUBLICADO",
+    position: item.ordem,
+    createdAt: item.criadoEm ?? item.ordemCriadoEm ?? new Date().toISOString(),
+    updatedAt: item.atualizadoEm,
+  };
+}
+
+const statusToBackend = (status: boolean): "PUBLICADO" | "RASCUNHO" =>
+  status ? "PUBLICADO" : "RASCUNHO";
+
+export default function LogosForm() {
+  const [loading, setLoading] = useState(true);
+  const [initialLogos, setInitialLogos] = useState<Slider[]>([]);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      setLoading(true);
+      try {
+        const data = await listLogoEnterprises({ headers: { Accept: "application/json" } });
+        const mapped = (data || [])
+          .sort((a, b) => a.ordem - b.ordem)
+          .map(mapFromBackend);
+        if (mounted) setInitialLogos(mapped);
+      } catch {
+        toastCustom.error("Não foi possível carregar as logos");
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const handleCreate = useCallback(
+    async (data: Omit<Slider, "id" | "createdAt">): Promise<Slider> => {
+      const created = await apiCreateLogo({
+        nome: data.title,
+        imagemUrl: data.image,
+        website: data.url || undefined,
+        status: statusToBackend(data.status),
+        ordem: typeof data.position === "number" ? data.position : undefined,
+      });
+      return mapFromBackend(created);
+    },
+    []
+  );
+
+  const handleUpdate = useCallback(
+    async (id: string, updates: Partial<Slider>): Promise<Slider> => {
+      const updated = await apiUpdateLogo(id, {
+        nome: updates.title,
+        imagemUrl: updates.image,
+        website: updates.url,
+        status:
+          updates.status === undefined
+            ? undefined
+            : statusToBackend(!!updates.status),
+        ordem: updates.position,
+      });
+      return mapFromBackend(updated);
+    },
+    []
+  );
+
+  const handleDelete = useCallback(async (id: string) => {
+    await apiDeleteLogo(id);
+  }, []);
+
+  const handleReorder = useCallback(async (orderId: string, newPos: number) => {
+    await apiUpdateLogoOrder(orderId, newPos);
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-10 w-1/3" />
+        <Skeleton className="h-96 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <SliderManager
+      initialSliders={initialLogos}
+      uploadPath="website/logo-enterprises"
+      entityName="Logo"
+      entityNamePlural="Logos"
+      firstFieldLabel="Nome da empresa"
+      secondFieldLabel="Website (opcional)"
+      validateSecondFieldAsUrl
+      secondFieldRequired={false}
+      onCreateSlider={handleCreate}
+      onUpdateSlider={handleUpdate}
+      onDeleteSlider={handleDelete}
+      onReorderSliders={handleReorder}
+      onRefreshSliders={async () => {
+        const data = await listLogoEnterprises({ headers: { Accept: "application/json" } });
+        return (data || [])
+          .sort((a, b) => a.ordem - b.ordem)
+          .map(mapFromBackend);
+      }}
+    />
+  );
+}

--- a/src/app/dashboard/config/website/geral/page.tsx
+++ b/src/app/dashboard/config/website/geral/page.tsx
@@ -5,6 +5,7 @@ import {
   VerticalTabs,
   type VerticalTabItem,
 } from "@/components/ui/custom";
+import LogosForm from "./logos/LogosForm";
 
 export default function GeralPage() {
   const items: VerticalTabItem[] = [
@@ -57,6 +58,12 @@ export default function GeralPage() {
           <h3 className="text-lg font-semibold mb-2">Depoimentos</h3>
         </div>
       ),
+    },
+    {
+      value: "logos",
+      label: "Logos",
+      icon: "Image",
+      content: <LogosForm />,
     },
   ];
 

--- a/src/app/website/page.tsx
+++ b/src/app/website/page.tsx
@@ -7,6 +7,7 @@ import AboutSection from "@/theme/website/components/about";
 import BannersGroup from "@/theme/website/components/banners";
 import ConsultoriaSection from "@/theme/website/components/consultoria-empresarial";
 import RecrutamentoSection from "@/theme/website/components/recrutamento";
+import LogoEnterprises from "@/theme/website/components/logo-enterprises";
 
 /**
  * Página Inicial do Website Institucional
@@ -47,6 +48,11 @@ export default function WebsiteHomePage() {
       <RecrutamentoSection
         onDataLoaded={() => handleComponentLoaded("Recrutamento")}
         onError={(error) => handleComponentError("Recrutamento", error)}
+      />
+
+      <LogoEnterprises
+        onDataLoaded={() => handleComponentLoaded("LogoEnterprises")}
+        onError={(error) => handleComponentError("LogoEnterprises", error)}
       />
 
       

--- a/src/app/website/recrutamento/page.tsx
+++ b/src/app/website/recrutamento/page.tsx
@@ -4,6 +4,7 @@ import ProblemSolutionSection from "@/theme/website/components/problem-solution-
 import AdvanceAjuda from "@/theme/website/components/advance-ajuda";
 import ProcessSteps from "@/theme/website/components/process-steps";
 import ServiceBenefits from "@/theme/website/components/service-benefits";
+import LogoEnterprises from "@/theme/website/components/logo-enterprises";
 
 export const metadata = {
   title: "Recrutamento & Seleção",
@@ -17,6 +18,7 @@ export default function RecrutamentoPage() {
       <AdvanceAjuda fetchFromApi={true} />
       <ProcessSteps />
       <ServiceBenefits fetchFromApi={true} service="recrutamentoSelecao" />
+      <LogoEnterprises fetchFromApi={true} />
     </div>
   );
 }

--- a/src/app/website/sobre/page.tsx
+++ b/src/app/website/sobre/page.tsx
@@ -6,6 +6,7 @@ import HeaderPages from "@/theme/website/components/header-pages";
 import AccordionGroupInformation from "@/theme/website/components/accordion-group-information";
 import TeamShowcase from "@/theme/website/components/team-showcase/TeamShowcase";
 import AboutAdvantages from "@/theme/website/components/about-advantages";
+import LogoEnterprises from "@/theme/website/components/logo-enterprises";
 
 /**
  * Página Sobre Nós
@@ -22,6 +23,7 @@ export default function SobrePage() {
       <AccordionGroupInformation fetchFromApi={true} />
       <AboutAdvantages fetchFromApi={true} />
       <TeamShowcase fetchFromApi={true} title="Conheça nossa Equipe" />
+      <LogoEnterprises fetchFromApi={true} />
     </div>
   );
 }

--- a/src/app/website/treinamento/page.tsx
+++ b/src/app/website/treinamento/page.tsx
@@ -3,6 +3,7 @@ import HeaderPages from "@/theme/website/components/header-pages";
 import ServiceBenefits from "@/theme/website/components/service-benefits";
 import TrainingResults from "@/theme/website/components/training-results";
 import CommunicationHighlights from "@/theme/website/components/communication-highlights";
+import LogoEnterprises from "@/theme/website/components/logo-enterprises";
 
 /**
  * Página de Treinamento In Company com cabeçalho e benefícios
@@ -18,6 +19,7 @@ export default function TreinamentoPage() {
       <TrainingResults fetchFromApi={true} />
       <CommunicationHighlights fetchFromApi={true} />
       <ServiceBenefits fetchFromApi={true} service="treinamentoCompany" />
+      <LogoEnterprises fetchFromApi={true} />
     </div>
   );
 }

--- a/src/theme/website/components/logo-enterprises/LogoEnterprises.tsx
+++ b/src/theme/website/components/logo-enterprises/LogoEnterprises.tsx
@@ -9,7 +9,7 @@ import { useLogosData } from "./hooks/useLogosData";
 import { ImageNotFound } from "@/components/ui/custom/image-not-found";
 import { ButtonCustom } from "@/components/ui/custom/button";
 import { DEFAULT_CONTENT } from "./constants";
-import type { LogoEnterprisesProps } from "./types";
+import type { LogoEnterprisesProps, LogoData } from "./types";
 
 /**
  * Componente LogoEnterprises
@@ -61,7 +61,7 @@ const LogoEnterprises: React.FC<LogoEnterprisesProps> = ({
   }, [error, onError]);
 
   // Handler para clique no logo
-  const handleLogoClick = (logo: any) => {
+  const handleLogoClick = (logo: LogoData) => {
     if (logo.website) {
       window.open(logo.website, "_blank", "noopener,noreferrer");
     }
@@ -108,13 +108,10 @@ const LogoEnterprises: React.FC<LogoEnterprisesProps> = ({
           />
           <p className="text-gray-600 mb-4 max-w-md mx-auto">
             Não foi possível carregar os logos das empresas parceiras.
-            {error.includes("padrão") ? " Exibindo dados de exemplo." : ""}
           </p>
-          {!error.includes("padrão") && (
-            <ButtonCustom onClick={refetch} variant="default" icon="RefreshCw">
-              Tentar Novamente
-            </ButtonCustom>
-          )}
+          <ButtonCustom onClick={refetch} variant="default" icon="RefreshCw">
+            Tentar Novamente
+          </ButtonCustom>
         </div>
       </section>
     );

--- a/src/theme/website/components/logo-enterprises/constants/index.ts
+++ b/src/theme/website/components/logo-enterprises/constants/index.ts
@@ -1,123 +1,9 @@
 // src/theme/website/components/logo-enterprises/constants/index.ts
 
-import type { LogoData } from "../types";
-
 /**
- * Dados padrão para fallback quando a API falha
- */
-export const DEFAULT_LOGOS_DATA: LogoData[] = [
-  {
-    id: 1,
-    name: "Appian",
-    src: "https://upload.wikimedia.org/wikipedia/en/thumb/9/93/Appian_Logo.svg/512px-Appian_Logo.svg",
-    alt: "Logo da Appian",
-    website: "https://appian.com",
-    category: "Tecnologia",
-    isActive: true,
-    order: 1,
-  },
-  {
-    id: 2,
-    name: "Kofax",
-    src: "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e5/Tungsten_Automation.svg/220px-Tungsten_Automation.svg",
-    alt: "Logo da Kofax (Tungsten Automation)",
-    website: "https://www.kofax.com",
-    category: "Automação",
-    isActive: true,
-    order: 2,
-  },
-  {
-    id: 3,
-    name: "AWS",
-    src: "https://upload.wikimedia.org/wikipedia/commons/9/93/Amazon_Web_Services_Logo.svg",
-    alt: "Logo da Amazon Web Services",
-    website: "https://aws.amazon.com",
-    category: "Cloud",
-    isActive: true,
-    order: 3,
-  },
-  {
-    id: 4,
-    name: "Microsoft",
-    src: "https://upload.wikimedia.org/wikipedia/commons/4/44/Microsoft_logo.svg",
-    alt: "Logo da Microsoft",
-    website: "https://microsoft.com",
-    category: "Tecnologia",
-    isActive: true,
-    order: 4,
-  },
-  {
-    id: 5,
-    name: "Google",
-    src: "https://upload.wikimedia.org/wikipedia/commons/2/2f/Google_2015_logo.svg",
-    alt: "Logo do Google",
-    website: "https://google.com",
-    category: "Tecnologia",
-    isActive: true,
-    order: 5,
-  },
-  {
-    id: 6,
-    name: "Apple",
-    src: "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fa/Apple_logo_black.svg/90px-Apple_logo_black.svg",
-    alt: "Logo da Apple",
-    website: "https://apple.com",
-    category: "Tecnologia",
-    isActive: true,
-    order: 6,
-  },
-  {
-    id: 7,
-    name: "Microsoft Outlook",
-    src: "https://upload.wikimedia.org/wikipedia/commons/thumb/d/df/Microsoft_Office_Outlook_%282018%E2%80%93present%29.svg/100px-Microsoft_Office_Outlook_%282018%E2%80%93present%29.svg",
-    alt: "Logo do Microsoft Outlook",
-    website: "https://outlook.com",
-    category: "Produtividade",
-    isActive: true,
-    order: 7,
-  },
-  {
-    id: 8,
-    name: "Windows",
-    src: "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e2/Windows_logo_and_wordmark_-_2021.svg/210px-Windows_logo_and_wordmark_-_2021.svg",
-    alt: "Logo do Windows",
-    website: "https://windows.com",
-    category: "Sistema Operacional",
-    isActive: true,
-    order: 8,
-  },
-  {
-    id: 9,
-    name: "Amazon",
-    src: "https://upload.wikimedia.org/wikipedia/commons/thumb/0/06/Amazon_2024.svg/220px-Amazon_2024.svg",
-    alt: "Logo da Amazon",
-    website: "https://amazon.com",
-    category: "E-commerce",
-    isActive: true,
-    order: 9,
-  },
-  {
-    id: 10,
-    name: "Nike",
-    src: "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a6/Logo_NIKE.svg/220px-Logo_NIKE.svg",
-    alt: "Logo da Nike",
-    website: "https://nike.com",
-    category: "Esportes",
-    isActive: true,
-    order: 10,
-  },
-];
-
-/**
- * Configurações do componente
+ * Configurações do componente LogoEnterprises
  */
 export const LOGOS_CONFIG = {
-  api: {
-    endpoint: "/api/enterprises/logos",
-    timeout: 5000,
-    retryAttempts: 3,
-    retryDelay: 1000,
-  },
   layout: {
     gridCols: {
       mobile: 2,
@@ -128,7 +14,8 @@ export const LOGOS_CONFIG = {
   },
   image: {
     quality: 90,
-    sizes: "(max-width: 640px) 100px, (max-width: 1024px) 120px, 140px",
+    sizes:
+      "(max-width: 640px) 100px, (max-width: 1024px) 120px, 140px",
     placeholder: "blur",
     maxWidth: 100,
     maxHeight: 40,
@@ -147,3 +34,4 @@ export const DEFAULT_CONTENT = {
   subtitle:
     "Na Advance RH, acreditamos que cada talento é singular e cada empresa tem um potencial ilimitado. Conectamos histórias para criar um futuro mais inovador, inclusivo e promissor.",
 } as const;
+

--- a/src/theme/website/components/logo-enterprises/index.ts
+++ b/src/theme/website/components/logo-enterprises/index.ts
@@ -12,4 +12,4 @@ export { useLogosData } from "./hooks/useLogosData";
 
 // Tipos e constantes
 export type { LogoData, LogoEnterprisesProps, LogoCardProps } from "./types";
-export { DEFAULT_LOGOS_DATA, LOGOS_CONFIG, DEFAULT_CONTENT } from "./constants";
+export { LOGOS_CONFIG, DEFAULT_CONTENT } from "./constants";

--- a/src/theme/website/components/logo-enterprises/types/index.ts
+++ b/src/theme/website/components/logo-enterprises/types/index.ts
@@ -4,29 +4,12 @@
  * Interface para dados de logo de empresa vindos da API
  */
 export interface LogoData {
-  id: number;
+  id: string;
   name: string;
   src: string;
   alt?: string;
   website?: string;
-  category?: string;
-  isActive: boolean;
   order: number;
-}
-
-/**
- * Interface para resposta da API
- */
-export interface LogosApiResponse {
-  data: LogoData[];
-  success: boolean;
-  message?: string;
-  pagination?: {
-    total: number;
-    page: number;
-    limit: number;
-    totalPages: number;
-  };
 }
 
 /**


### PR DESCRIPTION
## Summary
- remove mock logo data and API config from theme logo-enterprises component
- fetch enterprise logos from backend and show on website pages
- render logo enterprises section on home, treinamento, sobre and recrutamento pages

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb488730088325afe767dbec7c97e4