### PR TITLE
fix(auth): align password reset payload with API validation

### DIFF
--- a/src/api/usuarios/types.ts
+++ b/src/api/usuarios/types.ts
@@ -18,6 +18,7 @@ export type UsuarioPasswordRecoveryValidationResponse = UsuarioResponseBase;
 export interface UsuarioPasswordResetPayload {
   token: string;
   novaSenha: string;
+  confirmarSenha: string;
 }
 
 export type UsuarioPasswordResetResponse = UsuarioResponseBase;

--- a/src/app/auth/recuperar-senha/page.tsx
+++ b/src/app/auth/recuperar-senha/page.tsx
@@ -136,6 +136,7 @@ export default function PasswordResetPage() {
       await resetPasswordWithToken({
         token: tokenParam,
         novaSenha: password,
+        confirmarSenha: confirmPassword,
       });
       setPageState("success");
       toastCustom.success(


### PR DESCRIPTION
## Summary
- include the password confirmation field when submitting the reset form so the API accepts the payload
- update the UsuarioPasswordResetPayload contract to require confirmarSenha, keeping the front aligned with backend validation

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d2b7f86ad08332bba9c28e67629b84