### PR TITLE
fix: prevent select dirty check type error

### DIFF
--- a/src/components/ui/custom/modal/ModalCustom.tsx
+++ b/src/components/ui/custom/modal/ModalCustom.tsx
@@ -414,7 +414,10 @@ export function ModalContent({
           markAsDirty();
         }
       } else if (target instanceof HTMLSelectElement) {
-        if (target.value !== target.defaultValue) {
+        const hasSelectionChanged = Array.from(target.options).some(
+          (option) => option.selected !== option.defaultSelected
+        );
+        if (hasSelectionChanged) {
           markAsDirty();
         }
       }


### PR DESCRIPTION
## Summary
- avoid referencing non-existent defaultValue on HTMLSelectElement when tracking dirty state
- compute selection changes by comparing options' selected vs defaultSelected flags before marking dirty

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d2122731f0833296195ba9c4f870f8