### PR TITLE
fix: normalize empty state image size resolution

### DIFF
--- a/src/components/ui/custom/empty-state/EmptyState.tsx
+++ b/src/components/ui/custom/empty-state/EmptyState.tsx
@@ -51,7 +51,8 @@ const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
     },
     ref
   ) => {
-    const resolvedImageSize: EmptyStateSize = imageSize ?? size;
+    const resolvedVariantSize: EmptyStateSize = size ?? "md";
+    const resolvedImageSize: EmptyStateSize = imageSize ?? resolvedVariantSize;
     const illustrationSrc = illustration
       ? emptyStateIllustrations[illustration]
       : undefined;


### PR DESCRIPTION
## Summary
- ensure the empty state component resolves a concrete variant size before selecting an image size

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68cca90168e08332935c8603e304587f