### PR TITLE
Allow Building2 icon for breadcrumbs

### DIFF
--- a/src/config/breadcrumb.ts
+++ b/src/config/breadcrumb.ts
@@ -38,6 +38,7 @@ export type IconName =
   | "HelpCircle"
   | "Briefcase"
   | "BookOpen"
+  | "Building2"
   | "ExternalLink";
 
 export interface BreadcrumbItem {


### PR DESCRIPTION
## Summary
- add the Building2 icon to the breadcrumb icon type so breadcrumb configuration can reference it

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68caf6d26ee08325b9353eaae07e35ac