### PR TITLE
feat: add password recovery modal and refine register page

### DIFF
--- a/src/api/brevo/index.ts
+++ b/src/api/brevo/index.ts
@@ -1,0 +1,112 @@
+import { apiFetch } from "@/api/client";
+import { brevoRoutes } from "@/api/routes";
+import { apiConfig } from "@/lib/env";
+
+import type {
+  BrevoResendVerificationPayload,
+  BrevoResendVerificationResponse,
+  BrevoStatusResponse,
+  BrevoVerificationResponse,
+} from "./types";
+
+const ACCEPT_HEADER = { Accept: apiConfig.headers.Accept } as const;
+const JSON_HEADERS = {
+  ...ACCEPT_HEADER,
+  "Content-Type": apiConfig.headers["Content-Type"],
+} as const;
+
+export async function verifyEmail(
+  token: string,
+): Promise<BrevoVerificationResponse> {
+  return apiFetch<BrevoVerificationResponse>(
+    brevoRoutes.verification.verifyEmail(token),
+    {
+      init: {
+        method: "GET",
+        headers: ACCEPT_HEADER,
+      },
+      cache: "no-cache",
+      skipLogoutOn401: true,
+    },
+  );
+}
+
+export async function verifyEmailAlias(
+  token: string,
+): Promise<BrevoVerificationResponse> {
+  return apiFetch<BrevoVerificationResponse>(
+    brevoRoutes.verification.alias.verifyEmail(token),
+    {
+      init: {
+        method: "GET",
+        headers: ACCEPT_HEADER,
+      },
+      cache: "no-cache",
+      skipLogoutOn401: true,
+    },
+  );
+}
+
+export async function resendVerificationEmail(
+  payload: BrevoResendVerificationPayload,
+): Promise<BrevoResendVerificationResponse> {
+  return apiFetch<BrevoResendVerificationResponse>(
+    brevoRoutes.verification.resendVerification(),
+    {
+      init: {
+        method: "POST",
+        headers: JSON_HEADERS,
+        body: JSON.stringify(payload),
+      },
+      cache: "no-cache",
+      skipLogoutOn401: true,
+    },
+  );
+}
+
+export async function resendVerificationEmailAlias(
+  payload: BrevoResendVerificationPayload,
+): Promise<BrevoResendVerificationResponse> {
+  return apiFetch<BrevoResendVerificationResponse>(
+    brevoRoutes.verification.alias.resendVerification(),
+    {
+      init: {
+        method: "POST",
+        headers: JSON_HEADERS,
+        body: JSON.stringify(payload),
+      },
+      cache: "no-cache",
+      skipLogoutOn401: true,
+    },
+  );
+}
+
+export async function getVerificationStatusByUserId(
+  userId: string,
+): Promise<BrevoStatusResponse> {
+  return apiFetch<BrevoStatusResponse>(
+    brevoRoutes.verification.statusByUserId(userId),
+    {
+      init: {
+        method: "GET",
+        headers: ACCEPT_HEADER,
+      },
+      cache: "no-cache",
+    },
+  );
+}
+
+export async function getVerificationStatusByEmail(
+  email: string,
+): Promise<BrevoStatusResponse> {
+  return apiFetch<BrevoStatusResponse>(
+    brevoRoutes.verification.statusByEmail(email),
+    {
+      init: {
+        method: "GET",
+        headers: ACCEPT_HEADER,
+      },
+      cache: "no-cache",
+    },
+  );
+}

--- a/src/api/brevo/types.ts
+++ b/src/api/brevo/types.ts
@@ -1,0 +1,57 @@
+export interface BrevoSuccessResponse {
+  success: true;
+  message: string;
+}
+
+export interface BrevoErrorResponse {
+  success: false;
+  message: string;
+  code?: string;
+  error?: string;
+}
+
+export interface BrevoVerificationSuccess extends BrevoSuccessResponse {
+  redirectUrl: string;
+  userId: string;
+}
+
+export type BrevoVerificationResponse =
+  | BrevoVerificationSuccess
+  | BrevoErrorResponse;
+
+export interface BrevoResendVerificationSuccess extends BrevoSuccessResponse {
+  simulated: boolean;
+  messageId: string;
+}
+
+export type BrevoResendVerificationResponse =
+  | BrevoResendVerificationSuccess
+  | BrevoErrorResponse;
+
+export interface BrevoResendVerificationPayload {
+  email: string;
+}
+
+export interface BrevoVerificationStatus {
+  userId: string;
+  email: string;
+  emailVerified: boolean;
+  accountStatus: string;
+  hasValidToken: boolean;
+  tokenExpiration: string | null;
+  emailVerification: {
+    verified: boolean;
+    verifiedAt: string | null;
+    tokenExpiration: string | null;
+    attempts: number;
+    lastAttemptAt: string | null;
+  };
+}
+
+export interface BrevoStatusSuccessResponse extends BrevoSuccessResponse {
+  data: BrevoVerificationStatus;
+}
+
+export type BrevoStatusResponse =
+  | BrevoStatusSuccessResponse
+  | BrevoErrorResponse;

