### PR TITLE
feat: add terms modal to register page

### DIFF
--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -9,6 +9,8 @@ import {
   toastCustom,
   OfflineModal,
 } from "@/components/ui/custom";
+import TermsOfUseModal from "@/components/partials/auth/register/terms-of-use-modal";
+import PrivacyPolicyModal from "@/components/partials/auth/register/privacy-policy-modal";
 import { GraduationCap, User, Building } from "lucide-react";
 import { registerUser } from "@/api/usuarios";
 import type { UsuarioRegisterPayload } from "@/api/usuarios";
@@ -43,6 +45,8 @@ const RegisterPage = () => {
     () => createInitialFormData(),
   );
   const [passwordError, setPasswordError] = useState("");
+  const [isTermsModalOpen, setIsTermsModalOpen] = useState(false);
+  const [isPrivacyModalOpen, setIsPrivacyModalOpen] = useState(false);
 
   useEffect(() => {
     const savedForm = localStorage.getItem("registerFormData");
@@ -383,23 +387,29 @@ const RegisterPage = () => {
             className="sm:text-sm text-gray-600 leading-5 cursor-pointer"
           >
             Li e aceito os{" "}
-            <a
-              href="http://advancemais.com/termos-uso"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-600 hover:underline font-medium cursor-pointer"
+            <button
+              type="button"
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                setIsTermsModalOpen(true);
+              }}
+              className="text-blue-600 hover:underline font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white rounded"
             >
               Termos de Uso
-            </a>
+            </button>
             , a{" "}
-            <a
-              href="http://advancemais.com/politica-privacidade"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-600 hover:underline font-medium cursor-pointer"
+            <button
+              type="button"
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                setIsPrivacyModalOpen(true);
+              }}
+              className="text-blue-600 hover:underline font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white rounded"
             >
               Política de Privacidade
-            </a>{" "}
+            </button>{" "}
             e autorizo o uso das minhas informações conforme descrito.
           </Label>
         </div>
@@ -581,6 +591,14 @@ const RegisterPage = () => {
         </div>
       </footer>
 
+      <TermsOfUseModal
+        isOpen={isTermsModalOpen}
+        onOpenChange={setIsTermsModalOpen}
+      />
+      <PrivacyPolicyModal
+        isOpen={isPrivacyModalOpen}
+        onOpenChange={setIsPrivacyModalOpen}
+      />
       <OfflineModal />
     </div>
   );

