### PR TITLE
feat: add admin company listing dashboard

### DIFF
--- a/src/api/empresas/admin/index.ts
+++ b/src/api/empresas/admin/index.ts
@@ -1,0 +1,133 @@
+import { empresasRoutes } from "@/api/routes";
+import { apiFetch } from "@/api/client";
+import { apiConfig } from "@/lib/env";
+import type {
+  AdminCompanyDetailResponse,
+  CreateAdminCompanyPayload,
+  ListAdminCompaniesParams,
+  ListAdminCompaniesResponse,
+  UpdateAdminCompanyPayload,
+} from "./types";
+
+function normalizeHeaders(headers?: HeadersInit): Record<string, string> {
+  if (!headers) return {};
+  if (headers instanceof Headers) {
+    return Object.fromEntries(headers.entries());
+  }
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers);
+  }
+  return headers as Record<string, string>;
+}
+
+function getAuthHeader(): Record<string, string> {
+  if (typeof document === "undefined") return {};
+
+  const token = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith("token="))
+    ?.split("=")[1];
+
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export async function listAdminCompanies(
+  params?: ListAdminCompaniesParams,
+  init?: RequestInit,
+): Promise<ListAdminCompaniesResponse> {
+  const endpoint = empresasRoutes.admin.list();
+  const query = new URLSearchParams();
+
+  if (params?.page) {
+    query.set("page", String(params.page));
+  }
+  if (params?.pageSize) {
+    query.set("pageSize", String(params.pageSize));
+  }
+  if (params?.search) {
+    query.set("search", params.search);
+  }
+
+  const url = query.toString() ? `${endpoint}?${query.toString()}` : endpoint;
+
+  const headers = {
+    ...apiConfig.headers,
+    ...getAuthHeader(),
+    ...normalizeHeaders(init?.headers),
+  };
+
+  return apiFetch<ListAdminCompaniesResponse>(url, {
+    init: {
+      method: init?.method ?? "GET",
+      ...init,
+      headers,
+    },
+  });
+}
+
+export async function getAdminCompanyById(id: string, init?: RequestInit): Promise<AdminCompanyDetailResponse> {
+  const endpoint = empresasRoutes.admin.get(id);
+
+  const headers = {
+    ...apiConfig.headers,
+    ...getAuthHeader(),
+    ...normalizeHeaders(init?.headers),
+  };
+
+  return apiFetch<AdminCompanyDetailResponse>(endpoint, {
+    init: {
+      method: init?.method ?? "GET",
+      ...init,
+      headers,
+    },
+  });
+}
+
+export async function createAdminCompany(
+  data: CreateAdminCompanyPayload,
+  init?: RequestInit,
+): Promise<AdminCompanyDetailResponse> {
+  const endpoint = empresasRoutes.admin.create();
+
+  const headers = {
+    "Content-Type": "application/json",
+    Accept: apiConfig.headers.Accept,
+    ...getAuthHeader(),
+    ...normalizeHeaders(init?.headers),
+  };
+
+  return apiFetch<AdminCompanyDetailResponse>(endpoint, {
+    init: {
+      method: "POST",
+      ...init,
+      headers,
+      body: init?.body ?? JSON.stringify(data),
+    },
+    cache: "no-cache",
+  });
+}
+
+export async function updateAdminCompany(
+  id: string,
+  data: UpdateAdminCompanyPayload,
+  init?: RequestInit,
+): Promise<AdminCompanyDetailResponse> {
+  const endpoint = empresasRoutes.admin.update(id);
+
+  const headers = {
+    "Content-Type": "application/json",
+    Accept: apiConfig.headers.Accept,
+    ...getAuthHeader(),
+    ...normalizeHeaders(init?.headers),
+  };
+
+  return apiFetch<AdminCompanyDetailResponse>(endpoint, {
+    init: {
+      method: "PUT",
+      ...init,
+      headers,
+      body: init?.body ?? JSON.stringify(data),
+    },
+    cache: "no-cache",
+  });
+}

