### PR TITLE
test: silence env warning in validation spec

### DIFF
--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -17,12 +17,17 @@ describe('buildApiUrl', () => {
 describe('validateEnv', () => {
   it('throws in production when required variables are missing', async () => {
     const originalEnv = process.env.NODE_ENV
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     ;(process as any).env.NODE_ENV = 'production'
     delete process.env.NEXT_PUBLIC_API_BASE_URL
     delete process.env.NEXT_PUBLIC_BASE_URL
     vi.resetModules()
     const { validateEnv } = await import('./env')
-    expect(() => validateEnv()).toThrow(/Missing required environment variables/)
-    ;(process as any).env.NODE_ENV = originalEnv
+    try {
+      expect(() => validateEnv()).toThrow(/Missing required environment variables/)
+    } finally {
+      ;(process as any).env.NODE_ENV = originalEnv
+      warnSpy.mockRestore()
+    }
   })
 })


### PR DESCRIPTION
## Summary
- mock console.warn in the production validation spec to prevent noise about missing env vars
- restore NODE_ENV and the warn spy in a finally block to keep the test environment clean

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ccb3b28a008332916d1dacde037fdc