### PR TITLE
Fix email verification routes to use brevo endpoints

### DIFF
--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -200,10 +200,10 @@ export const usuarioRoutes = {
   },
   verification: {
     verify: (token: string) =>
-      `${prefix}/usuarios/verificar-email?token=${encodeURIComponent(token)}`,
-    resend: () => `${prefix}/usuarios/reenviar-verificacao`,
+      `${prefix}/brevo/verificar-email?token=${encodeURIComponent(token)}`,
+    resend: () => `${prefix}/brevo/reenviar-verificacao`,
     status: (userId: string) =>
-      `${prefix}/usuarios/status-verificacao/${encodeURIComponent(userId)}`,
+      `${prefix}/brevo/status-verificacao/${encodeURIComponent(userId)}`,
   },
 };
 


### PR DESCRIPTION
## Summary
- point email verification routes back to the brevo service endpoints

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cac8f3d8988325b8da2c5cacf2eeee