--- a/src/api/empresas/admin/types.ts
+++ b/src/api/empresas/admin/types.ts
@@ -1,0 +1,121 @@
+export type AdminCompanyStatus = "ATIVO" | "INATIVO";
+
+export type AdminCompanyPlanType =
+  | "7_dias"
+  | "15_dias"
+  | "30_dias"
+  | "60_dias"
+  | "90_dias"
+  | "120_dias"
+  | "parceiro";
+
+export interface AdminCompanyPlanSummary {
+  id: string;
+  nome: string;
+  tipo: AdminCompanyPlanType;
+  inicio?: string | null;
+  fim?: string | null;
+  modeloPagamento?: string | null;
+  metodoPagamento?: string | null;
+  statusPagamento?: string | null;
+  quantidadeVagas: number;
+  valor?: string | null;
+}
+
+export interface AdminCompanyVacancyInfo {
+  publicadas?: number | null;
+  limitePlano?: number | null;
+}
+
+export interface AdminCompanyPaymentInfo {
+  modelo?: string | null;
+  metodo?: string | null;
+  status?: string | null;
+  ultimoPagamentoEm?: string | null;
+}
+
+export interface AdminCompanyListItem {
+  id: string;
+  codUsuario: string;
+  nome: string;
+  avatarUrl?: string | null;
+  cnpj?: string | null;
+  email?: string | null;
+  telefone?: string | null;
+  descricao?: string | null;
+  instagram?: string | null;
+  linkedin?: string | null;
+  cidade?: string | null;
+  estado?: string | null;
+  criadoEm?: string | null;
+  ativa: boolean;
+  parceira: boolean;
+  diasTesteDisponibilizados?: number | null;
+  plano?: AdminCompanyPlanSummary | null;
+  vagas?: AdminCompanyVacancyInfo | null;
+  pagamento?: AdminCompanyPaymentInfo | null;
+}
+
+export type AdminCompanyDetail = AdminCompanyListItem;
+
+export interface AdminCompanyDetailResponse {
+  empresa: AdminCompanyDetail;
+}
+
+export interface AdminCompanyPagination {
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+}
+
+export interface ListAdminCompaniesResponse {
+  data: AdminCompanyListItem[];
+  pagination: AdminCompanyPagination;
+}
+
+export interface ListAdminCompaniesParams {
+  page?: number;
+  pageSize?: number;
+  search?: string;
+}
+
+export interface AdminCompanyPlanPayload {
+  planoEmpresarialId: string;
+  tipo: AdminCompanyPlanType;
+  iniciarEm?: string;
+  observacao?: string;
+}
+
+export interface CreateAdminCompanyPayload {
+  nome: string;
+  email: string;
+  telefone: string;
+  senha: string;
+  supabaseId: string;
+  cnpj: string;
+  cidade: string;
+  estado: string;
+  descricao?: string;
+  instagram?: string;
+  linkedin?: string;
+  avatarUrl?: string;
+  aceitarTermos: boolean;
+  status: AdminCompanyStatus;
+  plano?: AdminCompanyPlanPayload;
+}
+
+export interface UpdateAdminCompanyPayload {
+  nome?: string;
+  email?: string;
+  telefone?: string;
+  cnpj?: string;
+  cidade?: string;
+  estado?: string;
+  descricao?: string;
+  instagram?: string;
+  linkedin?: string;
+  avatarUrl?: string;
+  status?: AdminCompanyStatus;
+  plano?: AdminCompanyPlanPayload;
+}

--- a/src/api/empresas/index.ts
+++ b/src/api/empresas/index.ts
@@ -11,3 +11,25 @@ export type {
   CreatePlanoEmpresarialPayload,
   UpdatePlanoEmpresarialPayload,
 } from "./planos-empresarial/types";
+
+export {
+  listAdminCompanies,
+  getAdminCompanyById,
+  createAdminCompany,
+  updateAdminCompany,
+} from "./admin";
+
+export type {
+  AdminCompanyDetail,
+  AdminCompanyDetailResponse,
+  AdminCompanyListItem,
+  AdminCompanyPagination,
+  AdminCompanyPlanPayload,
+  AdminCompanyPlanSummary,
+  AdminCompanyPlanType,
+  AdminCompanyStatus,
+  CreateAdminCompanyPayload,
+  ListAdminCompaniesParams,
+  ListAdminCompaniesResponse,
+  UpdateAdminCompanyPayload,
+} from "./admin/types";

--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -179,6 +179,12 @@ export const empresasRoutes = {
     update: (id: string) => `${prefix}/empresas/planos-empresarial/${id}`,
     delete: (id: string) => `${prefix}/empresas/planos-empresarial/${id}`,
   },
