### PR TITLE
feat: allow layout dashboard breadcrumb icon

### DIFF
--- a/src/config/breadcrumb.ts
+++ b/src/config/breadcrumb.ts
@@ -1,8 +1,9 @@
 export type IconName = 
   | "Home" 
   | "Settings" 
-  | "Globe" 
-  | "Layout" 
+  | "Globe"
+  | "Layout"
+  | "LayoutDashboard"
   | "ChevronRight"
   | "Save"
   | "User"


### PR DESCRIPTION
## Summary
- include `LayoutDashboard` in `IconName` union for breadcrumbs

## Testing
- `pnpm test`
- `pnpm type-check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c312a9b0a08325b635e79792a32b72