### PR TITLE
Surface enterprise pricing plans on recruitment page

### DIFF
--- a/src/api/empresas/index.ts
+++ b/src/api/empresas/index.ts
@@ -1,0 +1,13 @@
+export {
+  listPlanosEmpresariais,
+  getPlanoEmpresarialById,
+  createPlanoEmpresarial,
+  updatePlanoEmpresarial,
+  deletePlanoEmpresarial,
+} from "./planos-empresarial";
+
+export type {
+  PlanoEmpresarialBackendResponse,
+  CreatePlanoEmpresarialPayload,
+  UpdatePlanoEmpresarialPayload,
+} from "./planos-empresarial/types";

--- a/src/api/empresas/planos-empresarial/index.ts
+++ b/src/api/empresas/planos-empresarial/index.ts
@@ -1,0 +1,89 @@
+import { empresasRoutes } from "@/api/routes";
+import { apiFetch } from "@/api/client";
+import { apiConfig } from "@/lib/env";
+import type {
+  PlanoEmpresarialBackendResponse,
+  CreatePlanoEmpresarialPayload,
+  UpdatePlanoEmpresarialPayload,
+} from "./types";
+
+export async function listPlanosEmpresariais(
+  init?: RequestInit,
+): Promise<PlanoEmpresarialBackendResponse[]> {
+  return apiFetch<PlanoEmpresarialBackendResponse[]>(
+    empresasRoutes.planosEmpresarial.list(),
+    { init: init ?? { headers: apiConfig.headers } },
+  );
+}
+
+export async function getPlanoEmpresarialById(
+  id: string,
+): Promise<PlanoEmpresarialBackendResponse> {
+  return apiFetch<PlanoEmpresarialBackendResponse>(
+    empresasRoutes.planosEmpresarial.get(id),
+    { init: { headers: apiConfig.headers } },
+  );
+}
+
+function getAuthHeader(): Record<string, string> {
+  if (typeof document === "undefined") return {};
+  const token = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith("token="))
+    ?.split("=")[1];
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export async function createPlanoEmpresarial(
+  data: CreatePlanoEmpresarialPayload,
+): Promise<PlanoEmpresarialBackendResponse> {
+  return apiFetch<PlanoEmpresarialBackendResponse>(
+    empresasRoutes.planosEmpresarial.create(),
+    {
+      init: {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: apiConfig.headers.Accept,
+          ...getAuthHeader(),
+        },
+        body: JSON.stringify(data),
+      },
+      cache: "no-cache",
+    },
+  );
+}
+
+export async function updatePlanoEmpresarial(
+  id: string,
+  data: UpdatePlanoEmpresarialPayload,
+): Promise<PlanoEmpresarialBackendResponse> {
+  return apiFetch<PlanoEmpresarialBackendResponse>(
+    empresasRoutes.planosEmpresarial.update(id),
+    {
+      init: {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: apiConfig.headers.Accept,
+          ...getAuthHeader(),
+        },
+        body: JSON.stringify(data),
+      },
+      cache: "no-cache",
+    },
+  );
+}
+
+export async function deletePlanoEmpresarial(id: string): Promise<void> {
+  await apiFetch<void>(empresasRoutes.planosEmpresarial.delete(id), {
+    init: {
+      method: "DELETE",
+      headers: {
+        Accept: apiConfig.headers.Accept,
+        ...getAuthHeader(),
+      },
+    },
+    cache: "no-cache",
+  });
+}

--- a/src/api/empresas/planos-empresarial/types.ts
+++ b/src/api/empresas/planos-empresarial/types.ts
@@ -1,0 +1,35 @@
+export interface PlanoEmpresarialBackendResponse {
+  id: string;
+  icon: string;
+  nome: string;
+  descricao: string;
+  valor: string;
+  desconto: number;
+  quantidadeVagas: number;
+  vagaEmDestaque: boolean;
+  quantidadeVagasDestaque: number;
+  criadoEm?: string;
+  atualizadoEm?: string;
+}
+
+export interface CreatePlanoEmpresarialPayload {
+  icon: string;
+  nome: string;
+  descricao: string;
+  valor: string;
+  desconto: number;
+  quantidadeVagas: number;
+  vagaEmDestaque: boolean;
+  quantidadeVagasDestaque: number;
+}
+
+export interface UpdatePlanoEmpresarialPayload {
+  icon?: string;
+  nome?: string;
+  descricao?: string;
+  valor?: string;
+  desconto?: number;
+  quantidadeVagas?: number;
+  vagaEmDestaque?: boolean;
+  quantidadeVagasDestaque?: number;
+}

