### PR TITLE
feat: add testimonials management

### DIFF
--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -129,6 +129,14 @@ export const websiteRoutes = {
     delete: (id: string) => `${prefix}/website/logo-enterprises/${id}`,
     reorder: (id: string) => `${prefix}/website/logo-enterprises/${id}/reorder`,
   },
+  depoimentos: {
+    list: () => `${prefix}/website/depoimentos`,
+    create: () => `${prefix}/website/depoimentos`,
+    get: (id: string) => `${prefix}/website/depoimentos/${id}`,
+    update: (id: string) => `${prefix}/website/depoimentos/${id}`,
+    delete: (id: string) => `${prefix}/website/depoimentos/${id}`,
+    reorder: (id: string) => `${prefix}/website/depoimentos/${id}/reorder`,
+  },
   team: {
     list: () => `${prefix}/website/team`,
     create: () => `${prefix}/website/team`,

--- a/src/api/websites/components/depoimentos/index.ts
+++ b/src/api/websites/components/depoimentos/index.ts
@@ -1,0 +1,135 @@
+import { websiteRoutes } from "@/api/routes";
+import { apiFetch } from "@/api/client";
+import { apiConfig } from "@/lib/env";
+import type {
+  DepoimentoBackendResponse,
+  CreateDepoimentoPayload,
+  UpdateDepoimentoPayload,
+} from "./types";
+
+function getAuthHeader(): Record<string, string> {
+  if (typeof document === "undefined") return {};
+  const token = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith("token="))
+    ?.split("=")[1];
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export async function listDepoimentos(
+  init?: RequestInit,
+  status?: "PUBLICADO" | "RASCUNHO",
+): Promise<DepoimentoBackendResponse[]> {
+  const url = status
+    ? `${websiteRoutes.depoimentos.list()}?status=${encodeURIComponent(status)}`
+    : websiteRoutes.depoimentos.list();
+  return apiFetch<DepoimentoBackendResponse[]>(url, {
+    init: init ?? { headers: apiConfig.headers },
+    cache: "no-cache",
+  });
+}
+
+export async function getDepoimentoById(id: string): Promise<DepoimentoBackendResponse> {
+  return apiFetch<DepoimentoBackendResponse>(websiteRoutes.depoimentos.get(id), {
+    init: { headers: apiConfig.headers },
+    cache: "no-cache",
+  });
+}
+
+export async function createDepoimento(
+  data: CreateDepoimentoPayload,
+): Promise<DepoimentoBackendResponse> {
+  const payload: Record<string, unknown> = {};
+  if (data.depoimento !== undefined) payload.depoimento = data.depoimento;
+  if (data.nome !== undefined) payload.nome = data.nome;
+  if (data.cargo !== undefined) payload.cargo = data.cargo;
+  if (data.fotoUrl !== undefined) payload.fotoUrl = data.fotoUrl;
+  if (data.status !== undefined) payload.status = data.status;
+  if (data.ordem !== undefined) payload.ordem = Number(data.ordem);
+
+  return apiFetch<DepoimentoBackendResponse>(websiteRoutes.depoimentos.create(), {
+    init: {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: apiConfig.headers.Accept,
+        ...getAuthHeader(),
+      },
+      body: JSON.stringify(payload),
+    },
+    cache: "no-cache",
+  });
+}
+
+export async function updateDepoimento(
+  id: string,
+  data: UpdateDepoimentoPayload,
+): Promise<DepoimentoBackendResponse> {
+  const payload: Record<string, unknown> = {};
+  if (data.depoimento !== undefined) payload.depoimento = data.depoimento;
+  if (data.nome !== undefined) payload.nome = data.nome;
+  if (data.cargo !== undefined) payload.cargo = data.cargo;
+  if (data.fotoUrl !== undefined) payload.fotoUrl = data.fotoUrl;
+  if (data.status !== undefined) payload.status = data.status;
+  if (data.ordem !== undefined) payload.ordem = Number(data.ordem);
+
+  return apiFetch<DepoimentoBackendResponse>(websiteRoutes.depoimentos.update(id), {
+    init: {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: apiConfig.headers.Accept,
+        ...getAuthHeader(),
+      },
+      body: JSON.stringify(payload),
+    },
+    cache: "no-cache",
+  });
+}
+
+export async function deleteDepoimento(id: string): Promise<void> {
+  await apiFetch<void>(websiteRoutes.depoimentos.delete(id), {
+    init: {
+      method: "DELETE",
+      headers: { Accept: apiConfig.headers.Accept, ...getAuthHeader() },
+    },
+    cache: "no-cache",
+  });
+}
+
+export async function updateDepoimentoOrder(
+  id: string,
+  ordem: number,
+): Promise<void> {
+  await apiFetch<DepoimentoBackendResponse>(websiteRoutes.depoimentos.reorder(id), {
+    init: {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: apiConfig.headers.Accept,
+        ...getAuthHeader(),
+      },
+      body: JSON.stringify({ ordem: Number(ordem) }),
+    },
+    cache: "no-cache",
+  });
+}
+
+export async function updateDepoimentoStatus(
+  id: string,
+  status: boolean | string,
+): Promise<DepoimentoBackendResponse> {
+  const payload = { status };
+  return apiFetch<DepoimentoBackendResponse>(websiteRoutes.depoimentos.update(id), {
+    init: {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: apiConfig.headers.Accept,
+        ...getAuthHeader(),
+      },
+      body: JSON.stringify(payload),
+    },
+    cache: "no-cache",
+  });
+}

