### PR TITLE
Allow login to accept CPF and CNPJ documents

### DIFF
--- a/src/components/partials/auth/login/sign-in.tsx
+++ b/src/components/partials/auth/login/sign-in.tsx
@@ -51,7 +51,6 @@ export const SignInPage: React.FC<SignInPageProps> = ({
 
   // Determina se é CPF (11 dígitos) ou CNPJ (14 dígitos)
   const documentoDigits = documento.replace(/\D/g, "");
-  const documentoMask = documentoDigits.length <= 11 ? "cpf" : "cnpj";
 
   // Validação do formulário
   const isFormValid =
@@ -106,7 +105,7 @@ export const SignInPage: React.FC<SignInPageProps> = ({
                   name="documento"
                   value={documento}
                   onChange={(e) => setDocumento(e.target.value)}
-                  mask={documentoMask}
+                  mask="cpfCnpj"
                   placeholder="Digite seu CPF ou CNPJ"
                   required
                   size="md"

--- a/src/services/components/input/maskService.test.ts
+++ b/src/services/components/input/maskService.test.ts
@@ -17,4 +17,14 @@ describe('MaskService applyMask deletion', () => {
     const withoutDigit = service.processInput('12.345.678/0001-', 'cnpj');
     expect(withoutDigit).toBe('12.345.678/0001');
   });
+
+  it('applies CPF format when using cpfCnpj mask with 11 digits', () => {
+    const formatted = service.processInput('12345678901', 'cpfCnpj');
+    expect(formatted).toBe('123.456.789-01');
+  });
+
+  it('switches to CNPJ format when using cpfCnpj mask with more than 11 digits', () => {
+    const formatted = service.processInput('12345678901234', 'cpfCnpj');
+    expect(formatted).toBe('12.345.678/9012-34');
+  });
 });

--- a/src/services/components/input/maskService.ts
+++ b/src/services/components/input/maskService.ts
@@ -21,6 +21,7 @@ class MaskService {
       mask: "99.999.999/9999-99",
       alwaysShowMask: false,
     },
+    cpfCnpj: null,
     phone: {
       mask: "(99) 99999-9999",
       alwaysShowMask: false,
@@ -174,6 +175,7 @@ class MaskService {
     switch (maskType) {
       case "cpf":
       case "cnpj":
+      case "cpfCnpj":
       case "phone":
       case "cep":
       case "date":
@@ -239,6 +241,12 @@ class MaskService {
       case "cnpj":
         return this.validationPatterns.cnpj.test(value);
 
+      case "cpfCnpj":
+        return (
+          this.validationPatterns.cpf.test(value) ||
+          this.validationPatterns.cnpj.test(value)
+        );
+
       case "cep":
         return this.validationPatterns.cep.test(value);
 
@@ -265,6 +273,12 @@ class MaskService {
 
     if (maskType === "alphanumeric") {
       return value.replace(/[^a-zA-Z0-9]/g, "");
+    }
+
+    if (maskType === "cpfCnpj") {
+      const digits = value.replace(/[^\d]/g, "");
+      const targetMask: MaskType = digits.length > 11 ? "cnpj" : "cpf";
+      return this.applyMask(digits, targetMask);
     }
     const unmaskedValue = this.removeMask(value, maskType);
     return this.applyMask(unmaskedValue, maskType, customConfig);

--- a/src/types/components/input.ts
+++ b/src/types/components/input.ts
@@ -10,6 +10,7 @@ import { InputHTMLAttributes } from "react";
 export type MaskType =
   | "cpf"
   | "cnpj"
+  | "cpfCnpj"
   | "phone"
   | "cep"
   | "date"


### PR DESCRIPTION
## Summary
- add a combined CPF/CNPJ mask type to the shared mask service and types
- apply the new mask to the login document field so both CPF and CNPJ inputs are accepted
- extend mask service tests to cover the combined mask behaviour

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cac8712c008325bafab5aed463a42d