### PR TITLE
fix: prevent login page reload on invalid credentials

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -8,6 +8,11 @@ interface FetchOptions<T> {
   cache?: "no-cache" | "short" | "medium" | "long";
   retries?: number;
   timeout?: number;
+  /**
+   * Evita executar o fluxo de logout automático quando a API retorna 401.
+   * Útil para rotas públicas como login, onde o redirect quebra a UX.
+   */
+  skipLogoutOn401?: boolean;
 }
 
 // Cache em memória simples
@@ -35,6 +40,7 @@ export async function apiFetch<T = unknown>(
     cache = "short",
     retries = 3,
     timeout = 15000,
+    skipLogoutOn401 = false,
   }: FetchOptions<T> = {}
 ): Promise<T> {
   const url = endpoint.startsWith("http") ? endpoint : buildApiUrl(endpoint);
@@ -90,7 +96,7 @@ export async function apiFetch<T = unknown>(
 
         const errorObj = new Error(errorMessage);
         (errorObj as any).status = res.status;
-        if (res.status === 401) {
+        if (res.status === 401 && !skipLogoutOn401) {
           logoutUser();
         }
         throw errorObj;

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -45,8 +45,10 @@ const SignInPageDemo = () => {
 
   const handleSignIn = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    const formElement = event.currentTarget;
+
     startTransition(async () => {
-      const formData = new FormData(event.currentTarget);
+      const formData = new FormData(formElement);
       const { documento, senha, rememberMe } = Object.fromEntries(
         formData.entries()
       ) as {
@@ -68,6 +70,7 @@ const SignInPageDemo = () => {
               body: JSON.stringify({ documento: documentoLimpo, senha }),
             },
             retries: 1,
+            skipLogoutOn401: true,
           }
         );
         let userRole: UserRole | undefined;
@@ -123,9 +126,18 @@ const SignInPageDemo = () => {
         }, 1000);
       } catch (error) {
         console.error("Erro ao fazer login:", error);
-        toastCustom.error(
-          "Não foi possível realizar o login. Verifique suas credenciais."
-        );
+        const status = (error as any)?.status as number | undefined;
+        let message = "Não foi possível realizar o login. Verifique suas credenciais.";
+
+        if (status === 404) {
+          message = "Usuário não encontrado. Verifique suas credenciais.";
+        } else if (status === 401) {
+          message = "Credenciais inválidas. Verifique e tente novamente.";
+        } else if (error instanceof Error && error.message) {
+          message = error.message;
+        }
+
+        toastCustom.error(message);
       }
     });
   };


### PR DESCRIPTION
## Summary
- add an option to the API client to skip the automatic logout redirect on 401 responses
- use the new option on the login screen, preserve the submitted form reference, and surface clearer error toasts

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cc8e36f75c8332ab793dfbba589d7d