### PR TITLE
feat: load login image from API

### DIFF
--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -152,6 +152,13 @@ export const websiteRoutes = {
     update: (id: string) => `${prefix}/website/header-pages/${id}`,
     delete: (id: string) => `${prefix}/website/header-pages/${id}`,
   },
+  loginImage: {
+    list: () => `${prefix}/website/imagem-login`,
+    create: () => `${prefix}/website/imagem-login`,
+    get: (id: string) => `${prefix}/website/imagem-login/${id}`,
+    update: (id: string) => `${prefix}/website/imagem-login/${id}`,
+    delete: (id: string) => `${prefix}/website/imagem-login/${id}`,
+  },
   informacoesGerais: {
     list: () => `${prefix}/website/informacoes-gerais`,
     create: () => `${prefix}/website/informacoes-gerais`,

--- a/src/api/websites/components/imagem-login/index.ts
+++ b/src/api/websites/components/imagem-login/index.ts
@@ -1,0 +1,129 @@
+/**
+ * API Client para componente Imagem de Login
+ * Busca dados da imagem exibida na página de login
+ */
+
+import { websiteRoutes } from "@/api/routes";
+import { apiFetch } from "@/api/client";
+import { apiConfig, env } from "@/lib/env";
+import { loginImageMockData } from "./mock";
+import type {
+  LoginImageItem,
+  LoginImageBackendResponse,
+  CreateLoginImagePayload,
+  UpdateLoginImagePayload,
+} from "./types";
+
+function mapLoginImageResponse(
+  data: LoginImageBackendResponse[],
+): LoginImageItem | null {
+  const latest = data[data.length - 1];
+  if (!latest) return null;
+  return {
+    id: latest.id,
+    imagemUrl: latest.imagemUrl,
+    imagemTitulo: latest.imagemTitulo,
+    link: latest.link ?? undefined,
+  };
+}
+
+export async function getLoginImageData(): Promise<LoginImageItem | null> {
+  try {
+    const raw = await listLoginImages({
+      headers: apiConfig.headers,
+      ...apiConfig.cache.medium,
+    });
+    return mapLoginImageResponse(raw);
+  } catch (error) {
+    console.error("❌ Erro ao buscar imagem de login:", error);
+    if (env.apiFallback === "mock") {
+      return loginImageMockData;
+    }
+    throw new Error("Falha ao carregar imagem de login");
+  }
+}
+
+export async function getLoginImageDataClient(): Promise<
+  LoginImageItem | null
+> {
+  try {
+    const raw = await listLoginImages({ headers: apiConfig.headers });
+    return mapLoginImageResponse(raw);
+  } catch (error) {
+    console.error("❌ Erro ao buscar imagem de login (client):", error);
+    if (env.apiFallback === "mock") {
+      return loginImageMockData;
+    }
+    throw new Error("Falha ao carregar imagem de login");
+  }
+}
+
+export async function listLoginImages(
+  init?: RequestInit,
+): Promise<LoginImageBackendResponse[]> {
+  return apiFetch<LoginImageBackendResponse[]>(
+    websiteRoutes.loginImage.list(),
+    { init: init ?? { headers: apiConfig.headers }, cache: "no-cache" },
+  );
+}
+
+export async function getLoginImageById(
+  id: string,
+): Promise<LoginImageBackendResponse> {
+  return apiFetch<LoginImageBackendResponse>(
+    websiteRoutes.loginImage.get(id),
+    { init: { headers: apiConfig.headers }, cache: "no-cache" },
+  );
+}
+
+function getAuthHeader(): Record<string, string> {
+  if (typeof document === "undefined") return {};
+  const token = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith("token="))
+    ?.split("=")[1];
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+function buildRequest(
+  data: CreateLoginImagePayload | UpdateLoginImagePayload,
+): { body: BodyInit; headers: Record<string, string> } {
+  const headers = { Accept: apiConfig.headers.Accept, ...getAuthHeader() };
+  const form = new FormData();
+  if (data.imagem) form.append("imagem", data.imagem);
+  if (data.imagemUrl) form.append("imagemUrl", data.imagemUrl);
+  if (data.imagemTitulo) form.append("imagemTitulo", data.imagemTitulo);
+  if (data.link) form.append("link", data.link);
+  return { body: form, headers };
+}
+
+export async function createLoginImage(
+  data: CreateLoginImagePayload,
+): Promise<LoginImageBackendResponse> {
+  const { body, headers } = buildRequest(data);
+  return apiFetch<LoginImageBackendResponse>(
+    websiteRoutes.loginImage.create(),
+    { init: { method: "POST", body, headers }, cache: "no-cache" },
+  );
+}
+
+export async function updateLoginImage(
+  id: string,
+  data: UpdateLoginImagePayload,
+): Promise<LoginImageBackendResponse> {
+  const { body, headers } = buildRequest(data);
+  return apiFetch<LoginImageBackendResponse>(
+    websiteRoutes.loginImage.update(id),
+    { init: { method: "PUT", body, headers }, cache: "no-cache" },
+  );
+}
+
+export async function deleteLoginImage(id: string): Promise<void> {
+  await apiFetch<void>(websiteRoutes.loginImage.delete(id), {
+    init: {
+      method: "DELETE",
+      headers: { Accept: apiConfig.headers.Accept, ...getAuthHeader() },
+    },
+    cache: "no-cache",
+  });
+}

--- a/src/api/websites/components/imagem-login/mock/index.ts
+++ b/src/api/websites/components/imagem-login/mock/index.ts
@@ -1,0 +1,13 @@
+import type { LoginImageItem } from "../types";
+
+export const loginImageMockData: LoginImageItem = {
+  id: "login-mock-id",
+  imagemUrl: "/images/login/mock-login.webp",
+  imagemTitulo: "login",
+  link: "#",
+};
+
+export async function getLoginImageDataMock(): Promise<LoginImageItem> {
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  return loginImageMockData;
+}

--- a/src/api/websites/components/imagem-login/types.ts
+++ b/src/api/websites/components/imagem-login/types.ts
@@ -1,0 +1,24 @@
+export interface LoginImageBackendResponse {
+  id: string;
+  imagemUrl: string;
+  imagemTitulo: string;
+  link?: string | null;
+  criadoEm: string;
+  atualizadoEm: string;
+}
+
+export interface LoginImageItem {
+  id: string;
+  imagemUrl: string;
+  imagemTitulo: string;
+  link?: string | null;
+}
+
+export interface CreateLoginImagePayload {
+  imagem?: File;
+  imagemUrl?: string;
+  imagemTitulo?: string;
+  link?: string;
+}
+
+export type UpdateLoginImagePayload = CreateLoginImagePayload;

--- a/src/api/websites/components/index.ts
+++ b/src/api/websites/components/index.ts
@@ -157,6 +157,15 @@ export {
   updateInformacoesGerais,
   deleteInformacoesGerais,
 } from "./informacoes-gerais";
+export {
+  getLoginImageData,
+  getLoginImageDataClient,
+  listLoginImages,
+  getLoginImageById,
+  createLoginImage,
+  updateLoginImage,
+  deleteLoginImage,
+} from "./imagem-login";
 
 export type {
   AboutApiResponse,
@@ -272,3 +281,9 @@ export type {
   CreateInformacoesGeraisPayload,
   UpdateInformacoesGeraisPayload,
 } from "./informacoes-gerais/types";
+export type {
+  LoginImageBackendResponse,
+  LoginImageItem,
+  CreateLoginImagePayload,
+  UpdateLoginImagePayload,
+} from "./imagem-login/types";

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -7,10 +7,13 @@ import { apiFetch } from "@/api/client";
 import { usuarioRoutes } from "@/api/routes";
 import { toastCustom } from "@/components/ui/custom/toast";
 import { UserRole } from "@/config/roles";
+import { getLoginImageDataClient } from "@/api/websites/components";
 
 const SignInPageDemo = () => {
   const [userName, setUserName] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const [heroImageSrc, setHeroImageSrc] = useState<string | undefined>();
+  const [heroImageLink, setHeroImageLink] = useState<string | undefined>();
   const searchParams = useSearchParams();
 
   useEffect(() => {
@@ -28,6 +31,17 @@ const SignInPageDemo = () => {
       );
     }
   }, [searchParams]);
+
+  useEffect(() => {
+    getLoginImageDataClient()
+      .then((data) => {
+        if (data?.imagemUrl) setHeroImageSrc(data.imagemUrl);
+        if (data?.link) setHeroImageLink(data.link || undefined);
+      })
+      .catch((err) => {
+        console.error("Erro ao carregar imagem de login:", err);
+      });
+  }, []);
 
   const handleSignIn = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -127,7 +141,8 @@ const SignInPageDemo = () => {
   return (
     <div className="bg-background text-foreground">
       <SignInPage
-        heroImageSrc="https://images.unsplash.com/photo-1642615835477-d303d7dc9ee9?w=2160&q=80"
+        heroImageSrc={heroImageSrc}
+        heroImageLink={heroImageLink}
         onSignIn={handleSignIn}
         onResetPassword={handleResetPassword}
         onCreateAccount={handleCreateAccount}

--- a/src/app/dashboard/config/dashboard/geral/login/LoginForm.tsx
+++ b/src/app/dashboard/config/dashboard/geral/login/LoginForm.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useEffect, useState, FormEvent } from "react";
+import {
+  FileUpload,
+  type FileUploadItem,
+  InputCustom,
+  ButtonCustom,
+} from "@/components/ui/custom";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toastCustom } from "@/components/ui/custom/toast";
+import {
+  listLoginImages,
+  createLoginImage,
+  updateLoginImage,
+  type LoginImageBackendResponse,
+} from "@/api/websites/components";
+
+interface LoginContent {
+  id?: string;
+  imagemUrl?: string;
+  link?: string;
+  imagemTitulo?: string;
+}
+
+export default function LoginForm() {
+  const [content, setContent] = useState<LoginContent>({});
+  const [files, setFiles] = useState<FileUploadItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isFetching, setIsFetching] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await listLoginImages({ headers: { Accept: "application/json" } });
+        const latest: LoginImageBackendResponse | undefined = data[data.length - 1];
+        if (latest) {
+          setContent({
+            id: latest.id,
+            imagemUrl: latest.imagemUrl,
+            link: latest.link ?? undefined,
+            imagemTitulo: latest.imagemTitulo,
+          });
+          const item: FileUploadItem = {
+            id: "existing",
+            name: latest.imagemTitulo || "imagem",
+            size: 0,
+            type: "image",
+            status: "completed",
+            uploadDate: new Date(latest.criadoEm),
+            previewUrl: latest.imagemUrl,
+            uploadedUrl: latest.imagemUrl,
+          };
+          setFiles([item]);
+        }
+      } catch (err) {
+        toastCustom.error("Não foi possível carregar a imagem de login");
+      } finally {
+        setIsFetching(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  const handleFilesChange = (list: FileUploadItem[]) => {
+    setFiles(list);
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (files.length === 0) return;
+    setIsLoading(true);
+    try {
+      const file = files[0]?.file;
+      let resp: LoginImageBackendResponse;
+      if (content.id) {
+        resp = await updateLoginImage(content.id, {
+          imagem: file,
+          link: content.link,
+          imagemTitulo: file ? file.name : content.imagemTitulo,
+        });
+      } else {
+        resp = await createLoginImage({
+          imagem: file!,
+          link: content.link,
+          imagemTitulo: file?.name || "login",
+        });
+      }
+      setContent({
+        id: resp.id,
+        imagemUrl: resp.imagemUrl,
+        link: resp.link ?? undefined,
+        imagemTitulo: resp.imagemTitulo,
+      });
+      setFiles([
+        {
+          id: "existing",
+          name: resp.imagemTitulo || "imagem",
+          size: 0,
+          type: "image",
+          status: "completed",
+          uploadDate: new Date(resp.criadoEm),
+          previewUrl: resp.imagemUrl,
+          uploadedUrl: resp.imagemUrl,
+        },
+      ]);
+      toastCustom.success("Imagem de login salva com sucesso");
+    } catch (err) {
+      toastCustom.error("Erro ao salvar imagem de login");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      {isFetching ? (
+        <div className="space-y-6">
+          <Skeleton className="h-40 w-full" />
+          <Skeleton className="h-10 w-1/3" />
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="space-y-4">
+            <Label className="text-sm font-medium text-gray-700">
+              Imagem de Login <span className="text-red-500">*</span>
+            </Label>
+            <FileUpload
+              files={files}
+              multiple={false}
+              maxFiles={1}
+              validation={{ accept: [".jpg", ".png", ".webp"] }}
+              autoUpload={false}
+              deleteOnRemove={false}
+              onFilesChange={handleFilesChange}
+              showProgress={false}
+            />
+          </div>
+
+          <div>
+            <InputCustom
+              label="Link"
+              id="link"
+              value={content.link ?? ""}
+              onChange={(e) =>
+                setContent((prev) => ({ ...prev, link: e.target.value }))
+              }
+              maxLength={255}
+              placeholder="https://example.com"
+            />
+          </div>
+
+          <div className="pt-4 flex justify-end">
+            <ButtonCustom
+              type="submit"
+              isLoading={isLoading}
+              disabled={
+                isLoading ||
+                files.length === 0 ||
+                files.some((f) => f.status === "uploading")
+              }
+              size="lg"
+              variant="default"
+              className="w-40"
+              withAnimation
+            >
+              Salvar
+            </ButtonCustom>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}
+

--- a/src/app/dashboard/config/dashboard/geral/page.tsx
+++ b/src/app/dashboard/config/dashboard/geral/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import React from "react";
+import {
+  VerticalTabs,
+  type VerticalTabItem,
+} from "@/components/ui/custom";
+import LoginForm from "./login/LoginForm";
+
+export default function GeralDashboardPage() {
+  const items: VerticalTabItem[] = [
+    {
+      value: "login",
+      label: "Login",
+      icon: "LogIn",
+      content: <LoginForm />,
+    },
+  ];
+
+  return (
+    <div className="bg-white rounded-3xl p-5 h-full min-h-[calc(100vh-8rem)] flex flex-col">
+      <div className="flex-1 min-h-0">
+        <VerticalTabs
+          items={items}
+          defaultValue="login"
+          variant="spacious"
+          size="sm"
+          withAnimation
+          showIndicator
+          tabsWidth="md"
+          classNames={{
+            root: "h-full",
+            contentWrapper: "h-full overflow-hidden",
+            tabsContent: "h-full overflow-auto p-6",
+            tabsList: "p-2",
+            tabsTrigger: "mb-1",
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/partials/auth/login/sign-in.tsx
+++ b/src/components/partials/auth/login/sign-in.tsx
@@ -12,6 +12,7 @@ interface SignInPageProps {
   title?: React.ReactNode;
   description?: React.ReactNode;
   heroImageSrc?: string;
+  heroImageLink?: string;
   onSignIn?: (event: React.FormEvent<HTMLFormElement>) => void;
   onResetPassword?: () => void;
   onCreateAccount?: () => void;
@@ -30,6 +31,7 @@ export const SignInPage: React.FC<SignInPageProps> = ({
   ),
   description,
   heroImageSrc,
+  heroImageLink,
   onSignIn,
   onResetPassword,
   onCreateAccount,
@@ -204,10 +206,24 @@ export const SignInPage: React.FC<SignInPageProps> = ({
       {/* Right column: hero image + testimonials */}
       {heroImageSrc && (
         <section className="hidden md:block flex-1 relative p-4">
-          <div
-            className="animate-slide-right animate-delay-300 absolute inset-4 rounded-3xl bg-cover bg-center"
-            style={{ backgroundImage: `url(${heroImageSrc})` }}
-          ></div>
+          {heroImageLink ? (
+            <a
+              href={heroImageLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block w-full h-full"
+            >
+              <div
+                className="animate-slide-right animate-delay-300 absolute inset-4 rounded-3xl bg-cover bg-center"
+                style={{ backgroundImage: `url(${heroImageSrc})` }}
+              ></div>
+            </a>
+          ) : (
+            <div
+              className="animate-slide-right animate-delay-300 absolute inset-4 rounded-3xl bg-cover bg-center"
+              style={{ backgroundImage: `url(${heroImageSrc})` }}
+            ></div>
+          )}
         </section>
       )}
     </div>

--- a/src/lib/breadcrumb-config.ts
+++ b/src/lib/breadcrumb-config.ts
@@ -70,4 +70,13 @@ export const breadcrumbConfig: Record<string, BreadcrumbConfig> = {
       { label: 'Treinamento', icon: 'BookOpen' }
     ]
   },
+  '/config/dashboard/geral': {
+    title: 'Configuração Dashboard',
+    items: [
+      { label: 'Dashboard', href: '/dashboard', icon: 'Home' },
+      { label: 'Configurações', href: '/dashboard/config', icon: 'Settings' },
+      { label: 'Dashboard', href: '/dashboard/config/dashboard', icon: 'LayoutDashboard' },
+      { label: 'Geral', icon: 'Settings' }
+    ]
+  },
 };

--- a/src/theme/dashboard/sidebar/config/menuConfig.ts
+++ b/src/theme/dashboard/sidebar/config/menuConfig.ts
@@ -237,8 +237,8 @@ const rawMenuSections: MenuSection[] = [
             submenu: [
               {
                 icon: null,
-                label: "Planos empresarial",
-                route: "/admin/dashboard/enterprise-plans",
+                label: "Geral",
+                route: "/config/dashboard/geral",
                 permissions: ADMIN_PERMISSIONS,
               },
             ],


### PR DESCRIPTION
## Summary
- add dashboard config page for login image
- implement login image form with upload and link
- wire admin menu and breadcrumbs to new page

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3093fa5148325a65e4a3c8e191c4e