### PR TITLE
fix: include status on admin company data

### DIFF
--- a/src/api/empresas/admin/types.ts
+++ b/src/api/empresas/admin/types.ts
@@ -68,6 +68,7 @@ export interface AdminCompanyListItem {
   estado?: string | null;
   criadoEm?: string | null;
   ativa: boolean;
+  status?: AdminCompanyStatus;
   parceira: boolean;
   diasTesteDisponibilizados?: number | null;
   plano?: AdminCompanyPlanSummary | null;

--- a/src/api/empresas/index.ts
+++ b/src/api/empresas/index.ts
@@ -34,6 +34,8 @@ export type {
   AdminCompanyPlanSummary,
   AdminCompanyPlanType,
   AdminCompanyStatus,
+  AdminCompanyPaymentInfo,
+  AdminCompanyBanInfo,
   CreateAdminCompanyPayload,
   ListAdminCompaniesParams,
   ListAdminCompaniesResponse,


### PR DESCRIPTION
## Summary
- add optional status field to the admin company list item type so dashboard mapping compiles
- re-export admin company payment and ban info types from the empresas API barrel

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccb3a2ea1c8332b719d5ff7071c577