### PR TITLE
feat: refine empty state design

### DIFF
--- a/src/components/ui/custom/empty-state/EmptyState.tsx
+++ b/src/components/ui/custom/empty-state/EmptyState.tsx
@@ -73,17 +73,21 @@ const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
         {illustrationSrc && (
           <div
             className={cn(
-              "relative flex items-center justify-center self-center rounded-3xl bg-gradient-to-br from-gray-50 via-white to-gray-100 shadow-sm ring-1 ring-black/5 dark:from-zinc-900 dark:via-zinc-900/90 dark:to-zinc-900 dark:ring-white/10",
+              "relative flex items-center justify-center overflow-hidden rounded-[28px] bg-white/90 shadow-[0_25px_65px_-40px_rgba(15,23,42,0.45)] ring-1 ring-black/5 backdrop-blur-sm dark:bg-zinc-900/70 dark:ring-white/10",
               illustrationWrapperPadding[resolvedImageSize],
-              align === "start" ? "self-start" : ""
+              align === "start" ? "self-start" : "self-center"
             )}
           >
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(79,70,229,0.12),_transparent_70%)] opacity-80 dark:bg-[radial-gradient(circle_at_top,_rgba(129,140,248,0.18),_transparent_70%)]"
+            />
             <Image
               src={illustrationSrc}
               alt={illustrationAlt ?? DEFAULT_ILLUSTRATION_ALT}
               width={illustrationSizeMap[resolvedImageSize]}
               height={illustrationSizeMap[resolvedImageSize]}
-              className="h-auto w-full max-w-[220px] object-contain"
+              className="relative h-auto w-full max-w-[220px] object-contain"
               sizes="(min-width: 1024px) 220px, (min-width: 640px) 180px, 160px"
               priority={false}
             />
@@ -98,7 +102,7 @@ const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
           )}
         >
           {eyebrow && (
-            <span className="text-xs font-semibold uppercase tracking-[0.25em] text-gray-400 dark:text-zinc-500">
+            <span className="text-xs font-medium uppercase tracking-[0.25em] text-gray-400 dark:text-zinc-500">
               {eyebrow}
             </span>
           )}
@@ -117,7 +121,7 @@ const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
         {(actions || children) && (
           <div
             className={cn(
-              "flex w-full flex-wrap items-center gap-3",
+              "flex w-full flex-wrap items-center gap-3 pt-1",
               align === "start" ? "justify-start" : "justify-center",
               maxWidthClass
             )}

--- a/src/components/ui/custom/empty-state/variants.ts
+++ b/src/components/ui/custom/empty-state/variants.ts
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority";
 
 export const emptyStateVariants = cva(
-  "flex w-full flex-col gap-6 rounded-2xl border border-dashed p-8 transition-colors duration-200",
+  "relative isolate flex w-full flex-col rounded-3xl transition-colors duration-200",
   {
     variants: {
       align: {
@@ -9,17 +9,17 @@ export const emptyStateVariants = cva(
         start: "items-start text-left",
       },
       size: {
-        sm: "p-6 gap-5",
-        md: "p-8 gap-6",
-        lg: "p-12 gap-8",
+        sm: "gap-5 px-6 py-8",
+        md: "gap-6 px-8 py-10",
+        lg: "gap-8 px-10 py-14",
       },
       tone: {
         neutral:
-          "border-gray-200/80 bg-white/70 text-gray-600 dark:border-zinc-800 dark:bg-zinc-900/40 dark:text-zinc-300",
+          "border border-gray-100/80 bg-gradient-to-b from-white/95 via-white/90 to-gray-50/80 text-gray-600 shadow-[0_24px_60px_-40px_rgba(15,23,42,0.45)] ring-1 ring-black/5 backdrop-blur-sm dark:border-zinc-800/70 dark:from-zinc-950/70 dark:via-zinc-950/60 dark:to-zinc-900/60 dark:text-zinc-300 dark:ring-white/10",
         muted:
-          "border-gray-200/50 bg-gray-50/80 text-gray-600 dark:border-zinc-800/70 dark:bg-zinc-900/30 dark:text-zinc-300",
+          "border border-gray-100/60 bg-gradient-to-b from-gray-50/95 via-white/90 to-gray-100/80 text-gray-600 shadow-[0_20px_55px_-45px_rgba(15,23,42,0.45)] ring-1 ring-black/5 backdrop-blur-sm dark:border-zinc-800/60 dark:from-zinc-950/70 dark:via-zinc-950/55 dark:to-zinc-900/55 dark:text-zinc-300 dark:ring-white/10",
         accent:
-          "border-[var(--primary-color)]/40 bg-[var(--primary-color)]/5 text-gray-600 dark:text-zinc-200",
+          "border border-[var(--primary-color)]/30 bg-gradient-to-b from-[var(--primary-color)]/15 via-[var(--primary-color)]/10 to-white/70 text-gray-700 shadow-[0_22px_60px_-45px_rgba(67,56,202,0.45)] ring-1 ring-[var(--primary-color)]/20 backdrop-blur-sm dark:text-zinc-100",
       },
       fullHeight: {
         true: "min-h-[320px] justify-center",

--- a/src/theme/dashboard/components/admin/lista-empresas/CompanyDashboard.tsx
+++ b/src/theme/dashboard/components/admin/lista-empresas/CompanyDashboard.tsx
@@ -554,7 +554,8 @@ export function CompanyDashboard({
             tone="muted"
             fullHeight
             maxContentWidth="sm"
-            illustration="userProfiles"
+            illustration="fileNotFound"
+            illustrationAlt="Ilustração de arquivo não encontrado"
             title="Nenhuma empresa encontrada"
             description="Revise os filtros aplicados ou cadastre uma nova empresa para começar a acompanhar os resultados."
             actions={


### PR DESCRIPTION
## Summary
- refresh the generic EmptyState layout with softer gradients, shadows, and improved spacing to match the new mock
- enhance illustration presentation with radial glow treatment for better focus and readability
- align the admin company list empty state with the shared file-not-found artwork and accessibility alt text

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ccb696fb508332a788ea613c1308dd