--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -169,6 +169,19 @@ export const websiteRoutes = {
 };
 
 /**
+ * Endpoints for empresas-related operations.
+ */
+export const empresasRoutes = {
+  planosEmpresarial: {
+    list: () => `${prefix}/empresas/planos-empresarial`,
+    create: () => `${prefix}/empresas/planos-empresarial`,
+    get: (id: string) => `${prefix}/empresas/planos-empresarial/${id}`,
+    update: (id: string) => `${prefix}/empresas/planos-empresarial/${id}`,
+    delete: (id: string) => `${prefix}/empresas/planos-empresarial/${id}`,
+  },
+};
+
+/**
  * Endpoints for user-related operations (usuarios).
  * Mirrors the backend users module and groups auth, profile
  * and password recovery helpers in one place.
@@ -233,6 +246,7 @@ export const uploadRoutes = {
  */
 export const routes = {
   website: websiteRoutes,
+  empresas: empresasRoutes,
   usuarios: usuarioRoutes,
   mercadopago: mercadoPagoRoutes,
   brevo: brevoRoutes,

--- a/src/app/dashboard/config/dashboard/geral/page.tsx
+++ b/src/app/dashboard/config/dashboard/geral/page.tsx
@@ -6,6 +6,7 @@ import {
   type VerticalTabItem,
 } from "@/components/ui/custom";
 import LoginForm from "./login/LoginForm";
+import PlanosEmpresarialForm from "../planos-empresarial/PlanosEmpresarialForm";
 
 export default function GeralDashboardPage() {
   const items: VerticalTabItem[] = [
@@ -14,6 +15,12 @@ export default function GeralDashboardPage() {
       label: "Login",
       icon: "LogIn",
       content: <LoginForm />,
+    },
+    {
+      value: "planos-empresariais",
+      label: "Planos Empresariais",
+      icon: "Building2",
+      content: <PlanosEmpresarialForm />,
     },
   ];
 

--- a/src/app/dashboard/config/dashboard/planos-empresarial/PlanosEmpresarialForm.tsx
+++ b/src/app/dashboard/config/dashboard/planos-empresarial/PlanosEmpresarialForm.tsx
@@ -1,0 +1,546 @@
+"use client";
+
+import { useEffect, useState, FormEvent } from "react";
+import {
+  InputCustom,
+  SimpleTextarea,
+  ButtonCustom,
+  IconSelector,
+  toastCustom,
+} from "@/components/ui/custom";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Checkbox } from "@/components/ui/radix-checkbox";
+import {
+  listPlanosEmpresariais,
+  createPlanoEmpresarial,
+  updatePlanoEmpresarial,
+  deletePlanoEmpresarial,
+  type PlanoEmpresarialBackendResponse,
+} from "@/api/empresas";
+import * as LucideIcons from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+interface PlanoEmpresarialFormState {
+  id?: string;
+  icon: string;
+  nome: string;
+  descricao: string;
+  valor: string;
+  desconto: string;
+  quantidadeVagas: string;
+  vagaEmDestaque: boolean;
+  quantidadeVagasDestaque: string;
+}
+
+const createEmptyFormState = (): PlanoEmpresarialFormState => ({
+  icon: "",
+  nome: "",
+  descricao: "",
+  valor: "",
+  desconto: "",
+  quantidadeVagas: "",
+  vagaEmDestaque: false,
+  quantidadeVagasDestaque: "",
+});
+
+const formatCurrencyValue = (value: string) => {
+  const normalized = value.replace(/,/g, ".").trim();
+  const parsed = Number.parseFloat(normalized);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return null;
+  }
+  return parsed.toFixed(2);
+};
+
+const parseNumber = (value: string) => {
+  if (!value) return null;
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed)) return null;
+  return parsed;
+};
+
+const parsePercentage = (value: string) => {
+  if (!value) return 0;
+  const normalized = value.replace(/,/g, ".").trim();
+  const parsed = Number.parseFloat(normalized);
+  if (Number.isNaN(parsed)) return null;
+  return parsed;
+};
+
+export default function PlanosEmpresarialForm() {
+  const [plans, setPlans] = useState<PlanoEmpresarialBackendResponse[]>([]);
+  const [formState, setFormState] = useState<PlanoEmpresarialFormState>(
+    createEmptyFormState,
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isFetching, setIsFetching] = useState(true);
+
+  const applyPlanToForm = (plan: PlanoEmpresarialBackendResponse) => {
+    setFormState({
+      id: plan.id,
+      icon: plan.icon ?? "",
+      nome: plan.nome ?? "",
+      descricao: plan.descricao ?? "",
+      valor: plan.valor ?? "",
+      desconto:
+        plan.desconto === null || plan.desconto === undefined
+          ? ""
+          : String(plan.desconto),
+      quantidadeVagas:
+        plan.quantidadeVagas === null || plan.quantidadeVagas === undefined
+          ? ""
+          : String(plan.quantidadeVagas),
+      vagaEmDestaque: Boolean(plan.vagaEmDestaque),
+      quantidadeVagasDestaque:
+        plan.quantidadeVagasDestaque === null ||
+        plan.quantidadeVagasDestaque === undefined
+          ? ""
+          : String(plan.quantidadeVagasDestaque),
+    });
+  };
+
+  const resetForm = () => {
+    setFormState(createEmptyFormState());
+  };
+
+  useEffect(() => {
+    const fetchPlans = async () => {
+      setIsFetching(true);
+      try {
+        const data = await listPlanosEmpresariais();
+        setPlans(data);
+        if (data.length > 0) {
+          applyPlanToForm(data[0]);
+        } else {
+          resetForm();
+        }
+      } catch (err) {
+        const status = (err as any)?.status;
+        switch (status) {
+          case 401:
+            toastCustom.error("Sessão expirada. Faça login novamente");
+            break;
+          case 403:
+            toastCustom.error("Você não tem permissão para acessar este conteúdo");
+            break;
+          case 500:
+            toastCustom.error("Erro do servidor ao carregar os planos cadastrados");
+            break;
+          default:
+            toastCustom.error("Erro ao carregar os planos empresariais");
+        }
+      } finally {
+        setIsFetching(false);
+      }
+    };
+
+    fetchPlans();
+  }, []);
+
+  const renderIconPreview = (iconName: string) => {
+    if (!iconName) return null;
+    const IconComponent = (
+      LucideIcons as Record<string, unknown>
+    )[iconName] as LucideIcon | undefined;
+    if (!IconComponent) return null;
+    return <IconComponent className="h-5 w-5 text-gray-600" />;
+  };
+
+  const handleSelectPlan = (plan: PlanoEmpresarialBackendResponse) => {
+    applyPlanToForm(plan);
+  };
+
+  const handleCreateNew = () => {
+    resetForm();
+  };
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (isLoading) return;
+
+    const icon = formState.icon.trim();
+    const nome = formState.nome.trim();
+    const descricao = formState.descricao.trim();
+
+    if (!icon) {
+      toastCustom.error("Selecione um ícone para o plano");
+      return;
+    }
+
+    if (!nome) {
+      toastCustom.error("O nome do plano é obrigatório");
+      return;
+    }
+
+    if (!descricao) {
+      toastCustom.error("A descrição do plano é obrigatória");
+      return;
+    }
+
+    const valor = formatCurrencyValue(formState.valor);
+    if (!valor) {
+      toastCustom.error("Informe um valor válido para o plano");
+      return;
+    }
+
+    const desconto = parsePercentage(formState.desconto);
+    if (desconto === null) {
+      toastCustom.error("Informe um percentual de desconto válido");
+      return;
+    }
+    if (desconto < 0 || desconto > 100) {
+      toastCustom.error("O desconto deve estar entre 0% e 100%");
+      return;
+    }
+
+    const quantidadeVagas = parseNumber(formState.quantidadeVagas);
+    if (!quantidadeVagas || quantidadeVagas <= 0) {
+      toastCustom.error("Informe uma quantidade de vagas válida");
+      return;
+    }
+
+    let quantidadeVagasDestaque = 0;
+    if (formState.vagaEmDestaque) {
+      const parsed = parseNumber(formState.quantidadeVagasDestaque);
+      if (!parsed || parsed <= 0) {
+        toastCustom.error(
+          "Informe a quantidade de vagas em destaque quando essa opção estiver ativa",
+        );
+        return;
+      }
+      quantidadeVagasDestaque = parsed;
+    }
+
+    if (!formState.id && plans.length >= 4) {
+      toastCustom.error("Limite máximo de 4 planos atingido");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const payload = {
+        icon,
+        nome,
+        descricao,
+        valor,
+        desconto,
+        quantidadeVagas,
+        vagaEmDestaque: formState.vagaEmDestaque,
+        quantidadeVagasDestaque,
+      };
+
+      const saved = formState.id
+        ? await updatePlanoEmpresarial(formState.id, payload)
+        : await createPlanoEmpresarial(payload);
+
+      toastCustom.success(
+        formState.id
+          ? "Plano atualizado com sucesso"
+          : "Plano criado com sucesso",
+      );
+
+      setPlans((prev) => {
+        if (formState.id) {
+          return prev.map((plan) =>
+            plan.id === saved.id ? saved : plan,
+          );
+        }
+        return [...prev, saved];
+      });
+
+      applyPlanToForm(saved);
+    } catch (err) {
+      const status = (err as any)?.status;
+      switch (status) {
+        case 400:
+        case 422:
+          toastCustom.error("Dados inválidos. Verifique os campos preenchidos");
+          break;
+        case 401:
+          toastCustom.error("Sessão expirada. Faça login novamente");
+          break;
+        case 403:
+          toastCustom.error("Você não tem permissão para realizar esta ação");
+          break;
+        case 409:
+          toastCustom.error("Limite máximo de 4 planos empresariais atingido");
+          break;
+        case 500:
+          toastCustom.error("Erro interno do servidor ao salvar o plano");
+          break;
+        default:
+          toastCustom.error("Não foi possível salvar o plano empresarial");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!formState.id || isDeleting) return;
+    const confirmed = window.confirm(
+      "Tem certeza que deseja remover este plano empresarial?",
+    );
+    if (!confirmed) return;
+
+    setIsDeleting(true);
+    try {
+      await deletePlanoEmpresarial(formState.id);
+      toastCustom.success("Plano removido com sucesso");
+
+      const updatedPlans = plans.filter((plan) => plan.id !== formState.id);
+      setPlans(updatedPlans);
+
+      if (updatedPlans.length > 0) {
+        applyPlanToForm(updatedPlans[0]);
+      } else {
+        resetForm();
+      }
+    } catch (err) {
+      const status = (err as any)?.status;
+      switch (status) {
+        case 401:
+          toastCustom.error("Sessão expirada. Faça login novamente");
+          break;
+        case 403:
+          toastCustom.error("Você não tem permissão para realizar esta ação");
+          break;
+        case 404:
+          toastCustom.error("Plano empresarial não encontrado");
+          break;
+        case 500:
+          toastCustom.error("Erro interno do servidor ao remover o plano");
+          break;
+        default:
+          toastCustom.error("Não foi possível remover o plano empresarial");
+      }
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  if (isFetching) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-1/3" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-2/3" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-3">
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900">
+              Planos cadastrados
+            </h2>
+            <p className="text-sm text-gray-500">
+              Gerencie até quatro planos empresariais com regras de vagas
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {plans.map((plan) => (
+              <ButtonCustom
+                key={plan.id}
+                type="button"
+                variant={formState.id === plan.id ? "primary" : "outline"}
+                size="sm"
+                onClick={() => handleSelectPlan(plan)}
+              >
+                {plan.nome || "Plano sem título"}
+              </ButtonCustom>
+            ))}
+            <ButtonCustom
+              type="button"
+              variant="ghost"
+              size="sm"
+              icon="Plus"
+              onClick={handleCreateNew}
+            >
+              Novo plano
+            </ButtonCustom>
+          </div>
+        </div>
+        <p className="text-xs text-gray-500">
+          Você pode cadastrar no máximo quatro planos empresariais.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label className="text-sm font-medium text-gray-700">
+                Ícone do plano
+              </Label>
+              <div className="flex items-center gap-2 text-xs text-gray-500">
+                <span>Ícone selecionado:</span>
+                {renderIconPreview(formState.icon)}
+              </div>
+            </div>
+            <IconSelector
+              value={formState.icon}
+              onValueChange={(iconName) =>
+                setFormState((prev) => ({ ...prev, icon: iconName }))
+              }
+              placeholder="Selecionar ícone"
+            />
+          </div>
+
+          <InputCustom
+            label="Nome do plano"
+            id="nome"
+            value={formState.nome}
+            onChange={(e) =>
+              setFormState((prev) => ({ ...prev, nome: e.target.value }))
+            }
+            placeholder="Digite o nome do plano"
+            maxLength={80}
+            required
+          />
+        </div>
+
+        <SimpleTextarea
+          id="descricao"
+          value={formState.descricao}
+          onChange={(e) =>
+            setFormState((prev) => ({ ...prev, descricao: e.target.value }))
+          }
+          placeholder="Descreva os benefícios do plano empresarial"
+          maxLength={400}
+          showCharCount
+          required
+        />
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <InputCustom
+            label="Valor mensal"
+            id="valor"
+            type="number"
+            step="0.01"
+            min="0"
+            value={formState.valor}
+            onChange={(e) =>
+              setFormState((prev) => ({ ...prev, valor: e.target.value }))
+            }
+            placeholder="Ex: 199.90"
+            required
+          />
+
+          <InputCustom
+            label="Desconto (%)"
+            id="desconto"
+            type="number"
+            min="0"
+            max="100"
+            step="1"
+            value={formState.desconto}
+            onChange={(e) =>
+              setFormState((prev) => ({ ...prev, desconto: e.target.value }))
+            }
+            placeholder="Ex: 10"
+          />
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <InputCustom
+            label="Quantidade de vagas"
+            id="quantidadeVagas"
+            type="number"
+            min="1"
+            value={formState.quantidadeVagas}
+            onChange={(e) =>
+              setFormState((prev) => ({
+                ...prev,
+                quantidadeVagas: e.target.value,
+              }))
+            }
+            placeholder="Ex: 10"
+            required
+          />
+
+          <div className="space-y-2">
+            <Label className="text-sm font-medium text-gray-700">
+              Vaga em destaque
+            </Label>
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="vagaDestaque"
+                checked={formState.vagaEmDestaque}
+                onCheckedChange={(checked) =>
+                  setFormState((prev) => ({
+                    ...prev,
+                    vagaEmDestaque: checked === true,
+                    quantidadeVagasDestaque:
+                      checked === true ? prev.quantidadeVagasDestaque : "",
+                  }))
+                }
+              />
+              <Label htmlFor="vagaDestaque" className="text-sm text-gray-600">
+                Incluir vagas com destaque
+              </Label>
+            </div>
+            <InputCustom
+              label="Quantidade de vagas em destaque"
+              id="quantidadeVagasDestaque"
+              type="number"
+              min="1"
+              value={formState.quantidadeVagasDestaque}
+              onChange={(e) =>
+                setFormState((prev) => ({
+                  ...prev,
+                  quantidadeVagasDestaque: e.target.value,
+                }))
+              }
+              placeholder="Ex: 2"
+              disabled={!formState.vagaEmDestaque}
+              required={formState.vagaEmDestaque}
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-wrap justify-between gap-3 pt-4">
+          <div className="flex gap-2">
+            <ButtonCustom
+              type="button"
+              variant="outline"
+              icon="RotateCcw"
+              onClick={handleCreateNew}
+              disabled={isLoading}
+            >
+              Limpar formulário
+            </ButtonCustom>
+            {formState.id && (
+              <ButtonCustom
+                type="button"
+                variant="danger"
+                icon="Trash2"
+                onClick={handleDelete}
+                isLoading={isDeleting}
+                disabled={isDeleting || isLoading}
+              >
+                Excluir plano
+              </ButtonCustom>
+            )}
+          </div>
+
+          <ButtonCustom
+            type="submit"
+            isLoading={isLoading}
+            disabled={isLoading}
+            size="lg"
+            className="w-full md:w-40"
+          >
+            Salvar plano
+          </ButtonCustom>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/website/recrutamento/page.tsx
+++ b/src/app/website/recrutamento/page.tsx
@@ -5,6 +5,7 @@ import AdvanceAjuda from "@/theme/website/components/advance-ajuda";
 import ProcessSteps from "@/theme/website/components/process-steps";
 import ServiceBenefits from "@/theme/website/components/service-benefits";
 import LogoEnterprises from "@/theme/website/components/logo-enterprises";
+import PricingPlans from "@/theme/website/components/pricing-plans";
 
 export const metadata = {
   title: "Recrutamento & Seleção",
@@ -18,6 +19,7 @@ export default function RecrutamentoPage() {
       <AdvanceAjuda fetchFromApi={true} />
       <ProcessSteps />
       <ServiceBenefits fetchFromApi={true} service="recrutamentoSelecao" />
+      <PricingPlans fetchFromApi={true} />
       <LogoEnterprises fetchFromApi={true} />
     </div>
   );

--- a/src/theme/website/components/pricing-plans/PricingPlans.tsx
+++ b/src/theme/website/components/pricing-plans/PricingPlans.tsx
@@ -3,12 +3,14 @@
 "use client";
 
 import React, { useEffect } from "react";
+import { ButtonCustom } from "@/components/ui/custom/button";
+import { ImageNotFound } from "@/components/ui/custom/image-not-found";
+import { Loader } from "@/components/ui/custom/loader";
+import { env } from "@/lib/env";
 import { cn } from "@/lib/utils";
 import { PricingPlanCard } from "./components/PricingPlanCard";
-import { usePricingData } from "./hooks/usePricingData";
-import { ImageNotFound } from "@/components/ui/custom/image-not-found";
-import { ButtonCustom } from "@/components/ui/custom/button";
 import { PRICING_CONFIG } from "./constants";
+import { usePricingData } from "./hooks/usePricingData";
 import type { PricingPlansProps } from "./types";
 
 /**
@@ -74,17 +76,23 @@ const PricingPlans: React.FC<PricingPlansProps> = ({
 
   // Estado de carregamento
   if (isLoading) {
+    if (env.apiFallback === "loading") {
+      return (
+        <div className={cn("py-24 flex justify-center", className)}>
+          <Loader />
+        </div>
+      );
+    }
+
     return (
-      <div
-        className={cn("container w-full mx-auto py-24", className)}
-      >
+      <div className={cn("container w-full mx-auto py-24", className)}>
         <div className="text-center animate-fade-in mb-12">
           <div className="h-10 bg-gray-200 rounded w-64 mx-auto mb-4 animate-pulse" />
           <div className="h-6 bg-gray-200 rounded w-96 mx-auto animate-pulse" />
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-          {Array.from({ length: 4 }).map((_, index) => (
+          {Array.from({ length: PRICING_CONFIG.grid.desktop }).map((_, index) => (
             <div
               key={index}
               className="rounded-lg p-6 bg-white shadow-medium border border-gray-200"
@@ -98,10 +106,7 @@ const PricingPlans: React.FC<PricingPlansProps> = ({
               <div className="h-10 bg-gray-200 rounded mb-6 animate-pulse" />
               <div className="space-y-3">
                 {Array.from({ length: 4 }).map((_, i) => (
-                  <div
-                    key={i}
-                    className="h-4 bg-gray-200 rounded animate-pulse"
-                  />
+                  <div key={i} className="h-4 bg-gray-200 rounded animate-pulse" />
                 ))}
               </div>
             </div>
@@ -114,9 +119,7 @@ const PricingPlans: React.FC<PricingPlansProps> = ({
   // Estado de erro (com opção de retry)
   if (error && (!data || data.length === 0)) {
     return (
-      <div
-        className={cn("container w-full mx-auto py-24", className)}
-      >
+      <div className={cn("container w-full mx-auto py-24", className)}>
         <div className="text-center">
           <ImageNotFound
             size="lg"
@@ -126,14 +129,30 @@ const PricingPlans: React.FC<PricingPlansProps> = ({
             className="mx-auto mb-6"
           />
           <p className="text-gray-600 mb-4 max-w-md mx-auto">
-            Não foi possível carregar os planos de preços.
-            {error.includes("padrão") ? " Exibindo dados de exemplo." : ""}
+            {error}
           </p>
-          {!error.includes("padrão") && (
-            <ButtonCustom onClick={refetch} variant="default" icon="RefreshCw">
-              Tentar Novamente
-            </ButtonCustom>
-          )}
+          <ButtonCustom onClick={refetch} variant="default" icon="RefreshCw">
+            Tentar Novamente
+          </ButtonCustom>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isLoading && data.length === 0) {
+    return (
+      <div className={cn("container w-full mx-auto py-24", className)}>
+        <div className="text-center">
+          <ImageNotFound
+            size="md"
+            variant="muted"
+            message="Nenhum plano empresarial disponível no momento"
+            icon="FileQuestion"
+            className="mx-auto mb-6"
+          />
+          <ButtonCustom onClick={refetch} variant="default" icon="RefreshCw">
+            Atualizar
+          </ButtonCustom>
         </div>
       </div>
     );
@@ -166,10 +185,12 @@ const PricingPlans: React.FC<PricingPlansProps> = ({
         ))}
       </div>
 
-      {/* Indicador de erro sutil se houver fallback */}
+      {/* Indicador de erro sutil se houver falha parcial */}
       {error && data.length > 0 && (
         <div className="text-center mt-8">
-          <span className="text-xs text-gray-500">Dados de exemplo</span>
+          <span className="text-xs text-gray-500">
+            Alguns dados podem estar indisponíveis no momento.
+          </span>
         </div>
       )}
     </div>

--- a/src/theme/website/components/pricing-plans/components/PricingPlanCard.tsx
+++ b/src/theme/website/components/pricing-plans/components/PricingPlanCard.tsx
@@ -4,9 +4,9 @@
 
 import React from "react";
 import { Button } from "@/components/ui/button";
-import { Icon } from "@/components/ui/custom/Icons";
+import { Icon, Icons, type IconName } from "@/components/ui/custom/Icons";
 import { Check } from "lucide-react";
-import { PRICING_CONFIG, ICON_MAPPING } from "../constants";
+import { PRICING_CONFIG } from "../constants";
 import type { PricingPlanCardProps } from "../types";
 
 export const PricingPlanCard: React.FC<PricingPlanCardProps> = ({
@@ -19,10 +19,9 @@ export const PricingPlanCard: React.FC<PricingPlanCardProps> = ({
   };
 
   // Validação do ícone
-  const iconName =
-    plan.iconName in ICON_MAPPING
-      ? (plan.iconName as keyof typeof ICON_MAPPING)
-      : "Package";
+  const iconName: IconName = Icons.exists(plan.iconName)
+    ? plan.iconName
+    : (PRICING_CONFIG.icons.fallbackIcon as IconName);
 
   return (
     <div

--- a/src/theme/website/components/pricing-plans/constants/index.ts
+++ b/src/theme/website/components/pricing-plans/constants/index.ts
@@ -1,104 +1,9 @@
 // src/theme/website/components/pricing-plans/constants/index.ts
 
-import type { PricingPlanData } from "../types";
-
-/**
- * Dados padrão para fallback quando a API falha
- */
-export const DEFAULT_PRICING_DATA: PricingPlanData[] = [
-  {
-    id: "inicial",
-    title: "Inicial",
-    iconName: "Briefcase",
-    price: "49,99",
-    description: "Comece a recrutar com eficiência",
-    features: [
-      "3 vagas ativas",
-      "30 dias de divulgação",
-      "Acesso a candidatos qualificados",
-      "Painel de controle básico",
-    ],
-    isPopular: false,
-    isActive: true,
-    order: 1,
-    buttonText: "Assinar plano",
-    buttonUrl: "/checkout?plano=inicial",
-    period: "mês",
-    currency: "R$",
-  },
-  {
-    id: "intermediario",
-    title: "Intermediário",
-    iconName: "Trophy",
-    price: "74,99",
-    description: "Amplie seu alcance de recrutamento",
-    features: [
-      "10 vagas ativas",
-      "30 dias de divulgação",
-      "Acesso a candidatos qualificados",
-      "Painel de controle básico",
-    ],
-    isPopular: false,
-    isActive: true,
-    order: 2,
-    buttonText: "Assinar plano",
-    buttonUrl: "/checkout?plano=intermediario",
-    period: "mês",
-    currency: "R$",
-  },
-  {
-    id: "avancado",
-    title: "Avançado",
-    iconName: "Crown",
-    price: "99,99",
-    description: "Solução completa para grandes equipes",
-    features: [
-      "20 vagas ativas",
-      "30 dias de divulgação",
-      "Acesso a candidatos qualificados",
-      "Painel de controle básico",
-    ],
-    isPopular: true,
-    isActive: true,
-    order: 3,
-    buttonText: "Assinar plano",
-    buttonUrl: "/checkout?plano=avancado",
-    period: "mês",
-    currency: "R$",
-  },
-  {
-    id: "destaque",
-    title: "Destaque",
-    iconName: "Rocket",
-    price: "199,99",
-    description: "Recrutamento sem limites",
-    features: [
-      "Vagas ilimitadas",
-      "30 dias de divulgação",
-      "Acesso a candidatos qualificados",
-      "Painel de controle avançado",
-      "1 vaga em destaque",
-    ],
-    isPopular: false,
-    isActive: true,
-    order: 4,
-    buttonText: "Assinar plano",
-    buttonUrl: "/checkout?plano=destaque",
-    period: "mês",
-    currency: "R$",
-  },
-];
-
 /**
  * Configurações do componente
  */
 export const PRICING_CONFIG = {
-  api: {
-    endpoint: "/api/pricing/plans",
-    timeout: 5000,
-    retryAttempts: 3,
-    retryDelay: 1000,
-  },
   animation: {
     staggerDelay: 100, // Delay entre cards
     duration: 600,
@@ -112,20 +17,11 @@ export const PRICING_CONFIG = {
     tablet: 2, // colunas no tablet
     desktop: 4, // colunas no desktop
   },
+  defaults: {
+    buttonText: "Falar com um especialista",
+    buttonUrl: "/contato",
+    period: "mês",
+    currency: "R$",
+  },
 } as const;
 
-/**
- * Mapeamento de ícones disponíveis
- */
-export const ICON_MAPPING = {
-  Briefcase: "Briefcase",
-  Trophy: "Trophy",
-  Crown: "Crown",
-  Rocket: "Rocket",
-  Package: "Package",
-  Star: "Star",
-  Zap: "Zap",
-  Shield: "Shield",
-  Target: "Target",
-  Award: "Award",
-} as const;

--- a/src/theme/website/components/pricing-plans/index.ts
+++ b/src/theme/website/components/pricing-plans/index.ts
@@ -16,4 +16,4 @@ export type {
   PricingPlansProps,
   PricingPlanCardProps,
 } from "./types";
-export { DEFAULT_PRICING_DATA, PRICING_CONFIG } from "./constants";
+export { PRICING_CONFIG } from "./constants";

--- a/src/theme/website/components/pricing-plans/types/index.ts
+++ b/src/theme/website/components/pricing-plans/types/index.ts
@@ -1,7 +1,5 @@
 // src/theme/website/components/pricing-plans/types/index.ts
 
-import { LucideIcon } from "lucide-react";
-
 /**
  * Interface para dados de plano vindos da API
  */
@@ -19,15 +17,6 @@ export interface PricingPlanData {
   buttonUrl: string;
   period: string; // ex: "mês", "ano"
   currency: string; // ex: "R$"
-}
-
-/**
- * Interface para resposta da API
- */
-export interface PricingApiResponse {
-  data: PricingPlanData[];
-  success: boolean;
-  message?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- pull enterprise plan data from the empresas API inside the website pricing plans hook and remove the mocked fallback content
- refresh the pricing plans UI states to use loader/skeleton fallbacks, validate icon choices and expose API-derived feature summaries
- place the pricing plans section on the public recrutamento page beneath the service benefits block

## Testing
- pnpm lint
- pnpm type-check

------
https://chatgpt.com/codex/tasks/task_e_68cad871cec48325b31b0ae7d254b809