### PR TITLE
fix: handle default value check for select elements

### DIFF
--- a/src/components/ui/custom/modal/ModalCustom.tsx
+++ b/src/components/ui/custom/modal/ModalCustom.tsx
@@ -568,7 +568,11 @@ export function ModalContentWrapper({
           markAsDirty();
         }
       } else if (target instanceof HTMLSelectElement) {
-        if (target.value !== target.defaultValue) {
+        const defaultOption = Array.from(target.options).find(
+          (option) => option.defaultSelected
+        );
+        const defaultValue = defaultOption?.value ?? target.options[0]?.value;
+        if (defaultValue !== undefined && target.value !== defaultValue) {
           markAsDirty();
         }
       }


### PR DESCRIPTION
## Summary
- derive the default option value for select elements when checking modal dirty state

## Testing
- CI=1 pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2138d33d48332a191b18ece8669e5