### PR TITLE
feat: add website general info forms and api

### DIFF
--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -152,6 +152,13 @@ export const websiteRoutes = {
     update: (id: string) => `${prefix}/website/header-pages/${id}`,
     delete: (id: string) => `${prefix}/website/header-pages/${id}`,
   },
+  informacoesGerais: {
+    list: () => `${prefix}/website/informacoes-gerais`,
+    create: () => `${prefix}/website/informacoes-gerais`,
+    get: (id: string) => `${prefix}/website/informacoes-gerais/${id}`,
+    update: (id: string) => `${prefix}/website/informacoes-gerais/${id}`,
+    delete: (id: string) => `${prefix}/website/informacoes-gerais/${id}`,
+  },
 };
 
 /**

--- a/src/api/websites/components/index.ts
+++ b/src/api/websites/components/index.ts
@@ -150,6 +150,14 @@ export {
   deleteHeaderPage,
   getHeaderForPage,
 } from "./header-pages";
+export {
+  listInformacoesGerais,
+  getInformacoesGeraisById,
+  createInformacoesGerais,
+  updateInformacoesGerais,
+  deleteInformacoesGerais,
+} from "./informacoes-gerais";
+
 export type {
   AboutApiResponse,
   AboutImageProps,
@@ -259,3 +267,8 @@ export type {
   UpdateHeaderPagePayload,
   HeaderPage,
 } from "./header-pages/types";
+export type {
+  InformacoesGeraisBackendResponse,
+  CreateInformacoesGeraisPayload,
+  UpdateInformacoesGeraisPayload,
+} from "./informacoes-gerais/types";

--- a/src/api/websites/components/informacoes-gerais/index.ts
+++ b/src/api/websites/components/informacoes-gerais/index.ts
@@ -1,0 +1,86 @@
+import { websiteRoutes } from "@/api/routes";
+import { apiFetch } from "@/api/client";
+import { apiConfig } from "@/lib/env";
+import type {
+  InformacoesGeraisBackendResponse,
+  CreateInformacoesGeraisPayload,
+  UpdateInformacoesGeraisPayload,
+} from "./types";
+
+function getAuthHeader(): Record<string, string> {
+  if (typeof document === "undefined") return {};
+  const token = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith("token="))
+    ?.split("=")[1];
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export async function listInformacoesGerais(
+  init?: RequestInit,
+): Promise<InformacoesGeraisBackendResponse[]> {
+  return apiFetch<InformacoesGeraisBackendResponse[]>(
+    websiteRoutes.informacoesGerais.list(),
+    { init: init ?? { headers: apiConfig.headers } },
+  );
+}
+
+export async function getInformacoesGeraisById(
+  id: string,
+): Promise<InformacoesGeraisBackendResponse> {
+  return apiFetch<InformacoesGeraisBackendResponse>(
+    websiteRoutes.informacoesGerais.get(id),
+    { init: { headers: apiConfig.headers } },
+  );
+}
+
+export async function createInformacoesGerais(
+  data: CreateInformacoesGeraisPayload,
+): Promise<InformacoesGeraisBackendResponse> {
+  return apiFetch<InformacoesGeraisBackendResponse>(
+    websiteRoutes.informacoesGerais.create(),
+    {
+      init: {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: apiConfig.headers.Accept,
+          ...getAuthHeader(),
+        },
+        body: JSON.stringify(data),
+      },
+      cache: "no-cache",
+    },
+  );
+}
+
+export async function updateInformacoesGerais(
+  id: string,
+  data: UpdateInformacoesGeraisPayload,
+): Promise<InformacoesGeraisBackendResponse> {
+  return apiFetch<InformacoesGeraisBackendResponse>(
+    websiteRoutes.informacoesGerais.update(id),
+    {
+      init: {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: apiConfig.headers.Accept,
+          ...getAuthHeader(),
+        },
+        body: JSON.stringify(data),
+      },
+      cache: "no-cache",
+    },
+  );
+}
+
+export async function deleteInformacoesGerais(id: string): Promise<void> {
+  await apiFetch<void>(websiteRoutes.informacoesGerais.delete(id), {
+    init: {
+      method: "DELETE",
+      headers: { Accept: apiConfig.headers.Accept, ...getAuthHeader() },
+    },
+    cache: "no-cache",
+  });
+}

--- a/src/api/websites/components/informacoes-gerais/types.ts
+++ b/src/api/websites/components/informacoes-gerais/types.ts
@@ -1,0 +1,27 @@
+export interface InformacoesGeraisBackendResponse {
+  id: string;
+  endereco: string;
+  cep: string;
+  cidade: string;
+  estado: string;
+  telefone1: string;
+  telefone2?: string;
+  whatsapp: string;
+  horarioDeFuncionamento: string;
+  linkedin?: string;
+  facebook?: string;
+  instagram: string;
+  youtube?: string;
+  email: string;
+  criadoEm?: string;
+  atualizadoEm?: string;
+}
+
+export type CreateInformacoesGeraisPayload = Omit<
+  InformacoesGeraisBackendResponse,
+  "id" | "criadoEm" | "atualizadoEm"
+>;
+
+export type UpdateInformacoesGeraisPayload = Partial<
+  CreateInformacoesGeraisPayload
+>;

--- a/src/app/dashboard/config/website/geral/atendimento/AtendimentoForm.tsx
+++ b/src/app/dashboard/config/website/geral/atendimento/AtendimentoForm.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+import { InputCustom, ButtonCustom } from "@/components/ui/custom";
+import { toastCustom } from "@/components/ui/custom/toast";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  listInformacoesGerais,
+  createInformacoesGerais,
+  updateInformacoesGerais,
+} from "@/api/websites/components/informacoes-gerais";
+import type { InformacoesGeraisBackendResponse } from "@/api/websites/components/informacoes-gerais/types";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function AtendimentoForm() {
+  const [id, setId] = useState<string | null>(null);
+  const [weekdayFrom, setWeekdayFrom] = useState("08:00");
+  const [weekdayTo, setWeekdayTo] = useState("20:00");
+  const [saturdayFrom, setSaturdayFrom] = useState("09:00");
+  const [saturdayTo, setSaturdayTo] = useState("13:00");
+  const [closedSaturday, setClosedSaturday] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const data = await listInformacoesGerais({
+          headers: { Accept: "application/json" },
+        });
+        const first: InformacoesGeraisBackendResponse | undefined = data[0];
+        if (first && mounted) {
+          setId(first.id);
+          if (first.horarioDeFuncionamento) {
+            const horario = first.horarioDeFuncionamento;
+            const segMatch = horario.match(/Seg-Sex\s(\d{2}:\d{2})\sàs\s(\d{2}:\d{2})/);
+            const sabMatch = horario.match(/Sáb\s(\d{2}:\d{2})\sàs\s(\d{2}:\d{2})/);
+            const sabFechado = /Sáb\sfechado/i.test(horario);
+            if (segMatch) {
+              setWeekdayFrom(segMatch[1]);
+              setWeekdayTo(segMatch[2]);
+            }
+            if (sabMatch) {
+              setSaturdayFrom(sabMatch[1]);
+              setSaturdayTo(sabMatch[2]);
+            }
+            if (sabFechado) setClosedSaturday(true);
+          }
+        }
+      } catch {
+        // ignore fetch errors
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const horario = closedSaturday
+      ? `Seg-Sex ${weekdayFrom} às ${weekdayTo} | Sáb fechado`
+      : `Seg-Sex ${weekdayFrom} às ${weekdayTo} | Sáb ${saturdayFrom} às ${saturdayTo}`;
+    try {
+      const payload = { horarioDeFuncionamento: horario };
+      if (id) {
+        await updateInformacoesGerais(id, payload);
+      } else {
+        const created = await createInformacoesGerais(payload);
+        setId(created.id);
+      }
+      toastCustom.success("Horário salvo");
+    } catch {
+      toastCustom.error("Erro ao salvar horário");
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-4 max-w-lg">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 max-w-lg">
+      <div className="flex gap-2">
+        <InputCustom
+          label="Seg-Sex de"
+          mask="time"
+          value={weekdayFrom}
+          onChange={(e) => setWeekdayFrom(e.target.value)}
+          required
+        />
+        <InputCustom
+          label="Seg-Sex até"
+          mask="time"
+          value={weekdayTo}
+          onChange={(e) => setWeekdayTo(e.target.value)}
+          required
+        />
+      </div>
+      <div className="flex items-center gap-2">
+        <Checkbox
+          checked={closedSaturday}
+          onCheckedChange={(v) => setClosedSaturday(!!v)}
+          id="saturdayClosed"
+        />
+        <label htmlFor="saturdayClosed" className="text-sm">
+          Sábado não funciona
+        </label>
+      </div>
+      {!closedSaturday && (
+        <div className="flex gap-2">
+          <InputCustom
+            label="Sáb de"
+            mask="time"
+            value={saturdayFrom}
+            onChange={(e) => setSaturdayFrom(e.target.value)}
+            required
+          />
+          <InputCustom
+            label="Sáb até"
+            mask="time"
+            value={saturdayTo}
+            onChange={(e) => setSaturdayTo(e.target.value)}
+            required
+          />
+        </div>
+      )}
+      <ButtonCustom type="submit">Salvar</ButtonCustom>
+    </form>
+  );
+}
+

--- a/src/app/dashboard/config/website/geral/contato/ContatoForm.tsx
+++ b/src/app/dashboard/config/website/geral/contato/ContatoForm.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { FormEvent, useEffect, useState, ChangeEvent } from "react";
+import { InputCustom, ButtonCustom } from "@/components/ui/custom";
+import { toastCustom } from "@/components/ui/custom/toast";
+import {
+  listInformacoesGerais,
+  createInformacoesGerais,
+  updateInformacoesGerais,
+} from "@/api/websites/components/informacoes-gerais";
+import type { InformacoesGeraisBackendResponse } from "@/api/websites/components/informacoes-gerais/types";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface ContatoState {
+  telefone1: string;
+  telefone2: string;
+  whatsapp: string;
+  email: string;
+}
+
+export default function ContatoForm() {
+  const [state, setState] = useState<ContatoState>({
+    telefone1: "",
+    telefone2: "",
+    whatsapp: "",
+    email: "",
+  });
+  const [id, setId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const data = await listInformacoesGerais({
+          headers: { Accept: "application/json" },
+        });
+        const first: InformacoesGeraisBackendResponse | undefined = data[0];
+        if (first && mounted) {
+          setId(first.id);
+          setState({
+            telefone1: first.telefone1 ?? "",
+            telefone2: first.telefone2 ?? "",
+            whatsapp: first.whatsapp ?? "",
+            email: first.email ?? "",
+          });
+        }
+      } catch {
+        toastCustom.error("Não foi possível carregar contatos");
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const handleChange = (field: keyof ContatoState) => (
+    e: ChangeEvent<HTMLInputElement>,
+  ) => {
+    setState((prev) => ({ ...prev, [field]: e.target.value }));
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!state.telefone1 || !state.whatsapp || !state.email) {
+      toastCustom.error("Preencha os campos obrigatórios");
+      return;
+    }
+    try {
+      if (id) {
+        await updateInformacoesGerais(id, state);
+      } else {
+        const created = await createInformacoesGerais(state);
+        setId(created.id);
+      }
+      toastCustom.success("Contatos salvos");
+    } catch {
+      toastCustom.error("Erro ao salvar contatos");
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-4 max-w-lg">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 max-w-lg">
+      <InputCustom
+        label="Telefone (1)"
+        mask="phone"
+        value={state.telefone1}
+        onChange={handleChange("telefone1")}
+        required
+      />
+      <InputCustom
+        label="Telefone (2)"
+        mask="phone"
+        value={state.telefone2}
+        onChange={handleChange("telefone2")}
+      />
+      <InputCustom
+        label="WhatsApp"
+        mask="phone"
+        value={state.whatsapp}
+        onChange={handleChange("whatsapp")}
+        required
+      />
+      <InputCustom
+        label="E-mail"
+        type="email"
+        value={state.email}
+        onChange={handleChange("email")}
+        required
+      />
+      <ButtonCustom type="submit">Salvar</ButtonCustom>
+    </form>
+  );
+}
+

--- a/src/app/dashboard/config/website/geral/endereco/EnderecoForm.tsx
+++ b/src/app/dashboard/config/website/geral/endereco/EnderecoForm.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import {
+  FormEvent,
+  useEffect,
+  useState,
+  ChangeEvent,
+} from "react";
+import { InputCustom, ButtonCustom } from "@/components/ui/custom";
+import { toastCustom } from "@/components/ui/custom/toast";
+import {
+  listInformacoesGerais,
+  createInformacoesGerais,
+  updateInformacoesGerais,
+} from "@/api/websites/components/informacoes-gerais";
+import type { InformacoesGeraisBackendResponse } from "@/api/websites/components/informacoes-gerais/types";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { fetchCepData } from "@/theme/website/components/contact-form-section/utils";
+
+interface StateItem {
+  sigla: string;
+  nome: string;
+}
+
+interface CityItem {
+  id: number;
+  nome: string;
+}
+
+export default function EnderecoForm() {
+  const [id, setId] = useState<string | null>(null);
+  const [cep, setCep] = useState("");
+  const [endereco, setEndereco] = useState("");
+  const [estado, setEstado] = useState("");
+  const [cidade, setCidade] = useState("");
+  const [states, setStates] = useState<StateItem[]>([]);
+  const [cities, setCities] = useState<CityItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const data = await listInformacoesGerais({
+          headers: { Accept: "application/json" },
+        });
+        const first: InformacoesGeraisBackendResponse | undefined = data[0];
+        if (first && mounted) {
+          setId(first.id);
+          setCep(first.cep ?? "");
+          setEndereco(first.endereco ?? "");
+          setEstado(first.estado ?? "");
+          setCidade(first.cidade ?? "");
+        }
+      } catch {
+        toastCustom.error("Não foi possível carregar endereço");
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    fetch("https://servicodados.ibge.gov.br/api/v1/localidades/estados")
+      .then((res) => res.json())
+      .then((data: StateItem[]) =>
+        setStates(data.sort((a, b) => a.nome.localeCompare(b.nome))),
+      )
+      .catch(() => {});
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (estado) {
+      fetch(
+        `https://servicodados.ibge.gov.br/api/v1/localidades/estados/${estado}/municipios`,
+      )
+        .then((res) => res.json())
+        .then((data: CityItem[]) =>
+          setCities(data.sort((a, b) => a.nome.localeCompare(b.nome))),
+        )
+        .catch(() => setCities([]));
+    }
+  }, [estado]);
+
+  const handleCepChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setCep(value);
+    const clean = value.replace(/\D/g, "");
+    if (clean.length === 8) {
+      fetchCepData(value).then((res) => {
+        if (res.address) setEndereco(res.address);
+        if (res.state) setEstado(res.state);
+        if (res.city) setCidade(res.city);
+      });
+    }
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!cep || !endereco || !estado || !cidade) {
+      toastCustom.error("Preencha todos os campos");
+      return;
+    }
+    try {
+      const payload = { cep, endereco, estado, cidade };
+      if (id) {
+        await updateInformacoesGerais(id, payload);
+      } else {
+        const created = await createInformacoesGerais(payload);
+        setId(created.id);
+      }
+      toastCustom.success("Endereço salvo");
+    } catch {
+      toastCustom.error("Erro ao salvar endereço");
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-4 max-w-lg">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 max-w-lg">
+      <InputCustom
+        label="CEP"
+        mask="cep"
+        value={cep}
+        onChange={handleCepChange}
+        required
+      />
+      <InputCustom
+        label="Endereço"
+        value={endereco}
+        onChange={(e) => setEndereco(e.target.value)}
+        required
+      />
+      <Select value={estado} onValueChange={setEstado}>
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder="Estado" />
+        </SelectTrigger>
+        <SelectContent>
+          {states.map((s) => (
+            <SelectItem key={s.sigla} value={s.sigla}>
+              {s.nome}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Select value={cidade} onValueChange={setCidade}>
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder="Cidade" />
+        </SelectTrigger>
+        <SelectContent>
+          {cities.map((c) => (
+            <SelectItem key={c.id} value={c.nome}>
+              {c.nome}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <ButtonCustom type="submit">Salvar</ButtonCustom>
+    </form>
+  );
+}
+

--- a/src/app/dashboard/config/website/geral/page.tsx
+++ b/src/app/dashboard/config/website/geral/page.tsx
@@ -7,9 +7,37 @@ import {
 } from "@/components/ui/custom";
 import LogosForm from "./logos/LogosForm";
 import DepoimentosForm from "./depoimentos/DepoimentosForm";
+import SocialsForm from "./socials/SocialsForm";
+import EnderecoForm from "./endereco/EnderecoForm";
+import ContatoForm from "./contato/ContatoForm";
+import AtendimentoForm from "./atendimento/AtendimentoForm";
 
 export default function GeralPage() {
   const items: VerticalTabItem[] = [
+    {
+      value: "socials",
+      label: "Redes sociais",
+      icon: "Share2",
+      content: <SocialsForm />,
+    },
+    {
+      value: "endereco",
+      label: "Endereço",
+      icon: "MapPin",
+      content: <EnderecoForm />,
+    },
+    {
+      value: "contato",
+      label: "Contato",
+      icon: "Phone",
+      content: <ContatoForm />,
+    },
+    {
+      value: "atendimento",
+      label: "Atendimento",
+      icon: "Clock",
+      content: <AtendimentoForm />,
+    },
     {
       value: "depoimentos",
       label: "Depoimentos",
@@ -29,7 +57,7 @@ export default function GeralPage() {
       <div className="flex-1 min-h-0">
         <VerticalTabs
           items={items}
-          defaultValue="depoimentos"
+          defaultValue="socials"
           variant="spacious"
           size="sm"
           withAnimation={true}

--- a/src/app/dashboard/config/website/geral/socials/SocialsForm.tsx
+++ b/src/app/dashboard/config/website/geral/socials/SocialsForm.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { FormEvent, useEffect, useState, ChangeEvent } from "react";
+import { InputCustom, ButtonCustom } from "@/components/ui/custom";
+import { toastCustom } from "@/components/ui/custom/toast";
+import {
+  listInformacoesGerais,
+  createInformacoesGerais,
+  updateInformacoesGerais,
+} from "@/api/websites/components/informacoes-gerais";
+import type { InformacoesGeraisBackendResponse } from "@/api/websites/components/informacoes-gerais/types";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface SocialsState {
+  instagram: string;
+  facebook: string;
+  youtube: string;
+  linkedin: string;
+}
+
+export default function SocialsForm() {
+  const [state, setState] = useState<SocialsState>({
+    instagram: "",
+    facebook: "",
+    youtube: "",
+    linkedin: "",
+  });
+  const [id, setId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const data = await listInformacoesGerais({
+          headers: { Accept: "application/json" },
+        });
+        const first: InformacoesGeraisBackendResponse | undefined = data[0];
+        if (first && mounted) {
+          setId(first.id);
+          setState({
+            instagram: first.instagram ?? "",
+            facebook: first.facebook ?? "",
+            youtube: first.youtube ?? "",
+            linkedin: first.linkedin ?? "",
+          });
+        }
+      } catch {
+        toastCustom.error("Não foi possível carregar as redes sociais");
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const handleChange = (field: keyof SocialsState) => (
+    e: ChangeEvent<HTMLInputElement>,
+  ) => {
+    setState((prev) => ({ ...prev, [field]: e.target.value }));
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!state.instagram) {
+      toastCustom.error("Instagram é obrigatório");
+      return;
+    }
+    try {
+      if (id) {
+        await updateInformacoesGerais(id, state);
+      } else {
+        const created = await createInformacoesGerais(state);
+        setId(created.id);
+      }
+      toastCustom.success("Redes sociais salvas");
+    } catch {
+      toastCustom.error("Erro ao salvar redes sociais");
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-4 max-w-lg">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 max-w-lg">
+      <InputCustom
+        label="Instagram"
+        value={state.instagram}
+        onChange={handleChange("instagram")}
+        required
+      />
+      <InputCustom
+        label="Facebook"
+        value={state.facebook}
+        onChange={handleChange("facebook")}
+      />
+      <InputCustom
+        label="YouTube"
+        value={state.youtube}
+        onChange={handleChange("youtube")}
+      />
+      <InputCustom
+        label="LinkedIn"
+        value={state.linkedin}
+        onChange={handleChange("linkedin")}
+      />
+      <ButtonCustom type="submit">Salvar</ButtonCustom>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add API routes and client for website general info
- implement dashboard forms for socials, address, contact, and schedule
- extend geral page with new configuration tabs

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbae9d231c832589f59df69d9b7b13