--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -201,25 +201,77 @@ export const empresasRoutes = {
 };
 
 /**
+ * Endpoints for Brevo email verification flows.
+ * Centraliza aliases e variações utilizadas no front.
+ */
+export const brevoRoutes = {
+  base: () => `${prefix}/brevo`,
+  verification: {
+    /**
+     * GET /api/v1/brevo/verificar-email?token=...
+     */
+    verifyEmail: (token: string) =>
+      `${prefix}/brevo/verificar-email?token=${encodeURIComponent(token)}`,
+    /**
+     * POST /api/v1/brevo/reenviar-verificacao
+     */
+    resendVerification: () => `${prefix}/brevo/reenviar-verificacao`,
+    /**
+     * GET /api/v1/brevo/status-verificacao/{userId}
+     */
+    statusByUserId: (userId: string) =>
+      `${prefix}/brevo/status-verificacao/${encodeURIComponent(userId)}`,
+    /**
+     * GET /api/v1/brevo/status/{email}
+     */
+    statusByEmail: (email: string) =>
+      `${prefix}/brevo/status/${encodeURIComponent(email)}`,
+    alias: {
+      /**
+       * GET /api/v1/brevo/verificar?token=...
+       */
+      verifyEmail: (token: string) =>
+        `${prefix}/brevo/verificar?token=${encodeURIComponent(token)}`,
+      /**
+       * POST /api/v1/brevo/reenviar
+       */
+      resendVerification: () => `${prefix}/brevo/reenviar`,
+    },
+  },
+};
+
+/**
  * Endpoints for user-related operations (usuarios).
  * Mirrors the backend users module and groups auth, profile
  * and password recovery helpers in one place.
  */