+  admin: {
+    list: () => `${prefix}/empresas/admin`,
+    create: () => `${prefix}/empresas/admin`,
+    get: (id: string) => `${prefix}/empresas/admin/${id}`,
+    update: (id: string) => `${prefix}/empresas/admin/${id}`,
+  },
 };
 
 /**

--- a/src/theme/dashboard/components/admin/index.ts
+++ b/src/theme/dashboard/components/admin/index.ts
@@ -1,2 +1,3 @@
 export * from "./website-features";
+export * from "./lista-empresas";
 

--- a/src/theme/dashboard/components/admin/lista-empresas/CompanyDashboard.tsx
+++ b/src/theme/dashboard/components/admin/lista-empresas/CompanyDashboard.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import { Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Table, TableBody, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+import {
+  CompanyRow,
+  CompanyStats,
+  CompanyTableSkeleton,
+  EmptyState,
+} from "./components";
+import { COMPANY_DASHBOARD_CONFIG, TRIAL_PARTNERSHIP_TYPES } from "./constants";
+import { useCompanyDashboardData } from "./hooks/useCompanyDashboardData";
+import type { CompanyDashboardProps, PlanFilter } from "./types";
+
+export function CompanyDashboard({
+  className,
+  partnerships: partnershipsProp,
+  fetchFromApi = true,
+  itemsPerPage: itemsPerPageProp,
+  pageSize,
+  onDataLoaded,
+  onError,
+}: CompanyDashboardProps) {
+  const itemsPerPage = itemsPerPageProp ?? COMPANY_DASHBOARD_CONFIG.itemsPerPage;
+  const shouldFetch = fetchFromApi && !partnershipsProp;
+
+  const { partnerships: fetchedPartnerships, isLoading, error, refetch } = useCompanyDashboardData({
+    enabled: shouldFetch,
+    pageSize: pageSize ?? COMPANY_DASHBOARD_CONFIG.api.pageSize,
+    onSuccess: (data, response) => onDataLoaded?.(data, response),
+    onError,
+  });
+
+  useEffect(() => {
+    if (partnershipsProp) {
+      onDataLoaded?.(partnershipsProp, null);
+    }
+  }, [onDataLoaded, partnershipsProp]);
+
+  const partnerships = partnershipsProp ?? fetchedPartnerships;
+
+  const [searchTerm, setSearchTerm] = useState("");
+  const [planFilter, setPlanFilter] = useState<PlanFilter>("all");
+  const [partnershipFilter, setPartnershipFilter] = useState<"all" | "partner" | "trial">("all");
+  const [currentPage, setCurrentPage] = useState(1);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchTerm, planFilter, partnershipFilter]);
+
+  const uniquePlans = useMemo(() => {
+    const names = partnerships
+      .map((partnership) => partnership.plano.nome)
+      .filter((name): name is string => Boolean(name));
+
+    return Array.from(new Set(names)).sort((a, b) => a.localeCompare(b));
+  }, [partnerships]);
+
+  const filteredPartnerships = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase();
+
+    return partnerships.filter((partnership) => {
+      const company = partnership.empresa;
+      const plan = partnership.plano;
+
+      const matchesSearch =
+        query.length === 0 ||
+        company.nome.toLowerCase().includes(query) ||
+        company.codUsuario.toLowerCase().includes(query) ||
+        (company.cnpj?.toLowerCase().includes(query) ?? false);
+
+      const matchesPlan = planFilter === "all" || plan.nome === planFilter;
+
+      const isPartner = partnership.tipo === "parceiro" || company.parceira;
+      const isTrial = partnership.tipo ? TRIAL_PARTNERSHIP_TYPES.includes(partnership.tipo) : false;
+
+      const matchesPartnership =
+        partnershipFilter === "all" ||
+        (partnershipFilter === "partner" && isPartner) ||
+        (partnershipFilter === "trial" && isTrial);
+
+      return matchesSearch && matchesPlan && matchesPartnership;
+    });
+  }, [partnershipFilter, partnerships, planFilter, searchTerm]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredPartnerships.length / itemsPerPage));
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      setCurrentPage(totalPages);
+    }
+  }, [currentPage, totalPages]);
+
+  const paginatedPartnerships = useMemo(() => {
+    const start = (currentPage - 1) * itemsPerPage;
+    const end = start + itemsPerPage;
+    return filteredPartnerships.slice(start, end);
+  }, [filteredPartnerships, currentPage, itemsPerPage]);
+
+  const metrics = useMemo(() => {
+    const partners = partnerships.filter(
+      (partnership) => partnership.tipo === "parceiro" || partnership.empresa.parceira,
+    ).length;
+    const trials = partnerships.filter((partnership) =>
+      partnership.tipo ? TRIAL_PARTNERSHIP_TYPES.includes(partnership.tipo) : false,
+    ).length;
+    const active = partnerships.filter((partnership) => partnership.empresa.ativo).length;
+    const inactive = partnerships.filter((partnership) => !partnership.empresa.ativo).length;
+
+    return { partners, trials, active, inactive };
+  }, [partnerships]);
+
+  const visiblePages = useMemo(() => {
+    const pages: number[] = [];
+    if (totalPages <= 5) {
+      for (let i = 1; i <= totalPages; i += 1) {
+        pages.push(i);
+      }
+      return pages;
+    }
+
+    const start = Math.max(1, currentPage - 2);
+    const end = Math.min(totalPages, start + 4);
+    const adjustedStart = Math.max(1, end - 4);
+
+    for (let i = adjustedStart; i <= end; i += 1) {
+      pages.push(i);
+    }
+
+    return pages;
+  }, [currentPage, totalPages]);
+
+  const isLoadingData = shouldFetch && isLoading;
+  const showEmptyState = !isLoadingData && filteredPartnerships.length === 0;
+
+  return (
+    <div className={cn("min-h-screen bg-gray-50/50", className)}>
+      <div className="bg-white border-b border-gray-200 sticky top-0 z-10 backdrop-blur-xl bg-white/95">
+        <div className="max-w-7xl mx-auto px-6 py-4">
+          <div className="flex items-center justify-between mb-6">
+            <div>
+              <h1 className="text-2xl font-semibold text-gray-900">Empresas</h1>
+              <p className="text-sm text-gray-500 mt-1">
+                {filteredPartnerships.length} de {partnerships.length} empresas
+              </p>
+            </div>
+            <CompanyStats
+              partners={metrics.partners}
+              trials={metrics.trials}
+              active={metrics.active}
+              inactive={metrics.inactive}
+            />
+          </div>
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-3">
+            <div className="relative flex-1 max-w-md">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
+              <Input
+                placeholder="Buscar empresa, código ou CNPJ..."
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+                className="pl-10 bg-white border-gray-200 focus:border-blue-500 focus:ring-blue-500/20"
+              />
+            </div>
+
+            <Select value={planFilter} onValueChange={setPlanFilter}>
+              <SelectTrigger className="w-full sm:w-[160px] bg-white border-gray-200">
+                <SelectValue placeholder="Plano" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Todos</SelectItem>
+                {uniquePlans.map((plan) => (
+                  <SelectItem key={plan} value={plan}>
+                    {plan}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <Select value={partnershipFilter} onValueChange={(value) => setPartnershipFilter(value as typeof partnershipFilter)}>
+              <SelectTrigger className="w-full sm:w-[140px] bg-white border-gray-200">
+                <SelectValue placeholder="Status" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Todos</SelectItem>
+                <SelectItem value="partner">Parceiros</SelectItem>
+                <SelectItem value="trial">Teste</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {error && shouldFetch && (
+            <div className="mt-4 text-sm text-red-600 flex items-center gap-2">
+              <span>{error}</span>
+              <Button variant="link" size="sm" onClick={() => refetch()} className="p-0 h-auto">
+                Tentar novamente
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="max-w-7xl mx-auto px-6 py-6">
+        <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow className="border-gray-200 bg-gray-50/50">
+                <TableHead className="font-medium text-gray-700 py-4">Empresa</TableHead>
+                <TableHead className="font-medium text-gray-700">Plano</TableHead>
+                <TableHead className="font-medium text-gray-700">Localização</TableHead>
+                <TableHead className="font-medium text-gray-700">Status Empresa</TableHead>
+                <TableHead className="font-medium text-gray-700">Status Plano</TableHead>
+                <TableHead className="font-medium text-gray-700">Vagas</TableHead>
+                <TableHead className="font-medium text-gray-700">Data Criação</TableHead>
+                <TableHead className="w-12" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoadingData && <CompanyTableSkeleton rows={5} />}
+              {!isLoadingData &&
+                paginatedPartnerships.map((partnership) => (
+                  <CompanyRow key={partnership.id} partnership={partnership} />
+                ))}
+            </TableBody>
+          </Table>
+
+          {totalPages > 1 && filteredPartnerships.length > 0 && (
+            <div className="flex flex-col gap-4 px-6 py-4 border-t border-gray-200 bg-gray-50/30 sm:flex-row sm:items-center sm:justify-between">
+              <div className="text-sm text-gray-600">
+                Mostrando {(currentPage - 1) * itemsPerPage + 1} a {Math.min(currentPage * itemsPerPage, filteredPartnerships.length)} de {filteredPartnerships.length} empresas
+              </div>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
+                  disabled={currentPage === 1}
+                  className="border-gray-200"
+                >
+                  Anterior
+                </Button>
+                <div className="flex items-center gap-1">
+                  {visiblePages.map((page) => (
+                    <Button
+                      key={page}
+                      variant={currentPage === page ? "default" : "ghost"}
+                      size="sm"
+                      onClick={() => setCurrentPage(page)}
+                      className="w-8 h-8 p-0"
+                    >
+                      {page}
+                    </Button>
+                  ))}
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setCurrentPage((prev) => Math.min(totalPages, prev + 1))}
+                  disabled={currentPage === totalPages}
+                  className="border-gray-200"
+                >
+                  Próxima
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {showEmptyState && (
+          <EmptyState
+            title="Nenhuma empresa encontrada"
+            description="Tente ajustar os filtros ou termo de busca"
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default CompanyDashboard;

--- a/src/theme/dashboard/components/admin/lista-empresas/components/CompanyRow.tsx
+++ b/src/theme/dashboard/components/admin/lista-empresas/components/CompanyRow.tsx
@@ -1,0 +1,154 @@
+import React from "react";
+import { MapPin, MoreHorizontal } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { TableRow, TableCell } from "@/components/ui/table";
+import type { Partnership } from "../types";
+
+interface CompanyRowProps {
+  partnership: Partnership;
+}
+
+function formatCurrency(value?: string | null): string {
+  if (!value) return "—";
+
+  const parsed = Number.parseFloat(value);
+  if (Number.isNaN(parsed)) {
+    return value;
+  }
+
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  }).format(parsed);
+}
+
+function formatDate(value?: string | null): string {
+  if (!value) return "N/A";
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "N/A";
+  }
+
+  return new Intl.DateTimeFormat("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  }).format(date);
+}
+
+function getPartnershipBadge(partnership: Partnership) {
+  if (partnership.tipo === "parceiro" || partnership.empresa.parceira) {
+    return (
+      <Badge className="bg-emerald-100 text-emerald-800 border-emerald-200">
+        Plano parceiro
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge variant="secondary" className="text-xs">
+      Plano mensal
+    </Badge>
+  );
+}
+
+export const CompanyRow: React.FC<CompanyRowProps> = ({ partnership }) => {
+  const vagasTotal = partnership.plano.quantidadeVagas ?? 0;
+  const vagasPublicadas = partnership.plano.vagasPublicadas ?? partnership.raw?.vagas?.publicadas ?? 0;
+
+  return (
+    <TableRow className="border-gray-100 hover:bg-gray-50/50 transition-colors">
+      <TableCell className="py-4">
+        <div className="flex items-center gap-3">
+          <Avatar className="h-8 w-8">
+            <AvatarImage
+              src={partnership.empresa.avatarUrl || undefined}
+              alt={partnership.empresa.nome}
+            />
+            <AvatarFallback className="bg-gray-100 text-gray-600 text-xs font-medium">
+              {partnership.empresa.nome.substring(0, 2).toUpperCase()}
+            </AvatarFallback>
+          </Avatar>
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 mb-1">
+              <div className="font-medium text-gray-900 truncate">
+                {partnership.empresa.nome}
+              </div>
+              <code className="text-xs bg-gray-100 px-1.5 py-0.5 rounded font-mono text-gray-500">
+                {partnership.empresa.codUsuario}
+              </code>
+            </div>
+            {partnership.empresa.cnpj && (
+              <div className="text-xs text-gray-500 font-mono">
+                {partnership.empresa.cnpj}
+              </div>
+            )}
+          </div>
+        </div>
+      </TableCell>
+      <TableCell>
+        <div>
+          <div className="font-medium text-sm text-gray-900">
+            {partnership.plano.nome}
+          </div>
+          <div className="text-xs text-gray-500">
+            {formatCurrency(partnership.plano.valor)}
+          </div>
+        </div>
+      </TableCell>
+      <TableCell>
+        <div className="flex items-center gap-1 text-sm text-gray-600">
+          <MapPin className="h-3 w-3" />
+          <span>
+            {partnership.empresa.cidade || "—"}/{partnership.empresa.estado || "—"}
+          </span>
+        </div>
+      </TableCell>
+      <TableCell>
+        <Badge
+          className={
+            partnership.empresa.ativo
+              ? "bg-green-100 text-green-800 border-green-200"
+              : "bg-red-100 text-red-800 border-red-200"
+          }
+        >
+          {partnership.empresa.ativo ? "Ativa" : "Inativa"}
+        </Badge>
+      </TableCell>
+      <TableCell>{getPartnershipBadge(partnership)}</TableCell>
+      <TableCell>
+        <span className="text-sm text-gray-600">
+          {vagasPublicadas}/{vagasTotal}
+        </span>
+      </TableCell>
+      <TableCell>
+        <span className="text-sm text-gray-600">
+          {formatDate(partnership.empresa.criadoEm ?? undefined)}
+        </span>
+      </TableCell>
+      <TableCell>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="sm" className="h-8 w-8 p-0" aria-label="Ações da empresa">
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem>Ver detalhes</DropdownMenuItem>
+            <DropdownMenuItem>Editar</DropdownMenuItem>
+            <DropdownMenuItem>Histórico</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </TableCell>
+    </TableRow>
+  );
+};

--- a/src/theme/dashboard/components/admin/lista-empresas/components/CompanyStats.tsx
+++ b/src/theme/dashboard/components/admin/lista-empresas/components/CompanyStats.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+interface CompanyStatsProps {
+  partners: number;
+  trials: number;
+  active: number;
+  inactive: number;
+}
+
+export const CompanyStats: React.FC<CompanyStatsProps> = ({
+  partners,
+  trials,
+  active,
+  inactive,
+}) => {
+  const stats = [
+    { label: "Parceiros", value: partners, color: "bg-emerald-500" },
+    { label: "Teste", value: trials, color: "bg-blue-500" },
+    { label: "Ativas", value: active, color: "bg-green-500" },
+    { label: "Inativas", value: inactive, color: "bg-red-500" },
+  ];
+
+  return (
+    <div className="flex items-center gap-4 text-sm text-gray-600">
+      {stats.map((stat) => (
+        <div key={stat.label} className="flex items-center gap-1">
+          <div className={`w-2 h-2 rounded-full ${stat.color}`} aria-hidden="true" />
+          <span>
+            {stat.value} {stat.label}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/theme/dashboard/components/admin/lista-empresas/components/CompanyTableSkeleton.tsx
+++ b/src/theme/dashboard/components/admin/lista-empresas/components/CompanyTableSkeleton.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { TableRow, TableCell } from "@/components/ui/table";
+
+interface CompanyTableSkeletonProps {
+  rows?: number;
+}
+
+export const CompanyTableSkeleton: React.FC<CompanyTableSkeletonProps> = ({ rows = 5 }) => {
+  return (
+    <>
+      {Array.from({ length: rows }).map((_, index) => (
+        <TableRow key={index} className="border-gray-100">
+          <TableCell className="py-4">
+            <div className="flex items-center gap-3">
+              <div className="h-8 w-8 rounded-full bg-gray-200 animate-pulse" aria-hidden="true" />
+              <div className="space-y-2 flex-1">
+                <div className="h-3 w-2/3 bg-gray-200 rounded animate-pulse" />
+                <div className="h-2 w-1/3 bg-gray-200 rounded animate-pulse" />
+              </div>
+            </div>
+          </TableCell>
+          <TableCell>
+            <div className="space-y-2">
+              <div className="h-3 w-24 bg-gray-200 rounded animate-pulse" />
+              <div className="h-2 w-16 bg-gray-200 rounded animate-pulse" />
+            </div>
+          </TableCell>
+          <TableCell>
+            <div className="h-3 w-24 bg-gray-200 rounded animate-pulse" />
+          </TableCell>
+          <TableCell>
+            <div className="h-5 w-20 bg-gray-200 rounded-full animate-pulse" />
+          </TableCell>
+          <TableCell>
+            <div className="h-5 w-24 bg-gray-200 rounded-full animate-pulse" />
+          </TableCell>
+          <TableCell>
+            <div className="h-3 w-16 bg-gray-200 rounded animate-pulse" />
+          </TableCell>
+          <TableCell>
+            <div className="h-3 w-20 bg-gray-200 rounded animate-pulse" />
+          </TableCell>
+          <TableCell>
+            <div className="h-8 w-8 bg-gray-200 rounded-full animate-pulse" />
+          </TableCell>
+        </TableRow>
+      ))}
+    </>
+  );
+};

--- a/src/theme/dashboard/components/admin/lista-empresas/components/EmptyState.tsx
+++ b/src/theme/dashboard/components/admin/lista-empresas/components/EmptyState.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Building2 } from "lucide-react";
+
+interface EmptyStateProps {
+  title: string;
+  description: string;
+}
+
+export const EmptyState: React.FC<EmptyStateProps> = ({ title, description }) => {
+  return (
+    <div className="text-center py-12">
+      <Building2 className="h-12 w-12 text-gray-400 mx-auto mb-4" aria-hidden="true" />
+      <h3 className="text-lg font-medium text-gray-900 mb-2">{title}</h3>
+      <p className="text-gray-500">{description}</p>
+    </div>
+  );
+};

--- a/src/theme/dashboard/components/admin/lista-empresas/components/index.ts
+++ b/src/theme/dashboard/components/admin/lista-empresas/components/index.ts
@@ -1,0 +1,4 @@
+export { CompanyRow } from "./CompanyRow";
+export { CompanyStats } from "./CompanyStats";
+export { CompanyTableSkeleton } from "./CompanyTableSkeleton";
+export { EmptyState } from "./EmptyState";

--- a/src/theme/dashboard/components/admin/lista-empresas/constants/index.ts
+++ b/src/theme/dashboard/components/admin/lista-empresas/constants/index.ts
@@ -1,0 +1,125 @@
+import type { AdminCompanyPagination } from "@/api/empresas";
+import type { Partnership, PartnershipType } from "../types";
+
+export const COMPANY_DASHBOARD_CONFIG = {
+  itemsPerPage: 25,
+  api: {
+    pageSize: 200,
+    timeout: 15000,
+  },
+};
+
+export const TRIAL_PARTNERSHIP_TYPES: PartnershipType[] = [
+  "7_dias",
+  "15_dias",
+  "30_dias",
+  "60_dias",
+  "90_dias",
+  "120_dias",
+];
+
+export const DEFAULT_COMPANY_PAGINATION: AdminCompanyPagination = {
+  page: 1,
+  pageSize: COMPANY_DASHBOARD_CONFIG.api.pageSize,
+  total: 0,
+  totalPages: 0,
+};
+
+export const MOCK_COMPANY_PARTNERSHIPS: Partnership[] = [
+  {
+    id: "mock-empresa-1",
+    tipo: "parceiro",
+    inicio: "2024-01-10T12:00:00Z",
+    fim: "2024-02-10T12:00:00Z",
+    empresa: {
+      id: "mock-empresa-1",
+      nome: "Advance Tech Consultoria",
+      avatarUrl: "https://cdn.advance.com.br/logo.png",
+      cidade: "São Paulo",
+      estado: "SP",
+      descricao: "Consultoria especializada em recrutamento e seleção para empresas de tecnologia.",
+      instagram: "https://instagram.com/advancemais",
+      linkedin: "https://linkedin.com/company/advancemais",
+      codUsuario: "EMP-123456",
+      cnpj: "12345678000190",
+      ativo: true,
+      criadoEm: "2023-11-01T08:30:00Z",
+      parceira: true,
+      diasTesteDisponibilizados: 30,
+    },
+    plano: {
+      id: "plano-avancado",
+      nome: "Plano Avançado",
+      valor: "499.90",
+      quantidadeVagas: 3,
+      vagasPublicadas: 1,
+      tipo: "parceiro",
+      inicio: "2024-01-10T12:00:00Z",
+      fim: "2024-02-10T12:00:00Z",
+    },
+  },
+  {
+    id: "mock-empresa-2",
+    tipo: "30_dias",
+    inicio: "2024-03-01T08:00:00Z",
+    fim: "2024-03-31T08:00:00Z",
+    empresa: {
+      id: "mock-empresa-2",
+      nome: "Inova RH Solutions",
+      avatarUrl: "https://cdn.advance.com.br/inova.png",
+      cidade: "Curitiba",
+      estado: "PR",
+      descricao: "Agência de recrutamento com foco em inovação.",
+      instagram: "https://instagram.com/inovarh",
+      linkedin: "https://linkedin.com/company/inovarh",
+      codUsuario: "EMP-654321",
+      cnpj: "98765432000109",
+      ativo: false,
+      criadoEm: "2024-02-10T10:15:00Z",
+      parceira: false,
+      diasTesteDisponibilizados: 30,
+    },
+    plano: {
+      id: "plano-essencial",
+      nome: "Plano Essencial",
+      valor: "199.90",
+      quantidadeVagas: 2,
+      vagasPublicadas: 2,
+      tipo: "30_dias",
+      inicio: "2024-03-01T08:00:00Z",
+      fim: "2024-03-31T08:00:00Z",
+    },
+  },
+  {
+    id: "mock-empresa-3",
+    tipo: "15_dias",
+    inicio: "2024-04-05T09:30:00Z",
+    fim: "2024-04-20T09:30:00Z",
+    empresa: {
+      id: "mock-empresa-3",
+      nome: "RH Startups Brasil",
+      avatarUrl: "https://cdn.advance.com.br/rhstartups.png",
+      cidade: "Belo Horizonte",
+      estado: "MG",
+      descricao: "Conectando startups a talentos de alto impacto.",
+      instagram: "https://instagram.com/rhstartups",
+      linkedin: "https://linkedin.com/company/rhstartups",
+      codUsuario: "EMP-789012",
+      cnpj: "19283746000155",
+      ativo: true,
+      criadoEm: "2024-04-01T11:45:00Z",
+      parceira: false,
+      diasTesteDisponibilizados: 15,
+    },
+    plano: {
+      id: "plano-start",
+      nome: "Plano Start",
+      valor: "149.90",
+      quantidadeVagas: 1,
+      vagasPublicadas: 0,
+      tipo: "15_dias",
+      inicio: "2024-04-05T09:30:00Z",
+      fim: "2024-04-20T09:30:00Z",
+    },
+  },
+];

--- a/src/theme/dashboard/components/admin/lista-empresas/index.ts
+++ b/src/theme/dashboard/components/admin/lista-empresas/index.ts
@@ -1,0 +1,18 @@
+export { default } from "./CompanyDashboard";
+export { CompanyDashboard } from "./CompanyDashboard";
+
+export { useCompanyDashboardData } from "./hooks/useCompanyDashboardData";
+
+export { COMPANY_DASHBOARD_CONFIG, TRIAL_PARTNERSHIP_TYPES, MOCK_COMPANY_PARTNERSHIPS } from "./constants";
+
+export type {
+  Company,
+  Plan,
+  Partnership,
+  CompanyDashboardProps,
+  CompanyDashboardMetrics,
+  UseCompanyDashboardDataOptions,
+  UseCompanyDashboardDataReturn,
+  PlanFilter,
+  PartnershipType,
+} from "./types";

--- a/src/theme/dashboard/components/admin/lista-empresas/types/index.ts
+++ b/src/theme/dashboard/components/admin/lista-empresas/types/index.ts
@@ -1,0 +1,91 @@
+import type {
+  AdminCompanyListItem,
+  AdminCompanyPagination,
+  AdminCompanyPlanType,
+  ListAdminCompaniesParams,
+  ListAdminCompaniesResponse,
+} from "@/api/empresas";
+
+export type PartnershipType = AdminCompanyPlanType;
+
+export type PlanFilter = "all" | string;
+
+export interface Company {
+  id: string;
+  nome: string;
+  avatarUrl?: string | null;
+  cidade?: string | null;
+  estado?: string | null;
+  descricao?: string | null;
+  instagram?: string | null;
+  linkedin?: string | null;
+  codUsuario: string;
+  cnpj?: string | null;
+  ativo: boolean;
+  criadoEm?: string | null;
+  parceira?: boolean;
+  diasTesteDisponibilizados?: number | null;
+}
+
+export interface Plan {
+  id: string;
+  icon?: string | null;
+  nome: string;
+  descricao?: string | null;
+  valor?: string | null;
+  desconto?: number | null;
+  quantidadeVagas: number;
+  vagaEmDestaque?: boolean | null;
+  quantidadeVagasDestaque?: number | null;
+  criadoEm?: string | null;
+  atualizadoEm?: string | null;
+  vagasPublicadas?: number | null;
+  tipo?: PartnershipType;
+  inicio?: string | null;
+  fim?: string | null;
+}
+
+export interface Partnership {
+  id: string;
+  tipo?: PartnershipType;
+  inicio?: string | null;
+  fim?: string | null;
+  ativo?: boolean;
+  empresa: Company;
+  plano: Plan;
+  raw?: AdminCompanyListItem;
+}
+
+export interface CompanyDashboardProps {
+  className?: string;
+  partnerships?: Partnership[];
+  fetchFromApi?: boolean;
+  itemsPerPage?: number;
+  pageSize?: number;
+  onDataLoaded?: (data: Partnership[], response?: ListAdminCompaniesResponse | null) => void;
+  onError?: (message: string) => void;
+}
+
+export interface CompanyDashboardMetrics {
+  partners: number;
+  trials: number;
+  active: number;
+  inactive: number;
+}
+
+export interface UseCompanyDashboardDataOptions {
+  enabled?: boolean;
+  pageSize?: number;
+  initialData?: Partnership[];
+  initialParams?: ListAdminCompaniesParams;
+  onSuccess?: (data: Partnership[], response: ListAdminCompaniesResponse) => void;
+  onError?: (message: string) => void;
+}
+
+export interface UseCompanyDashboardDataReturn {
+  partnerships: Partnership[];
+  pagination: AdminCompanyPagination | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: (params?: Partial<ListAdminCompaniesParams>) => Promise<Partnership[]>;
+}


### PR DESCRIPTION
## Summary
- add typed API client for the admin companies endpoints
- build the admin company dashboard component with filters, metrics, pagination and loading states
- expose supporting hooks, constants and mock data to integrate the listing in other screens

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cae89c14f08325924f6bd87574a6e1