### PR TITLE
Add admin companies list page and breadcrumb entry

### DIFF
--- a/src/app/dashboard/admin/companies/list/page.tsx
+++ b/src/app/dashboard/admin/companies/list/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/app/dashboard/empresas/admin/listagem/page";

--- a/src/app/dashboard/empresas/admin/list/page.tsx
+++ b/src/app/dashboard/empresas/admin/list/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../listagem/page";

--- a/src/app/dashboard/empresas/admin/listagem/page.tsx
+++ b/src/app/dashboard/empresas/admin/listagem/page.tsx
@@ -1,0 +1,11 @@
+import { CompanyDashboard } from "@/theme/dashboard/components/admin";
+import { DashboardHeader } from "@/components/layout";
+
+export default function AdminCompaniesListPage() {
+  return (
+    <div className="space-y-8">
+      <DashboardHeader />
+      <CompanyDashboard />
+    </div>
+  );
+}

--- a/src/lib/breadcrumb-config.ts
+++ b/src/lib/breadcrumb-config.ts
@@ -1,5 +1,14 @@
 import type { BreadcrumbConfig } from '@/config/breadcrumb';
 
+const EMPRESAS_BREADCRUMB: BreadcrumbConfig = {
+  title: 'Empresas',
+  items: [
+    { label: 'Dashboard', href: '/dashboard', icon: 'Home' },
+    { label: 'Admin', href: '/dashboard/admin', icon: 'Settings' },
+    { label: 'Empresas', href: '/dashboard/admin/companies/list', icon: 'Building2' }
+  ]
+};
+
 export const breadcrumbConfig: Record<string, BreadcrumbConfig> = {
   '/dashboard': {
     title: 'Dashboard',
@@ -24,6 +33,10 @@ export const breadcrumbConfig: Record<string, BreadcrumbConfig> = {
       { label: 'Website', href: '/dashboard/admin/website', icon: 'Globe' }
     ]
   },
+
+  '/dashboard/admin/companies/list': EMPRESAS_BREADCRUMB,
+  '/dashboard/empresas/admin/list': EMPRESAS_BREADCRUMB,
+  '/dashboard/empresas/admin/listagem': EMPRESAS_BREADCRUMB,
   
   '/config/website/pagina-inicial': {
     title: 'Configuração Página Inicial',


### PR DESCRIPTION
## Summary
- add admin companies list page that renders the CompanyDashboard with the dashboard header
- expose the page under both /dashboard/empresas/admin/list and /dashboard/admin/companies/list
- centralize and reuse the breadcrumb definition for the Empresas section

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68caf50607c483258bd79fa8dd86720c