--- a/src/api/websites/components/depoimentos/types/index.ts
+++ b/src/api/websites/components/depoimentos/types/index.ts
@@ -1,0 +1,33 @@
+export interface DepoimentoBackendResponse {
+  id: string; // ordem-uuid (ID da ordem)
+  depoimentoId: string; // ID real do depoimento
+  depoimento: string;
+  nome: string;
+  cargo: string;
+  fotoUrl: string;
+  status?: string; // PUBLICADO | RASCUNHO
+  ordem: number;
+  ordemCriadoEm?: string;
+  criadoEm?: string;
+  atualizadoEm?: string;
+}
+
+export interface CreateDepoimentoPayload {
+  depoimento: string;
+  nome: string;
+  cargo?: string;
+  foto?: File | Blob;
+  fotoUrl?: string;
+  ordem?: number;
+  status?: boolean | string;
+}
+
+export interface UpdateDepoimentoPayload {
+  depoimento?: string;
+  nome?: string;
+  cargo?: string;
+  foto?: File | Blob;
+  fotoUrl?: string;
+  ordem?: number;
+  status?: boolean | string;
+}

--- a/src/api/websites/components/index.ts
+++ b/src/api/websites/components/index.ts
@@ -134,6 +134,15 @@ export {
   updateLogoEnterpriseOrder,
 } from "./logo-enterprises";
 export {
+  listDepoimentos,
+  getDepoimentoById,
+  createDepoimento,
+  updateDepoimento,
+  deleteDepoimento,
+  updateDepoimentoOrder,
+  updateDepoimentoStatus,
+} from "./depoimentos";
+export {
   listHeaderPages,
   getHeaderPageById,
   createHeaderPage,
@@ -230,6 +239,11 @@ export type {
   CreateLogoEnterprisePayload,
   UpdateLogoEnterprisePayload,
 } from "./logo-enterprises/types";
+export type {
+  DepoimentoBackendResponse,
+  CreateDepoimentoPayload,
+  UpdateDepoimentoPayload,
+} from "./depoimentos/types";
 export {
   listTeam,
   getTeamById,

--- a/src/app/dashboard/config/website/geral/depoimentos/DepoimentosForm.tsx
+++ b/src/app/dashboard/config/website/geral/depoimentos/DepoimentosForm.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { SliderManager, type Slider } from "@/components/ui/custom";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toastCustom } from "@/components/ui/custom/toast";
+import {
+  listDepoimentos,
+  createDepoimento as apiCreateDepoimento,
+  updateDepoimento as apiUpdateDepoimento,
+  deleteDepoimento as apiDeleteDepoimento,
+  updateDepoimentoOrder as apiUpdateDepoimentoOrder,
+  updateDepoimentoStatus as apiUpdateDepoimentoStatus,
+} from "@/api/websites/components/depoimentos";
+import type { DepoimentoBackendResponse } from "@/api/websites/components/depoimentos/types";
+
+function mapFromBackend(item: DepoimentoBackendResponse): Slider {
+  return {
+    id: item.depoimentoId,
+    orderId: item.id,
+    title: item.depoimento,
+    image: item.fotoUrl || "",
+    url: item.nome || "",
+    content: item.cargo || "",
+    status:
+      (typeof item.status === "string"
+        ? item.status
+        : item.status
+        ? "PUBLICADO"
+        : "RASCUNHO") === "PUBLICADO",
+    position: item.ordem,
+    createdAt: item.criadoEm ?? item.ordemCriadoEm ?? new Date().toISOString(),
+    updatedAt: item.atualizadoEm,
+  };
+}
+
+const statusToBackend = (status: boolean): "PUBLICADO" | "RASCUNHO" =>
+  status ? "PUBLICADO" : "RASCUNHO";
+
+export default function DepoimentosForm() {
+  const [loading, setLoading] = useState(true);
+  const [initialItems, setInitialItems] = useState<Slider[]>([]);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      setLoading(true);
+      try {
+        const data = await listDepoimentos({ headers: { Accept: "application/json" } });
+        const mapped = (data || [])
+          .sort((a, b) => a.ordem - b.ordem)
+          .map(mapFromBackend);
+        if (mounted) setInitialItems(mapped);
+      } catch (error) {
+        toastCustom.error("Não foi possível carregar os depoimentos");
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const handleCreate = useCallback(
+    async (data: Omit<Slider, "id" | "createdAt">): Promise<Slider> => {
+      const created = await apiCreateDepoimento({
+        depoimento: data.title,
+        nome: data.url,
+        cargo: data.content,
+        fotoUrl: data.image,
+        status: statusToBackend(data.status),
+        ordem: typeof data.position === "number" ? data.position : undefined,
+      });
+      return mapFromBackend(created);
+    },
+    []
+  );
+
+  const handleUpdate = useCallback(
+    async (id: string, updates: Partial<Slider>): Promise<Slider> => {
+      if (
+        updates.status !== undefined &&
+        updates.title === undefined &&
+        updates.image === undefined &&
+        updates.url === undefined &&
+        updates.content === undefined &&
+        updates.position === undefined
+      ) {
+        const updated = await apiUpdateDepoimentoStatus(id, updates.status);
+        return mapFromBackend(updated);
+      }
+
+      const updated = await apiUpdateDepoimento(id, {
+        depoimento: updates.title,
+        nome: updates.url,
+        cargo: updates.content,
+        fotoUrl: updates.image,
+        status:
+          updates.status === undefined
+            ? undefined
+            : statusToBackend(!!updates.status),
+        ordem: updates.position,
+      });
+      return mapFromBackend(updated);
+    },
+    []
+  );
+
+  const handleDelete = useCallback(async (id: string) => {
+    await apiDeleteDepoimento(id);
+  }, []);
+
+  const handleReorder = useCallback(async (orderId: string, newPos: number) => {
+    await apiUpdateDepoimentoOrder(orderId, newPos);
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-10 w-1/3" />
+        <Skeleton className="h-96 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <SliderManager
+      initialSliders={initialItems}
+      uploadPath="website/depoimentos"
+      entityName="Depoimento"
+      entityNamePlural="Depoimentos"
+      firstFieldLabel="Depoimento"
+      secondFieldLabel="Nome"
+      validateSecondFieldAsUrl={false}
+      secondFieldRequired
+      onCreateSlider={handleCreate}
+      onUpdateSlider={handleUpdate}
+      onDeleteSlider={handleDelete}
+      onReorderSliders={handleReorder}
+      onRefreshSliders={async () => {
+        const data = await listDepoimentos({ headers: { Accept: "application/json" } });
+        return (data || [])
+          .sort((a, b) => a.ordem - b.ordem)
+          .map(mapFromBackend);
+      }}
+    />
+  );
+}

--- a/src/app/dashboard/config/website/geral/page.tsx
+++ b/src/app/dashboard/config/website/geral/page.tsx
@@ -6,58 +6,15 @@ import {
   type VerticalTabItem,
 } from "@/components/ui/custom";
 import LogosForm from "./logos/LogosForm";
+import DepoimentosForm from "./depoimentos/DepoimentosForm";
 
 export default function GeralPage() {
   const items: VerticalTabItem[] = [
     {
-      value: "telefone",
-      label: "Telefone",
-      icon: "Phone",
-      content: (
-        <div className="space-y-6">
-          <h3 className="text-lg font-semibold mb-2">Telefone</h3>
-        </div>
-      ),
-    },
-    {
-      value: "email",
-      label: "E-mail",
-      icon: "Mail",
-      content: (
-        <div className="space-y-6">
-          <h3 className="text-lg font-semibold mb-2">E-mail</h3>
-        </div>
-      ),
-    },
-    {
-      value: "redes-sociais",
-      label: "Redes Sociais",
-      icon: "Share2",
-      content: (
-        <div className="space-y-6">
-          <h3 className="text-lg font-semibold mb-2">Redes Sociais</h3>
-        </div>
-      ),
-    },
-    {
-      value: "endereco",
-      label: "Endereço",
-      icon: "MapPin",
-      content: (
-        <div className="space-y-6">
-          <h3 className="text-lg font-semibold mb-2">Endereço</h3>
-        </div>
-      ),
-    },
-    {
       value: "depoimentos",
       label: "Depoimentos",
       icon: "MessageSquare",
-      content: (
-        <div className="space-y-6">
-          <h3 className="text-lg font-semibold mb-2">Depoimentos</h3>
-        </div>
-      ),
+      content: <DepoimentosForm />,
     },
     {
       value: "logos",
@@ -72,7 +29,7 @@ export default function GeralPage() {
       <div className="flex-1 min-h-0">
         <VerticalTabs
           items={items}
-          defaultValue="telefone"
+          defaultValue="depoimentos"
           variant="spacious"
           size="sm"
           withAnimation={true}


### PR DESCRIPTION
## Summary
- remove unused contact tabs and add testimonials tab
- implement DepoimentosForm using SliderManager
- expose depoimentos API client and routes

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb968bf21c8325808c6b289b1515cd