--- a/src/components/partials/auth/register/privacy-policy-modal.tsx
+++ b/src/components/partials/auth/register/privacy-policy-modal.tsx
@@ -1,0 +1,256 @@
+import type { ReactNode } from "react";
+import {
+  ModalBody,
+  ModalContentWrapper,
+  ModalCustom,
+  ModalDescription,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+} from "@/components/ui/custom/modal";
+import { ButtonCustom } from "@/components/ui/custom";
+
+export type PrivacyPolicyModalProps = {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+const sections: Array<{
+  title: string;
+  content: ReactNode[];
+}> = [
+  {
+    title: "1. Quais dados coletamos",
+    content: [
+      "1.1 Conta e cadastro (obrigatórios para uso de serviços): nome/razão social, CPF/CNPJ, data de nascimento, e-mail, telefones, endereço, senha (hash), papel na plataforma (Empresa, Candidato, Aluno, Professor, Psicologia/Pedagógico).",
+      "Advance+",
+      "1.2 Dados acadêmicos e de cursos (Alunos/Professores): turmas, presença, notas/avaliações, certificados, interações em fóruns e suporte.",
+      "1.3 Recrutamento e seleção (Candidatos/Empresas): currículo, experiências, formações, dados de candidatura, mensagens e agendamentos de entrevistas.",
+      "1.4 Faturamento e contratação (quando aplicável): plano/assinatura, meios de pagamento (tokens/identificadores do provedor), notas fiscais e dados de cobrança (limitados ao necessário).",
+      "1.5 Suporte e comunicação: tickets, gravação de interações textuais, preferências e consentimentos.",
+      "1.6 Dados técnicos e cookies: IP, data/hora, dispositivo, navegador, páginas acessadas, identificadores de sessão, cookies essenciais/funcionais/analíticos/publicidade, conforme banner de Preferências de Cookies.",
+      "Advance+",
+      "+1",
+      "1.7 Dados sensíveis (tratamento restrito): informações de saúde/avaliação psicológica/pedagógica eventualmente necessárias à prestação de serviços por profissionais habilitados somente com base legal adequada (ex.: consentimento específico e informado) e controles reforçados.",
+      "Planalto",
+    ],
+  },
+  {
+    title: "2. Para que usamos seus dados (finalidades e bases legais da LGPD)",
+    content: [
+      "2.1 Execução de contrato e procedimentos preliminares:",
+      "• criar e manter sua conta; matricular em cursos; emitir certificados; permitir candidaturas e contato Empresa↔Candidato; operacionalizar assinaturas/planos. (Base: execução de contrato/ procedimento preliminar).",
+      "Planalto",
+      "2.2 Cumprimento de obrigação legal/regulatória:",
+      "• emissão fiscal; guarda de registros de acesso (Marco Civil); respostas a autoridades. (Base: obrigação legal).",
+      "Planalto",
+      "2.3 Interesses legítimos (sempre com ponderação e opt-out quando cabível):",
+      "• segurança antifraude e prevenção a incidentes; melhoria de usabilidade; métricas de navegação e desempenho; comunicação operacional. (Base: legítimo interesse).",
+      "Planalto",
+      "2.4 Consentimento:",
+      "• envio de comunicações de marketing; uso de cookies não essenciais; tratamento de dados sensíveis vinculados a serviços de psicologia/pedagógico quando exigido; participação em pesquisas. Consentimentos podem ser revogados a qualquer tempo nos canais indicados. (Base: consentimento).",
+      "Serviços e Informações do Brasil",
+      "+1",
+      "2.5 Proteção do crédito e exercício regular de direitos:",
+      "• tratamento mínimo para cobrança, defesa em processos e cumprimento de contratos. (Bases: proteção do crédito; exercício regular de direitos).",
+      "Planalto",
+    ],
+  },
+  {
+    title: "3. Cookies, identificadores e analytics",
+    content: [
+      "3.1 Usamos cookies e tecnologias similares para funcionamento da conta, segurança, estatísticas e personalização. Você pode gerenciar preferências pelo nosso link de Preferências de Cookies no rodapé.",
+      "Advance+",
+      "3.2 Seguimos as boas práticas da ANPD para transparência, granularidade de consentimento e evidências de opt-in/opt-out.",
+      "Serviços e Informações do Brasil",
+      "+1",
+    ],
+  },
+  {
+    title: "4. Com quem compartilhamos dados",
+    content: [
+      "4.1 Operadores e parceiros: provedores de nuvem/infra, e-mail/entrega de mensagens, antifraude, analytics, emissão fiscal e meios de pagamento — exclusivamente para cumprir as finalidades informadas.",
+      "4.2 Empresas e Candidatos: dados de candidatura/currículo são compartilhados quando você se aplica a uma vaga ou interage com a Empresa.",
+      "4.3 Autoridades públicas: mediante requisição legal, ordem judicial ou para resguardar direitos da ADVANCE+ e de terceiros, nos termos da lei.",
+      "4.4 Transferências internacionais: podem ocorrer quando nossos provedores estiverem fora do Brasil; adotamos salvaguardas contratuais e técnicas previstas na LGPD (arts. 33–36).",
+      "Planalto",
+    ],
+  },
+  {
+    title: "5. Segurança da informação",
+    content: [
+      "Aplicamos medidas técnicas e administrativas proporcionais ao risco: criptografia em trânsito, controles de acesso por perfil, registro de eventos, backups e testes periódicos. Nenhuma plataforma é 100% imune; por isso, também orientamos o uso de senhas fortes e autenticação adicional sempre que disponível.",
+    ],
+  },
+  {
+    title: "6. Retenção e descarte",
+    content: [
+      "6.1 Conta e histórico: mantidos enquanto a conta estiver ativa e/ou necessários para as finalidades informadas.",
+      "6.2 Registros de acesso a aplicações (Marco Civil): mantidos por no mínimo 6 meses.",
+      "Planalto",
+      "6.3 Faturamento/contábil: guardados pelos prazos legais aplicáveis.",
+      "6.4 Processos seletivos: dados de candidaturas podem ser retidos por período compatível ao ciclo de recrutamento e obrigações legais (ou até revogação do consentimento, quando aplicável).",
+      "6.5 Dados sensíveis: conservados apenas pelo tempo estritamente necessário e com controles reforçados.",
+    ],
+  },
+  {
+    title: "7. Direitos do titular",
+    content: [
+      "Você pode solicitar, a qualquer momento: confirmação do tratamento, acesso, correção, anonimização, portabilidade, informação sobre compartilhamentos, revogação de consentimento e eliminação nos termos da LGPD.",
+      (
+        <>
+          Para exercer seus direitos, contate o Encarregado (DPO) no e-mail
+          indicado abaixo ou utilize as páginas de{" "}
+          <a
+            href="https://advancemais.com/ouvidoria"
+            target="_blank"
+            rel="noreferrer"
+            className="text-primary underline-offset-4 hover:underline"
+          >
+            Ouvidoria
+          </a>{" "}e{" "}
+          <a
+            href="https://advancemais.com/faq"
+            target="_blank"
+            rel="noreferrer"
+            className="text-primary underline-offset-4 hover:underline"
+          >
+            FAQ
+          </a>
+          .
+        </>
+      ),
+      "Planalto",
+    ],
+  },
+  {
+    title: "8. Crianças e adolescentes",
+    content: [
+      "A Plataforma é voltada ao público geral e recomendada para maiores de 18 anos. Serviços educacionais para menores (quando oferecidos) exigem consentimento do responsável e observância ao ECA e à LGPD.",
+      "Planalto",
+    ],
+  },
+  {
+    title: "9. Links de terceiros",
+    content: [
+      "Podemos conter links para sites externos. Não nos responsabilizamos por suas práticas de privacidade. Recomendamos ler as respectivas políticas antes de fornecer dados.",
+    ],
+  },
+  {
+    title: "10. Atualizações desta Política",
+    content: [
+      "Podemos alterar esta Política para refletir mudanças legais ou operacionais. Publicaremos a versão vigente nesta página e, quando mudanças relevantes ocorrerem, poderemos notificar Usuários cadastrados pelos canais informados.",
+    ],
+  },
+  {
+    title: "11. Como falar com a ADVANCE+ sobre dados pessoais",
+    content: [
+      "Encarregado (DPO): [Nome do DPO]",
+      "E-mail do DPO: [email@advancemais.com]",
+      (
+        <>
+          Ouvidoria/FAQ:{" "}
+          <a
+            href="https://advancemais.com/ouvidoria"
+            target="_blank"
+            rel="noreferrer"
+            className="text-primary underline-offset-4 hover:underline"
+          >
+            advancemais.com/ouvidoria
+          </a>{" "}·{" "}
+          <a
+            href="https://advancemais.com/faq"
+            target="_blank"
+            rel="noreferrer"
+            className="text-primary underline-offset-4 hover:underline"
+          >
+            advancemais.com/faq
+          </a>
+        </>
+      ),
+      "Telefones: (82) 3234-1397 | (82) 98882-5559",
+      "Endereço: Av. Juca Sampaio, 2247 – sala 30, Condomínio Shopping Miramar, Feitosa, CEP 57.042-530, Maceió/AL.",
+      "Advance+",
+    ],
+  },
+  {
+    title: "Nota jurídica",
+    content: [
+      "Este documento atende às diretrizes da LGPD e boas práticas da ANPD (Cookies/Encarregado), além de considerar obrigações do Marco Civil para registros de acesso e transparência; pode conviver com obrigações do CDC/Decreto 7.962/2013 quando houver relação de consumo on-line. Recomenda-se revisão por assessoria jurídica para adequação final.",
+    ],
+  },
+];
+
+const PrivacyPolicyModal = ({
+  isOpen,
+  onOpenChange,
+}: PrivacyPolicyModalProps) => {
+  return (
+    <ModalCustom
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      size="lg"
+      backdrop="blur"
+      scrollBehavior="inside"
+    >
+      <ModalContentWrapper className="max-h-[90dvh]">
+        <ModalHeader>
+          <ModalTitle>Política de Privacidade</ModalTitle>
+          <ModalDescription className="text-sm text-muted-foreground">
+            Vigência: 23/09/2025 · Última atualização: 23/09/2025
+          </ModalDescription>
+        </ModalHeader>
+
+        <ModalBody className="space-y-6 overflow-y-auto pr-2 text-sm leading-relaxed text-muted-foreground">
+          <div className="space-y-2">
+            <p>
+              Controladora/Operadora: ADVANCE+ CURSOS E TREINAMENTOS LTDA, CNPJ
+              25.089.257/0001-92 (base pública), com sede em Av. Juca Sampaio,
+              2247 – sala 30, Condomínio Shopping Miramar, Feitosa, CEP
+              57.042-530, Maceió/AL.
+            </p>
+            <p>
+              Canais oficiais: (82) 3234-1397 | (82) 98882-5559 | Atendimento
+              seg–sex 08h–20h, sáb 09h–13h.
+            </p>
+            <p>E-mail do Encarregado (DPO): contato@advancemais.com</p>
+            <p>
+              Esta Política explica como tratamos dados pessoais de Empresas,
+              Candidatos, Alunos, Professores, Profissionais de
+              Psicologia/Pedagógico e demais Usuários, conforme a LGPD. Ao usar
+              a Plataforma, você concorda com esta Política.
+            </p>
+          </div>
+
+          <div className="space-y-6">
+            {sections.map((section) => (
+              <section key={section.title} className="space-y-3">
+                <h3 className="font-semibold text-base text-foreground">
+                  {section.title}
+                </h3>
+                <div className="space-y-2">
+                  {section.content.map((paragraph, index) => (
+                    <p key={`${section.title}-${index}`}>{paragraph}</p>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        </ModalBody>
+
+        <ModalFooter className="justify-end">
+          <ButtonCustom
+            type="button"
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+            className="min-w-[120px]"
+          >
+            Fechar
+          </ButtonCustom>
+        </ModalFooter>
+      </ModalContentWrapper>
+    </ModalCustom>
+  );
+};
+
+export default PrivacyPolicyModal;

--- a/src/components/partials/auth/register/terms-of-use-modal.tsx
+++ b/src/components/partials/auth/register/terms-of-use-modal.tsx
@@ -1,0 +1,268 @@
+import {
+  ModalBody,
+  ModalContentWrapper,
+  ModalCustom,
+  ModalDescription,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+} from "@/components/ui/custom/modal";
+import { ButtonCustom } from "@/components/ui/custom";
+
+type TermsOfUseModalProps = {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+const sections: Array<{
+  title: string;
+  content: string[];
+}> = [
+  {
+    title: "Público e Definições",
+    content: [
+      "Empresa: pessoa jurídica que divulga vagas, contrata planos/assinaturas e usa serviços B2B.",
+      "Candidato(a): pessoa física que cadastra currículo e aplica a vagas.",
+      "Aluno(a): pessoa física matriculada em cursos/treinamentos.",
+      "Professor(a): instrutor(a) responsável por conteúdo/avaliações.",
+      "Profissional de Psicologia/Pedagógico: presta serviços de avaliação/orientação educacional/psicológica na Plataforma.",
+      "Usuário(a): qualquer pessoa que acesse ou use a Plataforma.",
+    ],
+  },
+  {
+    title: "Elegibilidade e Cadastro",
+    content: [
+      "2.1. Idade mínima: recomendado para maiores de 18 anos; menores só com consentimento do responsável e observância ao ECA quando aplicável.",
+      "2.2. Dados verídicos: você declara fornecer informações verdadeiras, completas e atualizadas.",
+      "2.3. Credenciais: mantenha login/senha sob sigilo; atividades feitas na sua conta são de sua responsabilidade.",
+      "2.4. Perfis e permissões: funcionalidades variam conforme o papel (Empresa, Candidato, Aluno, Professor, Psicologia/Pedagógico).",
+    ],
+  },
+  {
+    title: "Planos, Assinaturas e Pagamentos",
+    content: [
+      "3.1. Planos/benefícios: algumas funções exigem contratação paga; valores e condições são informados antes da compra.",
+      "3.2. Cobrança/tributos: podem incidir taxas do meio de pagamento e tributos aplicáveis; comprovantes ficam disponíveis ao contratante.",
+      "3.3. Renovação/Cancelamento: renovação pode ser automática (quando indicado). Cancelamentos seguem a política comercial e o CDC quando aplicável ao consumidor.",
+      "3.4. Arrependimento (E-commerce): contratações à distância podem ter direito de arrependimento conforme o CDC/Decreto do E-commerce (quando aplicável).",
+    ],
+  },
+  {
+    title: "Cursos, Certificados e Comunidade",
+    content: [
+      "4.1. Conteúdo educacional: pode incluir aulas gravadas/ao vivo, materiais, avaliações e fóruns; disponibilidade varia por curso/turma.",
+      "4.2. Certificados: condicionados a requisitos (carga horária, nota, presença, etc.) divulgados na página do curso.",
+      "4.3. Propriedade intelectual: materiais são protegidos; é vedada reprodução/distribuição não autorizada.",
+      "4.4. Conduta: proibidos plágio, vazamento de avaliações, assédio, burla de acessos ou qualquer ato ilícito.",
+    ],
+  },
+  {
+    title: "Vagas e Recrutamento (Empresas x Candidatos)",
+    content: [
+      "5.1. Publicação: Empresas devem ofertar vagas verdadeiras, lícitas e não discriminatórias.",
+      "5.2. Seleção: a Plataforma não garante contratações, idoneidade ou veracidade de dados de terceiros; decisões são da Empresa.",
+      "5.3. Currículos: o Candidato autoriza o compartilhamento de seus dados com as Empresas às quais se candidatar.",
+      "5.4. Comunicação: pode ocorrer pela Plataforma ou meios informados pela Empresa; use com respeito e proteja dados pessoais.",
+    ],
+  },
+  {
+    title: "Serviços de Psicologia/Pedagógicos",
+    content: [
+      "6.1. Âmbito: serviços de avaliação/orientação prestados por profissionais cadastrados; a relação é diretamente entre profissional e Usuário.",
+      "6.2. Limites: não substituem diagnósticos/terapias exigidos por lei; em urgência, procure serviços de saúde.",
+    ],
+  },
+  {
+    title: "Privacidade, LGPD e Cookies",
+    content: [
+      "7.1. Conformidade: tratamos dados pessoais conforme LGPD, Marco Civil da Internet e normas de consumo. Detalhes na Política de Privacidade.",
+      "7.2. Bases legais: execução de contrato (matrícula/inscrição), obrigação legal (fiscal/contábil), legítimo interesse (segurança/antifraude), consentimento quando exigido.",
+      "7.3. Direitos do titular: confirmação de tratamento, acesso, correção, portabilidade, anonimização, revogação de consentimento e eliminação (nos termos legais).",
+      "7.4. Registros de acesso: guardados pelo prazo legal mínimo (Marco Civil).",
+      "7.5. Cookies: usamos cookies para funcionalidade, analytics e personalização; preferências podem ser geridas no banner ou navegador.",
+      "7.6. Encarregado/DPO: [inserir nome do DPO] — [inserir e-mail LGPD]. Enquanto não divulgado, use Ouvidoria/FAQ e telefones oficiais.",
+      "Advance+",
+      "+1",
+    ],
+  },
+  {
+    title: "Conteúdos de Usuários e Moderação",
+    content: [
+      "8.1. Responsabilidade pelo que você publica (textos, imagens, vídeos, avaliações, mensagens).",
+      "8.2. Licença de uso (conteúdos públicos): licença não exclusiva e gratuita para hospedagem/exibição na Plataforma.",
+      "8.3. Remoção/Suspensão: conteúdos/contas podem ser removidos/suspensos em caso de violação destes Termos, leis ou direitos de terceiros.",
+    ],
+  },
+  {
+    title: "Propriedade Intelectual",
+    content: [
+      "9.1. Plataforma: marcas, logotipos, layouts, software e bases de dados são da Controladora ou licenciados.",
+      "9.2. Proibições: copiar, adaptar, decompilar, fazer engenharia reversa, explorar economicamente ou remover avisos de direitos é vedado.",
+      "9.3. Denúncias: reporte supostas violações para [inserir e-mail jurídico/suporte].",
+    ],
+  },
+  {
+    title: "Disponibilidade, Suporte e Atualizações",
+    content: [
+      "10.1. Disponibilidade: empregamos esforços razoáveis para manter a operação, sem garantia de ininterruptividade.",
+      "10.2. Suporte: via Ouvidoria/FAQ e telefones oficiais nos horários informados.",
+      "Advance+",
+      "10.3. Alterações: funcionalidades/planos/políticas podem mudar; quando exigido, comunicaremos.",
+    ],
+  },
+  {
+    title: "Uso Aceitável",
+    content: [
+      "É proibido: (a) violar leis; (b) acessar áreas/dados de terceiros; (c) interferir no funcionamento (injeção de código, scraping abusivo, DDoS); (d) usos comerciais não autorizados; (e) contas falsas; (f) compartilhar credenciais; (g) robôs/bots não autorizados; (h) burlar paywalls/assinaturas.",
+    ],
+  },
+  {
+    title: "Isenções e Limitações",
+    content: [
+      "12.1. Conteúdos de terceiros (vagas/currículos/avaliações) são de responsabilidade de quem os publicou.",
+      "12.2. Contratação e aprendizagem: não participamos de decisões de contratação, nem garantimos resultados acadêmicos/profissionais.",
+      "12.3. Riscos de internet: reconheça riscos (interrupções/ataques) e adote medidas razoáveis (senhas fortes, antivírus).",
+      "12.4. Limite de responsabilidade: até o valor pago à Plataforma nos 12 meses anteriores ao evento, na extensão permitida em lei (sem prejuízo de direitos do consumidor).",
+    ],
+  },
+  {
+    title: "Links Externos",
+    content: [
+      "Não nos responsabilizamos por conteúdos/políticas de sites de terceiros; leia os respectivos termos/políticas.",
+    ],
+  },
+  {
+    title: "Comunicações",
+    content: [
+      "Você autoriza comunicações operacionais, transacionais e de marketing (opt-out disponível) por e-mail, push, telefone, WhatsApp/SMS ou dentro da conta.",
+    ],
+  },
+  {
+    title: "Encerramento de Conta e Retenção",
+    content: [
+      "Você pode solicitar encerramento da conta; reteremos registros mínimos exigidos por lei (ex.: logs, fiscais), conforme LGPD/Marco Civil.",
+    ],
+  },
+  {
+    title: "E-commerce (quando houver venda à distância)",
+    content: [
+      "Exibiremos informações essenciais (identificação do fornecedor, características, preço total, despesas, condições de pagamento/prazo, atendimento) conforme CDC e Decreto 7.962/2013.",
+    ],
+  },
+  {
+    title: "Alterações destes Termos",
+    content: [
+      "Podemos alterar a qualquer momento; mudanças relevantes serão comunicadas na Plataforma. O uso após a vigência indica concordância.",
+    ],
+  },
+  {
+    title: "Lei e Foro",
+    content: [
+      "Regidos pelas leis da República Federativa do Brasil (incluindo LGPD, Marco Civil e CDC, quando aplicáveis). Foro eleito: Comarca de Maceió/AL, salvo disposição legal específica.",
+    ],
+  },
+  {
+    title: "Contato",
+    content: [
+      "Ouvidoria/FAQ e suporte: via páginas da Plataforma. Telefones: (82) 3234-1397 | (82) 98882-5559.",
+      "Endereço físico: Av. Juca Sampaio, 2247 – sala 30, Condomínio Shopping Miramar, Feitosa, CEP 57.042-530, Maceió/AL.",
+      "E-mail: [inserir e-mail oficial].",
+      "Advance+",
+    ],
+  },
+];
+
+const TermsOfUseModal = ({ isOpen, onOpenChange }: TermsOfUseModalProps) => {
+  return (
+    <ModalCustom
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      size="lg"
+      backdrop="blur"
+      scrollBehavior="inside"
+    >
+      <ModalContentWrapper className="max-h-[90dvh]">
+        <ModalHeader>
+          <ModalTitle>Termos de Uso</ModalTitle>
+          <ModalDescription className="text-sm text-muted-foreground">
+            Vigência: 23/09/2025 · Última atualização: 23/09/2025
+          </ModalDescription>
+        </ModalHeader>
+
+        <ModalBody className="space-y-6 overflow-y-auto pr-2 text-sm leading-relaxed text-muted-foreground">
+          <div className="space-y-2">
+            <p>
+              Controladora/Operadora: ADVANCE+ CURSOS E TREINAMENTOS LTDA – ME, CNPJ 25.089.257/0001-92, com sede em Av. Juca Sampaio, 2247 – sala 30, Condomínio Shopping
+              Miramar, Feitosa, CEP 57.042-530, Maceió/AL.
+            </p>
+            <p>
+              Canais de atendimento: (82) 3234-1397 | (82) 98882-5559 | Horário comercial: seg–sex 08h–20h, sáb 09h–13h.
+            </p>
+            <p>E-mail de suporte: contato@advancemais.com</p>
+            <p>
+              Canal de Ouvidoria/FAQ: via páginas “Ouvidoria” e “FAQ” na Plataforma. Veja em{" "}
+              <a
+                href="https://advancemais.com/ouvidoria"
+                target="_blank"
+                rel="noreferrer noopener"
+                className="font-medium text-primary underline-offset-4 hover:underline"
+              >
+                advancemais.com/ouvidoria
+              </a>{" "}
+              e{" "}
+              <a
+                href="https://advancemais.com/faq"
+                target="_blank"
+                rel="noreferrer noopener"
+                className="font-medium text-primary underline-offset-4 hover:underline"
+              >
+                advancemais.com/faq
+              </a>
+              .
+            </p>
+            <p>
+              Ao acessar ou usar a Plataforma, você concorda com estes Termos e com a nossa Política de Privacidade (LGPD). Se não concordar, não utilize a Plataforma.
+              Poderemos atualizar este documento; a versão vigente estará sempre nesta página.
+            </p>
+          </div>
+
+          <div className="space-y-6">
+            {sections.map((section, index) => (
+              <section key={section.title} className="space-y-3">
+                <h3 className="text-base font-semibold text-foreground">
+                  {index + 1}) {section.title}
+                </h3>
+                <div className="space-y-2">
+                  {section.content.map((paragraph, contentIndex) => (
+                    <p key={`${section.title}-${contentIndex}`}>{paragraph}</p>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+
+          <section className="space-y-2">
+            <h3 className="text-base font-semibold text-foreground">Aviso</h3>
+            <p>
+              Este documento reflete legislação brasileira vigente e boas práticas, mas não substitui assessoria jurídica. Recomenda-se revisão por advogado(a) para adequação às
+              particularidades do seu negócio.
+            </p>
+          </section>
+        </ModalBody>
+
+        <ModalFooter className="justify-end">
+          <ButtonCustom
+            type="button"
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+            className="min-w-[120px]"
+          >
+            Fechar
+          </ButtonCustom>
+        </ModalFooter>
+      </ModalContentWrapper>
+    </ModalCustom>
+  );
+};
+
+export default TermsOfUseModal;


### PR DESCRIPTION
## Summary
- atualiza o texto do termo de consentimento no cadastro e aciona modais dedicadas
- adiciona modal de Termos de Uso com conteúdo completo e links de Ouvidoria/FAQ
- inclui modal de Política de Privacidade com todo o conteúdo solicitado e links para Ouvidoria/FAQ

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d2135a20148332897f453b7c0739d4