### PR TITLE
feat(menu): add companies submenu entry

### DIFF
--- a/src/theme/dashboard/sidebar/config/menuConfig.ts
+++ b/src/theme/dashboard/sidebar/config/menuConfig.ts
@@ -126,6 +126,12 @@ const rawMenuSections: MenuSection[] = [
           },
           {
             icon: null,
+            label: "Empresas",
+            route: "/admin/companies/list",
+            permissions: ADMIN_PERMISSIONS,
+          },
+          {
+            icon: null,
             label: "Vagas",
             route: "/admin/companies/jobs",
             permissions: ADMIN_PERMISSIONS,


### PR DESCRIPTION
## Summary
- add a new "Empresas" submenu entry for the admin companies section before the existing jobs link

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cad78c9fc883259d17409ad77ea29b