### PR TITLE
fix: improve company dashboard responsiveness

### DIFF
--- a/src/components/ui/custom/filters/FilterBar.tsx
+++ b/src/components/ui/custom/filters/FilterBar.tsx
@@ -51,11 +51,13 @@ export function FilterBar({
   return (
     <div
       className={cn(
-        "rounded-xl border border-gray-200 bg-white p-4 md:p-5 space-y-3",
+        "rounded-xl border border-gray-200 bg-white p-4 md:p-5 space-y-4",
         className
       )}
     >
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,3fr)_minmax(0,1fr)_minmax(0,1fr)_auto] md:gap-3 md:items-end">
+      <div
+        className="grid grid-cols-1 gap-3 md:grid-cols-2 md:gap-4 xl:grid-cols-[minmax(0,3fr)_minmax(0,1.2fr)_minmax(0,1.2fr)_auto] xl:items-end xl:gap-5"
+      >
         {search && (
           <div className="min-w-0">
             <div className="relative">
@@ -117,13 +119,17 @@ export function FilterBar({
             </div>
           );
         })}
-        <div className="flex items-center gap-3 justify-end">
-          {rightActions}
-        </div>
+        {rightActions && (
+          <div
+            className="flex w-full flex-col items-stretch gap-3 md:col-span-2 md:flex-row md:justify-start xl:col-span-1 xl:flex-col xl:items-end xl:justify-end"
+          >
+            {rightActions}
+          </div>
+        )}
       </div>
 
       {activeChips.length > 0 && (
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex flex-wrap items-center gap-2">
             {activeChips.map((chip) => (
               <span

--- a/src/theme/dashboard/components/admin/lista-empresas/CompanyDashboard.tsx
+++ b/src/theme/dashboard/components/admin/lista-empresas/CompanyDashboard.tsx
@@ -440,8 +440,14 @@ export function CompanyDashboard({
   return (
     <div className={cn("min-h-full", className)}>
       {/* Top action bar */}
-      <div className="flex items-center justify-end mb-2">
-        <ButtonCustom variant="primary" size="md" icon="Plus">
+      <div className="mb-4 flex flex-col items-stretch gap-3 sm:mb-2 sm:flex-row sm:items-center sm:justify-end">
+        <ButtonCustom
+          variant="primary"
+          size="md"
+          icon="Plus"
+          fullWidth
+          className="sm:w-auto"
+        >
           Criar empresa
         </ButtonCustom>
       </div>
@@ -503,6 +509,8 @@ export function CompanyDashboard({
                     runFetch(1);
                   }}
                   disabled={isLoadingData}
+                  fullWidth
+                  className="md:w-full xl:w-auto"
                 >
                   Pesquisar
                 </ButtonCustom>


### PR DESCRIPTION
## Summary
- adjust the company dashboard action bar so primary actions adapt to smaller screens
- update the shared filter bar grid to better wrap fields and right actions on compact viewports
- allow the search action to grow full width when stacked to avoid clipping on notebooks

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ceebac3ab48332ad149f404925f33f