### PR TITLE
feat: add mobile team carousel and five-column layout

### DIFF
--- a/src/theme/website/components/team-showcase/TeamShowcase.tsx
+++ b/src/theme/website/components/team-showcase/TeamShowcase.tsx
@@ -2,10 +2,11 @@
 
 "use client";
 
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { TeamMember } from "./components/TeamMember";
+import { TeamSlider } from "./components/TeamSlider";
 import { useTeamData } from "./hooks/useTeamData";
 import { ImageNotFound } from "@/components/ui/custom/image-not-found";
 import { ButtonCustom } from "@/components/ui/custom/button";
@@ -24,6 +25,18 @@ const TeamShowcase: React.FC<TeamShowcaseProps> = ({
     fetchFromApi,
     staticData
   );
+
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth < 768);
+    };
+
+    checkMobile();
+    window.addEventListener("resize", checkMobile);
+    return () => window.removeEventListener("resize", checkMobile);
+  }, []);
 
   useEffect(() => {
     if (data && data.length > 0 && !isLoading) {
@@ -49,7 +62,7 @@ const TeamShowcase: React.FC<TeamShowcaseProps> = ({
           </div>
 
           {/* Grid skeleton */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-6">
             {Array.from({ length: 8 }).map((_, index) => (
               <div
                 key={index}
@@ -132,15 +145,19 @@ const TeamShowcase: React.FC<TeamShowcaseProps> = ({
           </h2>
         </motion.div>
 
-        {/* Grid de membros - responsivo e 4 por linha em telas amplas */}
-        <div
-          className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
-          style={{ gap: "var(--team-gap, 1.25rem)" }}
-        >
-          {data.map((member, index) => (
-            <TeamMember key={member.id} data={member} index={index} />
-          ))}
-        </div>
+        {/* Grid/Slider de membros */}
+        {isMobile ? (
+          <TeamSlider members={data} />
+        ) : (
+          <div
+            className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5"
+            style={{ gap: "var(--team-gap, 1.25rem)" }}
+          >
+            {data.map((member, index) => (
+              <TeamMember key={member.id} data={member} index={index} />
+            ))}
+          </div>
+        )}
       </div>
     </section>
   );

--- a/src/theme/website/components/team-showcase/components/TeamMember.tsx
+++ b/src/theme/website/components/team-showcase/components/TeamMember.tsx
@@ -34,7 +34,7 @@ export const TeamMember: React.FC<TeamMemberProps> = ({ data, index }) => {
       initial={{ opacity: 0, y: 20 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, margin: "-50px" }}
-      transition={{ duration: 0.5, delay: (index % 4) * 0.08, ease: "easeOut" }}
+      transition={{ duration: 0.5, delay: (index % 5) * 0.08, ease: "easeOut" }}
     >
       <Card
         className="group relative overflow-hidden !p-0 rounded-2xl transition-transform duration-500 !border-none"

--- a/src/theme/website/components/team-showcase/components/TeamSlider.tsx
+++ b/src/theme/website/components/team-showcase/components/TeamSlider.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import React from "react";
+import useEmblaCarousel from "embla-carousel-react";
+import Autoplay from "embla-carousel-autoplay";
+import { TeamMember } from "./TeamMember";
+import type { TeamMemberData } from "../types";
+
+interface TeamSliderProps {
+  members: TeamMemberData[];
+}
+
+const AUTOPLAY_OPTIONS = { delay: 4000, stopOnInteraction: true };
+
+export const TeamSlider: React.FC<TeamSliderProps> = ({ members }) => {
+  const [emblaRef] = useEmblaCarousel(
+    {
+      loop: true,
+      align: "center",
+      dragFree: false,
+    },
+    [Autoplay(AUTOPLAY_OPTIONS)]
+  );
+
+  return (
+    <div className="relative">
+      <div ref={emblaRef} className="overflow-hidden">
+        <div className="flex gap-4 px-4">
+          {members.map((member, index) => (
+            <div key={member.id} className="flex-none w-[85vw] max-w-[320px]">
+              <TeamMember data={member} index={index} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- show five team members per row on large screens
- add mobile carousel for team members using embla

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2fd78bbe08325a4d8320b0ad4fe7f