### PR TITLE
Allow partial general info payloads

### DIFF
--- a/src/api/websites/components/informacoes-gerais/types.ts
+++ b/src/api/websites/components/informacoes-gerais/types.ts
@@ -17,11 +17,8 @@ export interface InformacoesGeraisBackendResponse {
   atualizadoEm?: string;
 }
 
-export type CreateInformacoesGeraisPayload = Omit<
-  InformacoesGeraisBackendResponse,
-  "id" | "criadoEm" | "atualizadoEm"
+export type CreateInformacoesGeraisPayload = Partial<
+  Omit<InformacoesGeraisBackendResponse, "id" | "criadoEm" | "atualizadoEm">
 >;
 
-export type UpdateInformacoesGeraisPayload = Partial<
-  CreateInformacoesGeraisPayload
->;
+export type UpdateInformacoesGeraisPayload = CreateInformacoesGeraisPayload;


### PR DESCRIPTION
## Summary
- allow partial field set when creating or updating website general info

## Testing
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbb20663f88325b87f8227c245c4bf