### PR TITLE
Fix layout spacing for companies dashboard

### DIFF
--- a/src/app/dashboard/empresas/page.tsx
+++ b/src/app/dashboard/empresas/page.tsx
@@ -1,9 +1,10 @@
+import { PageWrapper } from "@/components/layout/PageWrapper";
 import { CompanyDashboard } from "@/theme/dashboard/components/admin";
 
 export default function AdminCompaniesListPage() {
   return (
-    <div className="space-y-8">
+    <PageWrapper className="space-y-8 pb-12" maxWidth="xl">
       <CompanyDashboard />
-    </div>
+    </PageWrapper>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the companies dashboard page with PageWrapper to enforce the standard max-width container and padding

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ceefe0fdcc8332be56ea52e47299a6