### PR TITLE
feat: format company cnpj and fix plan filter toggle

### DIFF
--- a/src/components/ui/custom/filters/MultiSelectFilter.tsx
+++ b/src/components/ui/custom/filters/MultiSelectFilter.tsx
@@ -147,12 +147,12 @@ export function MultiSelectFilter({
                     className={cn(
                       "flex items-center space-x-2.5 p-2 -mx-1",
                       "hover:bg-accent/50 rounded-lg transition-all duration-200",
-                      "cursor-pointer group",
+                      "group",
                       checked && "bg-blue-50/50"
                     )}
-                    onClick={() => toggle(opt.value)}
                   >
                     <CheckboxCustom
+                      id={checkboxId(opt.value)}
                       checked={checked}
                       onCheckedChange={() => toggle(opt.value)}
                       className="size-4 rounded-[6px]"

--- a/src/theme/dashboard/components/admin/lista-empresas/CompanyDashboard.tsx
+++ b/src/theme/dashboard/components/admin/lista-empresas/CompanyDashboard.tsx
@@ -34,6 +34,9 @@ import type { CompanyDashboardProps } from "./types";
 import { FilterBar } from "@/components/ui/custom";
 import type { FilterField } from "@/components/ui/custom/filters";
 
+const normalizeCnpj = (value?: string | null): string =>
+  value?.replace(/\D/g, "") ?? "";
+
 export function CompanyDashboard({
   className,
   partnerships: partnershipsProp,
@@ -135,16 +138,20 @@ export function CompanyDashboard({
     }
 
     const query = searchTerm.trim().toLowerCase();
+    const numericQuery = query.replace(/\D/g, "");
 
     return partnerships.filter((partnership) => {
       const company = partnership.empresa;
       const plan = partnership.plano;
+      const companyCnpj = company.cnpj ?? "";
+      const normalizedCnpj = normalizeCnpj(companyCnpj);
 
       const matchesSearch =
         query.length === 0 ||
         company.nome.toLowerCase().includes(query) ||
         company.codUsuario.toLowerCase().includes(query) ||
-        (company.cnpj?.toLowerCase().includes(query) ?? false);
+        companyCnpj.toLowerCase().includes(query) ||
+        (numericQuery.length > 0 && normalizedCnpj.includes(numericQuery));
 
       const matchesPlan =
         selectedPlans.length === 0 || selectedPlans.includes(plan.nome);

--- a/src/theme/dashboard/components/admin/lista-empresas/components/CompanyRow.tsx
+++ b/src/theme/dashboard/components/admin/lista-empresas/components/CompanyRow.tsx
@@ -18,6 +18,26 @@ interface CompanyRowProps {
   partnership: Partnership;
 }
 
+function formatCnpj(value?: string | null): string | null {
+  if (!value) return null;
+
+  const digits = value.replace(/\D/g, "").slice(0, 14);
+  if (digits.length === 0) return null;
+
+  if (digits.length <= 2) return digits;
+  if (digits.length <= 5) {
+    return `${digits.slice(0, 2)}.${digits.slice(2)}`;
+  }
+  if (digits.length <= 8) {
+    return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5)}`;
+  }
+  if (digits.length <= 12) {
+    return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5, 8)}/${digits.slice(8)}`;
+  }
+
+  return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5, 8)}/${digits.slice(8, 12)}-${digits.slice(12)}`;
+}
+
 function formatCurrency(value?: string | null): string {
   if (!value) return "—";
 
@@ -75,6 +95,7 @@ export const CompanyRow: React.FC<CompanyRowProps> = ({ partnership }) => {
   const vagasTotal = partnership.plano.quantidadeVagas ?? 0;
   const vagasPublicadas = partnership.plano.vagasPublicadas ?? partnership.raw?.vagas?.publicadas ?? 0;
   const percent = vagasTotal > 0 ? Math.min(100, Math.round((vagasPublicadas / vagasTotal) * 100)) : 0;
+  const formattedCnpj = formatCnpj(partnership.empresa.cnpj);
 
   return (
     <TableRow className="border-gray-100 hover:bg-gray-50/50 transition-colors">
@@ -98,9 +119,9 @@ export const CompanyRow: React.FC<CompanyRowProps> = ({ partnership }) => {
                 {partnership.empresa.codUsuario}
               </code>
             </div>
-            {partnership.empresa.cnpj && (
+            {formattedCnpj && (
               <div className="text-xs text-gray-500 font-mono">
-                {partnership.empresa.cnpj}
+                {formattedCnpj}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- format CNPJ values before rendering and enhance search to accept masked or raw digits
- adjust plan filter multi-select to ensure selections toggle correctly without double clicks

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cc6d07125c8332a0cb02129dea4c23