### PR TITLE
Aprimora UX do filtro de planos empresariais

### DIFF
--- a/src/components/ui/custom/filters/FilterBar.tsx
+++ b/src/components/ui/custom/filters/FilterBar.tsx
@@ -97,7 +97,7 @@ export function FilterBar({
                   selectedValues={(values[field.key] as string[]) || []}
                   onSelectionChange={(val) => onChange(field.key, val)}
                   showApplyButton
-                  className="w-full md:w-[360px] lg:w-[400px]"
+                  className="w-full"
                 />
               </div>
             );


### PR DESCRIPTION
## Summary
- ajusta o MultiSelectFilter para espelhar a largura do trigger e adiciona a ação de limpar condicionada à seleção
- aplica estado de carregamento e desabilita o botão de aplicar quando não há itens marcados
- alinha a configuração do FilterBar com o novo comportamento de largura do dropdown

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68cc76482040833290071c7618d841e4