### PR TITLE
feat: show user profile button when logged in

### DIFF
--- a/src/components/ui/custom/user-button/components/UserButton.tsx
+++ b/src/components/ui/custom/user-button/components/UserButton.tsx
@@ -30,12 +30,9 @@ interface User {
 }
 
 const UserButtonSkeleton = () => (
-  <div className="flex items-center justify-center gap-3 px-0">
+  <div className="flex items-center justify-center gap-2">
     <Skeleton className="h-8 w-8 rounded-full bg-white/20" />
-    <div className="hidden md:block">
-      <Skeleton className="h-4 w-24 bg-white/20" />
-    </div>
-    <Skeleton className="h-3 w-3 rounded bg-white/10" />
+    <Skeleton className="h-3 w-3 rounded bg-white/10 hidden sm:block" />
   </div>
 );
 
@@ -150,7 +147,8 @@ export function UserButton({ className, onNavigate }: UserButtonProps) {
         <Button
           variant="ghost"
           className={cn(
-            "group relative h-10 px-3 rounded-xl hover:bg-white/10 active:scale-95",
+            "group relative h-10 rounded-xl hover:bg-white/10 active:scale-95",
+            "px-2 sm:px-3",
             "transition-all duration-200",
             "focus-visible:outline-none focus-visible:ring-0",
             className
@@ -160,7 +158,13 @@ export function UserButton({ className, onNavigate }: UserButtonProps) {
             <div className="relative">
               <AvatarCustom name={displayName} size="sm" showStatus={false} />
             </div>
-            <div className={cn("transition-transform duration-200", isOpen ? "rotate-180" : "rotate-0")}> 
+            <div
+              className={cn(
+                "transition-transform duration-200",
+                isOpen ? "rotate-180" : "rotate-0",
+                "hidden sm:block"
+              )}
+            >
               <Icon name="ChevronDown" size={14} className="text-white/70" />
             </div>
           </div>

--- a/src/theme/website/header/components/ActionButtons.tsx
+++ b/src/theme/website/header/components/ActionButtons.tsx
@@ -1,7 +1,10 @@
-import React from "react";
+"use client";
+
+import React, { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import { MenuIcon, CloseIcon } from "../icons";
 import { NavLink } from "./NavLink";
+import { UserButton } from "@/components/ui/custom/user-button";
 
 interface ActionButtonsProps {
   isMobileMenuOpen: boolean;
@@ -12,35 +15,50 @@ export const ActionButtons: React.FC<ActionButtonsProps> = ({
   isMobileMenuOpen,
   onToggleMobileMenu,
 }) => {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  useEffect(() => {
+    const hasToken = document.cookie
+      .split("; ")
+      .some((row) => row.startsWith("token="));
+    setIsAuthenticated(hasToken);
+  }, []);
+
   return (
     <div className="flex items-center flex-shrink-0 space-x-4 lg:space-x-6">
-      <motion.div
-        className="bg-white px-4 py-1 rounded-md hidden md:inline-block"
-        whileHover={{ scale: 1.03, y: -1 }}
-        whileTap={{ scale: 0.97 }}
-        transition={{ type: "spring", stiffness: 400, damping: 15 }}
-      >
-        <NavLink
-          href="https://auth.advancemais.com/login"
-          className="text-base text-[var(--color-blue)] hover:text-[var(--color-blue)]"
-        >
-          Entrar
-        </NavLink>
-      </motion.div>
+      {!isAuthenticated && (
+        <>
+          <motion.div
+            className="bg-white px-4 py-1 rounded-md hidden md:inline-block"
+            whileHover={{ scale: 1.03, y: -1 }}
+            whileTap={{ scale: 0.97 }}
+            transition={{ type: "spring", stiffness: 400, damping: 15 }}
+          >
+            <NavLink
+              href="https://auth.advancemais.com/login"
+              className="text-base text-[var(--color-blue)] hover:text-[var(--color-blue)]"
+            >
+              Entrar
+            </NavLink>
+          </motion.div>
 
-      <motion.div
-        className="bg-[var(--secondary-color)] px-4 py-1 rounded-md"
-        whileHover={{ scale: 1.03, y: -1 }}
-        whileTap={{ scale: 0.97 }}
-        transition={{ type: "spring", stiffness: 400, damping: 15 }}
-      >
-        <NavLink
-          href="https://auth.advancemais.com/register"
-          className="text-base text-white hover:text-white"
-        >
-          Cadastre-se
-        </NavLink>
-      </motion.div>
+          <motion.div
+            className="bg-[var(--secondary-color)] px-4 py-1 rounded-md"
+            whileHover={{ scale: 1.03, y: -1 }}
+            whileTap={{ scale: 0.97 }}
+            transition={{ type: "spring", stiffness: 400, damping: 15 }}
+          >
+            <NavLink
+              href="https://auth.advancemais.com/register"
+              className="text-base text-white hover:text-white"
+            >
+              Cadastre-se
+            </NavLink>
+          </motion.div>
+        </>
+      )}
+
+      {isAuthenticated && <UserButton />}
 
       <motion.button
         className="md:hidden text-gray-300 hover:text-white z-50"

--- a/src/theme/website/header/components/MobileMenu.tsx
+++ b/src/theme/website/header/components/MobileMenu.tsx
@@ -1,4 +1,6 @@
-import React from "react";
+"use client";
+
+import React, { useEffect, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { NavLink } from "./NavLink";
 import { MOBILE_MENU_VARIANTS } from "../constants/animations";
@@ -10,6 +12,15 @@ interface MobileMenuProps {
 }
 
 export const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose }) => {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  useEffect(() => {
+    const hasToken = document.cookie
+      .split("; ")
+      .some((row) => row.startsWith("token="));
+    setIsAuthenticated(hasToken);
+  }, []);
+
   return (
     <AnimatePresence>
       {isOpen && (
@@ -28,9 +39,11 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose }) => {
               </NavLink>
             ))}
             <hr className="w-full border-t border-gray-700/50 my-2" />
-            <NavLink href="https://auth.advancemais.com/login" onClick={onClose}>
-              Entrar
-            </NavLink>
+            {!isAuthenticated && (
+              <NavLink href="https://auth.advancemais.com/login" onClick={onClose}>
+                Entrar
+              </NavLink>
+            )}
           </div>
         </motion.div>
       )}


### PR DESCRIPTION
## Summary
- replace login/register with UserButton when authenticated
- hide mobile menu login for authenticated users
- make UserButton responsive on small screens

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc86d938b08325a1a04cf9ec26f54f