### PR TITLE
feat: align admin empresas api and ui

### DIFF
--- a/src/api/empresas/admin/index.ts
+++ b/src/api/empresas/admin/index.ts
@@ -3,10 +3,19 @@ import { apiFetch } from "@/api/client";
 import { apiConfig } from "@/lib/env";
 import type {
   AdminCompanyDetailResponse,
+  AdminCompanyVacancyDetailResponse,
+  AdminCompanyVacancyListResponse,
   CreateAdminCompanyPayload,
+  AdminCompanyBanDetailResponse,
+  AdminCompanyBanHistoryResponse,
+  AdminCompanyPaymentHistoryResponse,
   ListAdminCompaniesParams,
   ListAdminCompaniesResponse,
+  ListAdminCompanyBansParams,
+  ListAdminCompanyPaymentsParams,
+  ListAdminCompanyVacanciesParams,
   UpdateAdminCompanyPayload,
+  CreateAdminCompanyBanPayload,
 } from "./types";
 
 function normalizeHeaders(headers?: HeadersInit): Record<string, string> {
@@ -135,6 +144,192 @@ export async function updateAdminCompany(
       ...init,
       headers,
       body: init?.body ?? JSON.stringify(data),
+    },
+    cache: "no-cache",
+  });
+}
+
+function appendPaginationParams(
+  query: URLSearchParams,
+  params?: { page?: number; pageSize?: number },
+): void {
+  if (!params) return;
+  if (params.page) {
+    query.set("page", String(params.page));
+  }
+  if (params.pageSize) {
+    query.set("pageSize", String(params.pageSize));
+  }
+}
+
+export async function listAdminCompanyPayments(
+  id: string,
+  params?: ListAdminCompanyPaymentsParams,
+  init?: RequestInit,
+): Promise<AdminCompanyPaymentHistoryResponse> {
+  const endpoint = empresasRoutes.adminEmpresas.pagamentos.list(id);
+  const query = new URLSearchParams();
+  appendPaginationParams(query, params);
+
+  const url = query.toString() ? `${endpoint}?${query}` : endpoint;
+
+  const headers = {
+    ...apiConfig.headers,
+    ...getAuthHeader(),
+    ...normalizeHeaders(init?.headers),
+  };
+
+  return apiFetch<AdminCompanyPaymentHistoryResponse>(url, {
+    init: {
+      method: init?.method ?? "GET",
+      ...init,
+      headers,
+    },
+    cache: "no-cache",
+  });
+}
+
+export async function listAdminCompanyBans(
+  id: string,
+  params?: ListAdminCompanyBansParams,
+  init?: RequestInit,
+): Promise<AdminCompanyBanHistoryResponse> {
+  const endpoint = empresasRoutes.adminEmpresas.banimentos.list(id);
+  const query = new URLSearchParams();
+  appendPaginationParams(query, params);
+
+  const url = query.toString() ? `${endpoint}?${query}` : endpoint;
+
+  const headers = {
+    ...apiConfig.headers,
+    ...getAuthHeader(),
+    ...normalizeHeaders(init?.headers),
+  };
+
+  return apiFetch<AdminCompanyBanHistoryResponse>(url, {
+    init: {
+      method: init?.method ?? "GET",
+      ...init,
+      headers,
+    },
+    cache: "no-cache",
+  });
+}
+
+export async function createAdminCompanyBan(
+  id: string,
+  data: CreateAdminCompanyBanPayload,
+  init?: RequestInit,
+): Promise<AdminCompanyBanDetailResponse> {
+  const endpoint = empresasRoutes.adminEmpresas.banimentos.create(id);
+
+  const headers = {
+    "Content-Type": "application/json",
+    Accept: apiConfig.headers.Accept,
+    ...getAuthHeader(),
+    ...normalizeHeaders(init?.headers),
+  };
+
+  return apiFetch<AdminCompanyBanDetailResponse>(endpoint, {
+    init: {
+      method: "POST",
+      ...init,
+      headers,
+      body: init?.body ?? JSON.stringify(data),
+    },
+    cache: "no-cache",
+  });
+}
+
+function normalizeStatusParam(
+  status?: ListAdminCompanyVacanciesParams["status"],
+): string | undefined {
+  if (!status) return undefined;
+  if (Array.isArray(status)) {
+    return status.filter(Boolean).join(",");
+  }
+  return typeof status === "string" ? status : String(status);
+}
+
+export async function listAdminCompanyVacancies(
+  id: string,
+  params?: ListAdminCompanyVacanciesParams,
+  init?: RequestInit,
+): Promise<AdminCompanyVacancyListResponse> {
+  const endpoint = empresasRoutes.adminEmpresas.vagas.list(id);
+  const query = new URLSearchParams();
+  appendPaginationParams(query, params);
+
+  const normalizedStatus = normalizeStatusParam(params?.status);
+  if (normalizedStatus) {
+    query.set("status", normalizedStatus);
+  }
+
+  const url = query.toString() ? `${endpoint}?${query}` : endpoint;
+
+  const headers = {
+    ...apiConfig.headers,
+    ...getAuthHeader(),
+    ...normalizeHeaders(init?.headers),
+  };
+
+  return apiFetch<AdminCompanyVacancyListResponse>(url, {
+    init: {
+      method: init?.method ?? "GET",
+      ...init,
+      headers,
+    },
+    cache: "no-cache",
+  });
+}
+
+export async function listAdminCompanyVacanciesInReview(
+  id: string,
+  params?: Omit<ListAdminCompanyVacanciesParams, "status">,
+  init?: RequestInit,
+): Promise<AdminCompanyVacancyListResponse> {
+  const endpoint = empresasRoutes.adminEmpresas.vagas.emAnalise(id);
+  const query = new URLSearchParams();
+  appendPaginationParams(query, params);
+
+  const url = query.toString() ? `${endpoint}?${query}` : endpoint;
+
+  const headers = {
+    ...apiConfig.headers,
+    ...getAuthHeader(),
+    ...normalizeHeaders(init?.headers),
+  };
+
+  return apiFetch<AdminCompanyVacancyListResponse>(url, {
+    init: {
+      method: init?.method ?? "GET",
+      ...init,
+      headers,
+    },
+    cache: "no-cache",
+  });
+}
+
+export async function approveAdminCompanyVacancy(
+  id: string,
+  vacancyId: string,
+  init?: RequestInit,
+): Promise<AdminCompanyVacancyDetailResponse> {
+  const endpoint = empresasRoutes.adminEmpresas.vagas.aprovar(id, vacancyId);
+
+  const headers = {
+    "Content-Type": "application/json",
+    Accept: apiConfig.headers.Accept,
+    ...getAuthHeader(),
+    ...normalizeHeaders(init?.headers),
+  };
+
+  return apiFetch<AdminCompanyVacancyDetailResponse>(endpoint, {
+    init: {
+      method: "POST",
+      ...init,
+      headers,
+      body: init?.body ?? null,
     },
     cache: "no-cache",
   });

--- a/src/api/empresas/admin/types.ts
+++ b/src/api/empresas/admin/types.ts
@@ -9,6 +9,13 @@ export type AdminCompanyPlanType =
   | "120_dias"
   | "parceiro";
 
+export type AdminCompanyVacancyStatus =
+  | "RASCUNHO"
+  | "EM_ANALISE"
+  | "PUBLICADO"
+  | "EXPIRADO"
+  | string;
+
 export interface AdminCompanyPlanSummary {
   id: string;
   nome: string;
@@ -20,6 +27,9 @@ export interface AdminCompanyPlanSummary {
   statusPagamento?: string | null;
   quantidadeVagas: number;
   valor?: string | null;
+  duracaoEmDias?: number | null;
+  diasRestantes?: number | null;
+  vagasPublicadas?: number | null;
 }
 
 export interface AdminCompanyVacancyInfo {
@@ -32,6 +42,15 @@ export interface AdminCompanyPaymentInfo {
   metodo?: string | null;
   status?: string | null;
   ultimoPagamentoEm?: string | null;
+}
+
+export interface AdminCompanyBanInfo {
+  id: string;
+  motivo: string;
+  dias: number;
+  inicio: string;
+  fim: string;
+  criadoEm: string;
 }
 
 export interface AdminCompanyListItem {
@@ -54,6 +73,10 @@ export interface AdminCompanyListItem {
   plano?: AdminCompanyPlanSummary | null;
   vagas?: AdminCompanyVacancyInfo | null;
   pagamento?: AdminCompanyPaymentInfo | null;
+  banida?: boolean;
+  banimentoAtivo?: AdminCompanyBanInfo | null;
+  vagasPublicadas?: number | null;
+  limiteVagasPlano?: number | null;
 }
 
 export type AdminCompanyDetail = AdminCompanyListItem;
@@ -88,6 +111,7 @@ export interface AdminCompanyPlanPayload {
   tipo: AdminCompanyPlanType;
   iniciarEm?: string;
   observacao?: string;
+  resetPeriodo?: boolean;
 }
 
 export interface CreateAdminCompanyPayload {
@@ -121,4 +145,74 @@ export interface UpdateAdminCompanyPayload {
   avatarUrl?: string;
   status?: AdminCompanyStatus;
   plano?: AdminCompanyPlanPayload;
+}
+
+export interface ListAdminCompanyPaymentsParams {
+  page?: number;
+  pageSize?: number;
+}
+
+export interface ListAdminCompanyBansParams {
+  page?: number;
+  pageSize?: number;
+}
+
+export interface CreateAdminCompanyBanPayload {
+  dias: number;
+  motivo: string;
+}
+
+export interface AdminCompanyPaymentLog {
+  id: string;
+  tipo: string;
+  status: string;
+  mensagem?: string | null;
+  externalRef?: string | null;
+  mpResourceId?: string | null;
+  criadoEm?: string | null;
+  plano?: {
+    id: string;
+    nome?: string | null;
+  } | null;
+}
+
+export interface AdminCompanyPaymentHistoryResponse {
+  data: AdminCompanyPaymentLog[];
+  pagination: AdminCompanyPagination;
+}
+
+export interface AdminCompanyBanHistoryResponse {
+  data: AdminCompanyBanInfo[];
+  pagination: AdminCompanyPagination;
+}
+
+export interface AdminCompanyBanDetailResponse {
+  banimento: AdminCompanyBanInfo;
+}
+
+export interface ListAdminCompanyVacanciesParams {
+  page?: number;
+  pageSize?: number;
+  status?: AdminCompanyVacancyStatus[] | AdminCompanyVacancyStatus | string;
+}
+
+export interface AdminCompanyVacancyListItem {
+  id: string;
+  status: AdminCompanyVacancyStatus;
+  inseridaEm?: string | null;
+  atualizadoEm?: string | null;
+  inscricoesAte?: string | null;
+  modoAnonimo?: boolean | null;
+  modalidade?: string | null;
+  regimeDeTrabalho?: string | null;
+  paraPcd?: boolean | null;
+}
+
+export interface AdminCompanyVacancyListResponse {
+  data: AdminCompanyVacancyListItem[];
+  pagination: AdminCompanyPagination;
+}
+
+export interface AdminCompanyVacancyDetailResponse {
+  vaga: AdminCompanyVacancyListItem;
 }

--- a/src/api/empresas/index.ts
+++ b/src/api/empresas/index.ts
@@ -17,6 +17,12 @@ export {
   getAdminCompanyById,
   createAdminCompany,
   updateAdminCompany,
+  listAdminCompanyPayments,
+  listAdminCompanyBans,
+  createAdminCompanyBan,
+  listAdminCompanyVacancies,
+  listAdminCompanyVacanciesInReview,
+  approveAdminCompanyVacancy,
 } from "./admin";
 
 export type {
@@ -32,4 +38,16 @@ export type {
   ListAdminCompaniesParams,
   ListAdminCompaniesResponse,
   UpdateAdminCompanyPayload,
+  ListAdminCompanyPaymentsParams,
+  ListAdminCompanyBansParams,
+  CreateAdminCompanyBanPayload,
+  AdminCompanyPaymentHistoryResponse,
+  AdminCompanyBanHistoryResponse,
+  AdminCompanyBanDetailResponse,
+  AdminCompanyPaymentLog,
+  ListAdminCompanyVacanciesParams,
+  AdminCompanyVacancyListItem,
+  AdminCompanyVacancyListResponse,
+  AdminCompanyVacancyDetailResponse,
+  AdminCompanyVacancyStatus,
 } from "./admin/types";

--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -184,6 +184,19 @@ export const empresasRoutes = {
     create: () => `${prefix}/empresas/admin`,
     get: (id: string) => `${prefix}/empresas/admin/${id}`,
     update: (id: string) => `${prefix}/empresas/admin/${id}`,
+    pagamentos: {
+      list: (id: string) => `${prefix}/empresas/admin/${id}/pagamentos`,
+    },
+    banimentos: {
+      list: (id: string) => `${prefix}/empresas/admin/${id}/banimentos`,
+      create: (id: string) => `${prefix}/empresas/admin/${id}/banimentos`,
+    },
+    vagas: {
+      list: (id: string) => `${prefix}/empresas/admin/${id}/vagas`,
+      emAnalise: (id: string) => `${prefix}/empresas/admin/${id}/vagas/em-analise`,
+      aprovar: (id: string, vagaId: string) =>
+        `${prefix}/empresas/admin/${id}/vagas/${vagaId}/aprovar`,
+    },
   },
 };
 

--- a/src/theme/dashboard/components/admin/lista-empresas/hooks/useCompanyDashboardData.ts
+++ b/src/theme/dashboard/components/admin/lista-empresas/hooks/useCompanyDashboardData.ts
@@ -13,6 +13,14 @@ import type { AdminCompanyListItem, ListAdminCompaniesParams } from "@/api/empre
 
 function mapAdminCompanyToPartnership(company: AdminCompanyListItem): Partnership {
   const plan = company.plano;
+  const payment = company.pagamento;
+  const vagasPublicadas =
+    plan?.vagasPublicadas ??
+    company.vagas?.publicadas ??
+    company.vagasPublicadas ??
+    null;
+  const limiteVagas =
+    company.vagas?.limitePlano ?? company.limiteVagasPlano ?? plan?.quantidadeVagas ?? 0;
 
   return {
     id: company.id,
@@ -32,21 +40,30 @@ function mapAdminCompanyToPartnership(company: AdminCompanyListItem): Partnershi
       codUsuario: company.codUsuario,
       cnpj: company.cnpj ?? null,
       ativo: company.ativa,
+      status: company.status,
       criadoEm: company.criadoEm ?? null,
       parceira: company.parceira,
       diasTesteDisponibilizados: company.diasTesteDisponibilizados ?? null,
+      banida: company.banida,
+      banimentoAtivo: company.banimentoAtivo ?? null,
     },
     plano: {
       id: plan?.id ?? `${company.id}-plano`,
       nome: plan?.nome ?? "Plano não informado",
       valor: plan?.valor ?? null,
-      quantidadeVagas: plan?.quantidadeVagas ?? 0,
-      vagasPublicadas: company.vagas?.publicadas ?? null,
+      quantidadeVagas: plan?.quantidadeVagas ?? limiteVagas,
+      vagasPublicadas,
       tipo: plan?.tipo,
       inicio: plan?.inicio ?? null,
       fim: plan?.fim ?? null,
+      metodoPagamento: plan?.metodoPagamento ?? payment?.metodo ?? null,
+      modeloPagamento: plan?.modeloPagamento ?? payment?.modelo ?? null,
+      statusPagamento: plan?.statusPagamento ?? payment?.status ?? null,
+      duracaoEmDias: plan?.duracaoEmDias ?? null,
+      diasRestantes: plan?.diasRestantes ?? null,
     },
     raw: company,
+    pagamento: payment ?? null,
   };
 }
 

--- a/src/theme/dashboard/components/admin/lista-empresas/types/index.ts
+++ b/src/theme/dashboard/components/admin/lista-empresas/types/index.ts
@@ -2,6 +2,9 @@ import type {
   AdminCompanyListItem,
   AdminCompanyPagination,
   AdminCompanyPlanType,
+  AdminCompanyPaymentInfo,
+  AdminCompanyBanInfo,
+  AdminCompanyStatus,
   ListAdminCompaniesParams,
   ListAdminCompaniesResponse,
 } from "@/api/empresas";
@@ -22,9 +25,12 @@ export interface Company {
   codUsuario: string;
   cnpj?: string | null;
   ativo: boolean;
+  status?: AdminCompanyStatus;
   criadoEm?: string | null;
   parceira?: boolean;
   diasTesteDisponibilizados?: number | null;
+  banida?: boolean;
+  banimentoAtivo?: AdminCompanyBanInfo | null;
 }
 
 export interface Plan {
@@ -43,6 +49,11 @@ export interface Plan {
   tipo?: PartnershipType;
   inicio?: string | null;
   fim?: string | null;
+  modeloPagamento?: string | null;
+  metodoPagamento?: string | null;
+  statusPagamento?: string | null;
+  duracaoEmDias?: number | null;
+  diasRestantes?: number | null;
 }
 
 export interface Partnership {
@@ -54,6 +65,7 @@ export interface Partnership {
   empresa: Company;
   plano: Plan;
   raw?: AdminCompanyListItem;
+  pagamento?: AdminCompanyPaymentInfo | null;
 }
 
 export interface CompanyDashboardProps {


### PR DESCRIPTION
## Summary
- expand admin empresas API client and typings to cover payments, bans and vacancies endpoints
- enrich admin company dashboard data mapping with plan, payment and ban status metadata
- refresh company list row UI to surface plan payment status, ban alerts and trial details

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ccaeca0c488332a018965d8e646d68