+const usuarioBase = () => `${prefix}/usuarios`;
+const usuarioRegister = () => `${prefix}/usuarios/registrar`;
+const usuarioLogin = () => `${prefix}/usuarios/login`;
+const usuarioLogout = () => `${prefix}/usuarios/logout`;
+const usuarioRefresh = () => `${prefix}/usuarios/refresh`;
+
 export const usuarioRoutes = {
   /**
    * Retorna o endpoint raiz do módulo de usuários.
    * Deve ser usado para recuperar as informações gerais do serviço
    * (GET /api/v1/usuarios).
    */
-  base: () => `${prefix}/usuarios`,
+  base: usuarioBase,
   /**
    * Alias semântico para o endpoint de informações do módulo.
    */
-  info: () => `${prefix}/usuarios`,
-  register: () => `${prefix}/usuarios/registrar`,
-  login: () => `${prefix}/usuarios/login`,
-  logout: () => `${prefix}/usuarios/logout`,
-  refresh: () => `${prefix}/usuarios/refresh`,
+  info: usuarioBase,
+  register: usuarioRegister,
+  login: usuarioLogin,
+  logout: usuarioLogout,
+  refresh: usuarioRefresh,
+  auth: {
+    register: usuarioRegister,
+    login: usuarioLogin,
+    logout: usuarioLogout,
+    refresh: usuarioRefresh,
+  },
   profile: {
     get: () => `${prefix}/usuarios/perfil`,
     update: () => `${prefix}/usuarios/perfil`,
@@ -231,11 +283,10 @@ export const usuarioRoutes = {
     reset: () => `${prefix}/usuarios/recuperar-senha/redefinir`,
   },
   verification: {
-    verify: (token: string) =>
-      `${prefix}/brevo/verificar-email?token=${encodeURIComponent(token)}`,
-    resend: () => `${prefix}/brevo/reenviar-verificacao`,
-    status: (userId: string) =>
-      `${prefix}/brevo/status-verificacao/${encodeURIComponent(userId)}`,
+    verify: brevoRoutes.verification.verifyEmail,
+    resend: brevoRoutes.verification.resendVerification,
+    status: brevoRoutes.verification.statusByUserId,
+    alias: brevoRoutes.verification.alias,
   },
 };
 
@@ -245,10 +296,6 @@ export const usuarioRoutes = {
  */
 export const mercadoPagoRoutes = {
   base: () => `${prefix}/mercadopago`,
-};
-
-export const brevoRoutes = {
-  base: () => `${prefix}/brevo`,
 };
 
 /**

--- a/src/api/usuarios/index.ts
+++ b/src/api/usuarios/index.ts
@@ -1,31 +1,165 @@
 import { apiFetch } from "@/api/client";
-import { apiConfig } from "@/lib/env";
 import { usuarioRoutes } from "@/api/routes";
+import { apiConfig } from "@/lib/env";
 
-function getAuthHeader(): Record<string, string> {
-  if (typeof document === "undefined") return {};
+import type {
+  UsuarioLoginPayload,
+  UsuarioLoginResponse,
+  UsuarioLogoutResponse,
+  UsuarioPasswordRecoveryRequestPayload,
+  UsuarioPasswordRecoveryResponse,
+  UsuarioPasswordRecoveryValidationResponse,
+  UsuarioPasswordResetPayload,
+  UsuarioPasswordResetResponse,
+  UsuarioProfileResponse,
+  UsuarioRefreshPayload,
+  UsuarioRefreshResponse,
+  UsuarioRegisterPayload,
+  UsuarioRegisterResponse,
+} from "./types";
 
-  const token = document.cookie
+const ACCEPT_HEADER = { Accept: apiConfig.headers.Accept } as const;
+const JSON_HEADERS = {
+  ...ACCEPT_HEADER,
+  "Content-Type": apiConfig.headers["Content-Type"],
+} as const;
+
+function readBrowserToken(): string | undefined {
+  if (typeof document === "undefined") return undefined;
+
+  return document.cookie
     .split("; ")
     .find((row) => row.startsWith("token="))
     ?.split("=")[1];
-
-  return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
-export async function requestUserPasswordReset(
-  email: string,
-): Promise<void> {
-  await apiFetch<void>(usuarioRoutes.recovery.request(), {
+function buildAuthHeaders(token?: string): Record<string, string> {
+  const resolvedToken = token ?? readBrowserToken();
+
+  if (!resolvedToken) {
+    return { ...ACCEPT_HEADER };
+  }
+
+  return {
+    ...ACCEPT_HEADER,
+    Authorization: `Bearer ${resolvedToken}`,
+  };
+}
+
+export async function requestPasswordRecovery(
+  payload: UsuarioPasswordRecoveryRequestPayload,
+): Promise<UsuarioPasswordRecoveryResponse> {
+  return apiFetch<UsuarioPasswordRecoveryResponse>(
+    usuarioRoutes.recovery.request(),
+    {
+      init: {
+        method: "POST",
+        headers: JSON_HEADERS,
+        body: JSON.stringify(payload),
+      },
+      cache: "no-cache",
+      skipLogoutOn401: true,
+    },
+  );
+}
+
+export async function validatePasswordRecoveryToken(
+  token: string,
+): Promise<UsuarioPasswordRecoveryValidationResponse> {
+  return apiFetch<UsuarioPasswordRecoveryValidationResponse>(
+    usuarioRoutes.recovery.validate(token),
+    {
+      init: {
+        method: "GET",
+        headers: ACCEPT_HEADER,
+      },
+      cache: "no-cache",
+      skipLogoutOn401: true,
+    },
+  );
+}
+
+export async function resetPasswordWithToken(
+  payload: UsuarioPasswordResetPayload,
+): Promise<UsuarioPasswordResetResponse> {
+  return apiFetch<UsuarioPasswordResetResponse>(
+    usuarioRoutes.recovery.reset(),
+    {
+      init: {
+        method: "POST",
+        headers: JSON_HEADERS,
+        body: JSON.stringify(payload),
+      },
+      cache: "no-cache",
+      skipLogoutOn401: true,
+    },
+  );
+}
+
+export async function registerUser(
+  payload: UsuarioRegisterPayload,
+): Promise<UsuarioRegisterResponse> {
+  return apiFetch<UsuarioRegisterResponse>(usuarioRoutes.register(), {
     init: {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: apiConfig.headers.Accept,
-        ...getAuthHeader(),
-      },
-      body: JSON.stringify({ email }),
+      headers: JSON_HEADERS,
+      body: JSON.stringify(payload),
+    },
+    cache: "no-cache",
+    skipLogoutOn401: true,
+  });
+}
+
+export async function loginUser(
+  payload: UsuarioLoginPayload,
+): Promise<UsuarioLoginResponse> {
+  return apiFetch<UsuarioLoginResponse>(usuarioRoutes.login(), {
+    init: {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(payload),
+    },
+    cache: "no-cache",
+    retries: 1,
+    skipLogoutOn401: true,
+  });
+}
+
+export async function refreshUserToken(
+  payload: UsuarioRefreshPayload,
+): Promise<UsuarioRefreshResponse> {
+  return apiFetch<UsuarioRefreshResponse>(usuarioRoutes.refresh(), {
+    init: {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(payload),
     },
     cache: "no-cache",
   });
 }
+
+export async function logoutUserSession(
+  token?: string,
+): Promise<UsuarioLogoutResponse> {
+  return apiFetch<UsuarioLogoutResponse>(usuarioRoutes.logout(), {
+    init: {
+      method: "POST",
+      headers: buildAuthHeaders(token),
+    },
+    cache: "no-cache",
+  });
+}
+
+export async function getUserProfile(
+  token?: string,
+): Promise<UsuarioProfileResponse> {
+  return apiFetch<UsuarioProfileResponse>(usuarioRoutes.profile.get(), {
+    init: {
+      method: "GET",
+      headers: buildAuthHeaders(token),
+    },
+    cache: "no-cache",
+  });
+}
+
+export * from "./types";

--- a/src/api/usuarios/types.ts
+++ b/src/api/usuarios/types.ts
@@ -1,0 +1,112 @@
+export interface UsuarioResponseBase {
+  success?: boolean;
+  message?: string;
+  code?: string;
+}
+
+export interface UsuarioPasswordRecoveryRequestPayload {
+  identificador?: string;
+  email?: string;
+  cpf?: string;
+  cnpj?: string;
+}
+
+export type UsuarioPasswordRecoveryResponse = UsuarioResponseBase;
+
+export type UsuarioPasswordRecoveryValidationResponse = UsuarioResponseBase;
+
+export interface UsuarioPasswordResetPayload {
+  token: string;
+  novaSenha: string;
+}
+
+export type UsuarioPasswordResetResponse = UsuarioResponseBase;
+
+export interface UsuarioRegisterPayload {
+  nomeCompleto: string;
+  documento: string;
+  telefone: string;
+  email: string;
+  senha: string;
+  confirmarSenha: string;
+  aceitarTermos: boolean;
+  supabaseId?: string;
+  tipoUsuario: "PESSOA_FISICA" | "PESSOA_JURIDICA" | string;
+}
+
+export interface UsuarioRegisterResponse extends UsuarioResponseBase {
+  usuario?: {
+    id: string;
+    email: string;
+    nomeCompleto: string;
+  };
+}
+
+export interface UsuarioLoginPayload {
+  documento: string;
+  senha: string;
+  rememberMe?: boolean;
+}
+
+export interface UsuarioSessionInfo {
+  id: string;
+  rememberMe: boolean;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export interface UsuarioLoginResponse extends UsuarioResponseBase {
+  token: string;
+  refreshToken: string;
+  tokenType?: string;
+  expiresIn?: string;
+  rememberMe?: boolean;
+  refreshTokenExpiresIn?: string;
+  refreshTokenExpiresAt?: string;
+  session?: UsuarioSessionInfo;
+  correlationId?: string;
+  timestamp?: string;
+}
+
+export interface UsuarioRefreshPayload {
+  refreshToken?: string;
+}
+
+export interface UsuarioRefreshResponse extends UsuarioResponseBase {
+  token: string;
+  refreshToken: string;
+  rememberMe?: boolean;
+  refreshTokenExpiresAt?: string;
+  session?: UsuarioSessionInfo;
+  correlationId?: string;
+  timestamp?: string;
+}
+
+export interface UsuarioLogoutResponse extends UsuarioResponseBase {
+  correlationId?: string;
+  timestamp?: string;
+}
+
+export interface UsuarioEmailVerificationState {
+  verified: boolean;
+  verifiedAt: string | null;
+  tokenExpiration: string | null;
+  attempts: number;
+  lastAttemptAt: string | null;
+}
+
+export interface UsuarioProfileResponse {
+  id: string;
+  email: string;
+  nomeCompleto: string;
+  role?: string;
+  roles?: string[];
+  tipoUsuario?: string;
+  supabaseId?: string;
+  emailVerificado?: boolean;
+  emailVerificadoEm?: string | null;
+  emailVerification?: UsuarioEmailVerificationState;
+  ultimoLogin?: string | null;
+  imagemPerfil?: string | null;
+  plano?: string | null;
+}

--- a/src/components/partials/auth/login/password-recovery-modal.tsx
+++ b/src/components/partials/auth/login/password-recovery-modal.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+
+import {
+  ButtonCustom,
+  InputCustom,
+  ModalBody,
+  ModalContentWrapper,
+  ModalCustom,
+  ModalDescription,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+  toastCustom,
+} from "@/components/ui/custom";
+import { requestPasswordRecovery } from "@/api/usuarios";
+import type { UsuarioPasswordRecoveryRequestPayload } from "@/api/usuarios";
+import { MaskService } from "@/services";
+
+interface PasswordRecoveryModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+type RecoveryMode = "email" | "document";
+
+const animationVariants = {
+  initial: { opacity: 0, y: 8 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: -6 },
+};
+
+export function PasswordRecoveryModal({ open, onOpenChange }: PasswordRecoveryModalProps) {
+  const maskService = useMemo(() => MaskService.getInstance(), []);
+  const [mode, setMode] = useState<RecoveryMode>("email");
+  const [identifier, setIdentifier] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setIdentifier("");
+      setMode("email");
+      setError(null);
+      setIsSubmitting(false);
+    }
+  }, [open]);
+
+  const isEmailMode = mode === "email";
+
+  const validateIdentifier = (value: string): boolean => {
+    if (!value) {
+      setError("Informe um valor para continuar.");
+      return false;
+    }
+
+    if (isEmailMode) {
+      if (!maskService.validate(value, "email")) {
+        setError("Digite um e-mail válido.");
+        return false;
+      }
+      return true;
+    }
+
+    const maskedValue = maskService.processInput(value, "cpfCnpj");
+    const isValid = maskService.validate(maskedValue, "cpfCnpj");
+
+    if (!isValid) {
+      setError("Informe um CPF ou CNPJ válido.");
+      return false;
+    }
+
+    return true;
+  };
+
+  const buildPayload = (value: string): UsuarioPasswordRecoveryRequestPayload => {
+    if (isEmailMode) {
+      const normalized = value.trim().toLowerCase();
+      return {
+        identificador: normalized,
+        email: normalized,
+      };
+    }
+
+    const digits = maskService.removeMask(value, "cpfCnpj");
+    if (digits.length === 11) {
+      return {
+        identificador: digits,
+        cpf: digits,
+      };
+    }
+
+    return {
+      identificador: digits,
+      cnpj: digits,
+    };
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    const trimmed = identifier.trim();
+
+    if (!validateIdentifier(trimmed)) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await requestPasswordRecovery(buildPayload(trimmed));
+      toastCustom.success("Se existir uma conta, enviaremos as instruções por e-mail.");
+      onOpenChange(false);
+    } catch (err) {
+      console.error("Erro ao solicitar recuperação de senha:", err);
+      const status = (err as { status?: number }).status;
+      if (status === 404) {
+        setError("Não encontramos uma conta com esses dados. Verifique e tente novamente.");
+      } else if (status === 429) {
+        setError("Muitas tentativas. Aguarde alguns instantes para tentar novamente.");
+      } else {
+        setError("Ocorreu um erro ao enviar a solicitação. Tente novamente mais tarde.");
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleModeToggle = () => {
+    setMode((prev) => (prev === "email" ? "document" : "email"));
+    setIdentifier("");
+    setError(null);
+  };
+
+  const description = isEmailMode
+    ? "Informe seu e-mail cadastrado para receber o link de redefinição."
+    : "Informe o CPF ou CNPJ associado à conta para receber suporte por e-mail.";
+
+  return (
+    <ModalCustom isOpen={open} onOpenChange={onOpenChange}>
+      <ModalContentWrapper className="sm:max-w-md" placement="center">
+        <form onSubmit={handleSubmit} noValidate>
+          <ModalHeader>
+            <ModalTitle>Recuperar acesso</ModalTitle>
+            <ModalDescription>{description}</ModalDescription>
+          </ModalHeader>
+
+          <ModalBody className="space-y-4">
+            <AnimatePresence mode="wait">
+              {isEmailMode ? (
+                <motion.div
+                  key="email"
+                  {...animationVariants}
+                  transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
+                >
+                  <InputCustom
+                    label="E-mail"
+                    type="email"
+                    mask="email"
+                    placeholder="seuemail@email.com"
+                    value={identifier}
+                    onChange={(event) => setIdentifier(event.target.value)}
+                    required
+                    autoFocus
+                  />
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    Enviaremos instruções para o endereço informado.
+                  </p>
+                </motion.div>
+              ) : (
+                <motion.div
+                  key="document"
+                  {...animationVariants}
+                  transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
+                >
+                  <InputCustom
+                    label="CPF ou CNPJ"
+                    mask="cpfCnpj"
+                    placeholder="000.000.000-00"
+                    value={identifier}
+                    onChange={(event) => setIdentifier(event.target.value)}
+                    required
+                    autoFocus
+                  />
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    Usaremos o documento para localizar sua conta.
+                  </p>
+                </motion.div>
+              )}
+            </AnimatePresence>
+
+            <button
+              type="button"
+              onClick={handleModeToggle}
+              className="text-left text-sm font-medium text-[var(--primary-color)] hover:underline focus:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--primary-color)]"
+            >
+              {isEmailMode
+                ? "Esqueci meu e-mail. Tentar por CPF ou CNPJ"
+                : "Voltar e tentar com meu e-mail"}
+            </button>
+
+            {error && (
+              <p className="text-sm text-destructive" role="alert" aria-live="assertive">
+                {error}
+              </p>
+            )}
+          </ModalBody>
+
+          <ModalFooter>
+            <ButtonCustom
+              type="button"
+              variant="ghost"
+              onClick={() => onOpenChange(false)}
+              className="sm:w-auto"
+            >
+              Cancelar
+            </ButtonCustom>
+            <ButtonCustom
+              type="submit"
+              variant="primary"
+              isLoading={isSubmitting}
+              disabled={isSubmitting || !identifier.trim()}
+              className="sm:w-auto"
+            >
+              Enviar instruções
+            </ButtonCustom>
+          </ModalFooter>
+        </form>
+      </ModalContentWrapper>
+    </ModalCustom>
+  );
+}
+
+export default PasswordRecoveryModal;

--- a/src/theme/dashboard/components/admin/company-details/modal-acoes/ResetarSenhaModal.tsx
+++ b/src/theme/dashboard/components/admin/company-details/modal-acoes/ResetarSenhaModal.tsx
@@ -13,7 +13,7 @@ import {
 import { InputCustom } from "@/components/ui/custom/input";
 import { ButtonCustom } from "@/components/ui/custom/button";
 import { toastCustom } from "@/components/ui/custom/toast";
-import { requestUserPasswordReset } from "@/api/usuarios";
+import { requestPasswordRecovery } from "@/api/usuarios";
 
 interface ResetarSenhaModalProps {
   isOpen: boolean;
@@ -52,7 +52,7 @@ export function ResetarSenhaModal({
     setIsSubmitting(true);
 
     try {
-      await requestUserPasswordReset(email);
+      await requestPasswordRecovery({ email });
 
       toastCustom.success({
         title: "Solicitação enviada",


### PR DESCRIPTION
## Summary
- refine the register screen to rely on the typed usuarios client, normalise payload values and guard local storage restores and validation
- add an animated password recovery modal that accepts email or CPF/CNPJ and calls the new recovery endpoint with helpful messaging
- hook the login page reset link to open the modal, keeping the existing UX while integrating the recovery flow

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d1c2d1c7248332b0c9694f245a34f0