### PR TITLE
refactor: rename admin empresas routes alias

### DIFF
--- a/src/api/empresas/admin/index.ts
+++ b/src/api/empresas/admin/index.ts
@@ -35,7 +35,7 @@ export async function listAdminCompanies(
   params?: ListAdminCompaniesParams,
   init?: RequestInit,
 ): Promise<ListAdminCompaniesResponse> {
-  const endpoint = empresasRoutes.admin.list();
+  const endpoint = empresasRoutes.adminEmpresas.list();
   const query = new URLSearchParams();
 
   if (params?.page) {
@@ -74,7 +74,7 @@ export async function listAdminCompanies(
 }
 
 export async function getAdminCompanyById(id: string, init?: RequestInit): Promise<AdminCompanyDetailResponse> {
-  const endpoint = empresasRoutes.admin.get(id);
+  const endpoint = empresasRoutes.adminEmpresas.get(id);
 
   const headers = {
     ...apiConfig.headers,
@@ -95,7 +95,7 @@ export async function createAdminCompany(
   data: CreateAdminCompanyPayload,
   init?: RequestInit,
 ): Promise<AdminCompanyDetailResponse> {
-  const endpoint = empresasRoutes.admin.create();
+  const endpoint = empresasRoutes.adminEmpresas.create();
 
   const headers = {
     "Content-Type": "application/json",
@@ -120,7 +120,7 @@ export async function updateAdminCompany(
   data: UpdateAdminCompanyPayload,
   init?: RequestInit,
 ): Promise<AdminCompanyDetailResponse> {
-  const endpoint = empresasRoutes.admin.update(id);
+  const endpoint = empresasRoutes.adminEmpresas.update(id);
 
   const headers = {
     "Content-Type": "application/json",

--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -179,7 +179,7 @@ export const empresasRoutes = {
     update: (id: string) => `${prefix}/empresas/planos-empresarial/${id}`,
     delete: (id: string) => `${prefix}/empresas/planos-empresarial/${id}`,
   },
-  admin: {
+  adminEmpresas: {
     list: () => `${prefix}/empresas/admin`,
     create: () => `${prefix}/empresas/admin`,
     get: (id: string) => `${prefix}/empresas/admin/${id}`,


### PR DESCRIPTION
## Summary
- rename the empresas admin route group to adminEmpresas to avoid naming confusion
- update the admin companies API helpers to use the renamed route helpers

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cca9881b2c833299de009f90ebf84f