### PR TITLE
feat: inject published scripts into layouts

### DIFF
--- a/src/api/dashboard/scripts/index.ts
+++ b/src/api/dashboard/scripts/index.ts
@@ -1,0 +1,94 @@
+import { apiFetch } from "@/api/client";
+import { dashboardRoutes } from "@/api/routes";
+import { apiConfig } from "@/lib/env";
+import type {
+  ScriptResponse,
+  CreateScriptPayload,
+  UpdateScriptPayload,
+  ScriptListParams,
+} from "@/api/scripts/types";
+
+function getAuthHeader(): Record<string, string> {
+  if (typeof document === "undefined") return {};
+  const token = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith("token="))
+    ?.split("=")[1];
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+function buildQuery(params?: ScriptListParams): string {
+  if (!params) return "";
+  const query = new URLSearchParams();
+  if (params.aplicacao) query.set("aplicacao", params.aplicacao);
+  if (params.orientacao) query.set("orientacao", params.orientacao);
+  if (params.status) query.set("status", params.status);
+  const str = query.toString();
+  return str ? `?${str}` : "";
+}
+
+export async function listDashboardScripts(
+  params?: ScriptListParams,
+  init?: RequestInit,
+): Promise<ScriptResponse[]> {
+  const query = buildQuery(params);
+  return apiFetch<ScriptResponse[]>(`${dashboardRoutes.scripts.list()}${query}`, {
+    init: init ?? { headers: apiConfig.headers },
+    cache: "no-cache",
+  });
+}
+
+export async function getDashboardScriptById(id: string): Promise<ScriptResponse> {
+  return apiFetch<ScriptResponse>(dashboardRoutes.scripts.get(id), {
+    init: { headers: apiConfig.headers },
+    cache: "no-cache",
+  });
+}
+
+export async function createDashboardScript(
+  payload: CreateScriptPayload,
+): Promise<ScriptResponse> {
+  return apiFetch<ScriptResponse>(dashboardRoutes.scripts.create(), {
+    init: {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: apiConfig.headers.Accept,
+        ...getAuthHeader(),
+      },
+      body: JSON.stringify(payload),
+    },
+    cache: "no-cache",
+  });
+}
+
+export async function updateDashboardScript(
+  id: string,
+  payload: UpdateScriptPayload,
+): Promise<ScriptResponse> {
+  return apiFetch<ScriptResponse>(dashboardRoutes.scripts.update(id), {
+    init: {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: apiConfig.headers.Accept,
+        ...getAuthHeader(),
+      },
+      body: JSON.stringify(payload),
+    },
+    cache: "no-cache",
+  });
+}
+
+export async function deleteDashboardScript(id: string): Promise<void> {
+  await apiFetch<void>(dashboardRoutes.scripts.delete(id), {
+    init: {
+      method: "DELETE",
+      headers: {
+        Accept: apiConfig.headers.Accept,
+        ...getAuthHeader(),
+      },
+    },
+    cache: "no-cache",
+  });
+}

--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -166,6 +166,13 @@ export const websiteRoutes = {
     update: (id: string) => `${prefix}/website/informacoes-gerais/${id}`,
     delete: (id: string) => `${prefix}/website/informacoes-gerais/${id}`,
   },
+  scripts: {
+    list: () => `${prefix}/website/scripts`,
+    create: () => `${prefix}/website/scripts`,
+    get: (id: string) => `${prefix}/website/scripts/${id}`,
+    update: (id: string) => `${prefix}/website/scripts/${id}`,
+    delete: (id: string) => `${prefix}/website/scripts/${id}`,
+  },
 };
 
 /**
@@ -197,6 +204,16 @@ export const empresasRoutes = {
       aprovar: (id: string, vagaId: string) =>
         `${prefix}/empresas/admin/${id}/vagas/${vagaId}/aprovar`,
     },
+  },
+};
+
+export const dashboardRoutes = {
+  scripts: {
+    list: () => `${prefix}/dashboard/scripts`,
+    create: () => `${prefix}/dashboard/scripts`,
+    get: (id: string) => `${prefix}/dashboard/scripts/${id}`,
+    update: (id: string) => `${prefix}/dashboard/scripts/${id}`,
+    delete: (id: string) => `${prefix}/dashboard/scripts/${id}`,
   },
 };
 

--- a/src/api/scripts/types.ts
+++ b/src/api/scripts/types.ts
@@ -1,0 +1,34 @@
+export type ScriptApplication = "WEBSITE" | "DASHBOARD";
+
+export type ScriptOrientation = "HEADER" | "BODY" | "FOOTER";
+
+export type ScriptStatus = "PUBLICADO" | "RASCUNHO";
+
+export interface ScriptResponse {
+  id: string;
+  nome: string;
+  descricao?: string | null;
+  codigo: string;
+  aplicacao: ScriptApplication;
+  orientacao: ScriptOrientation;
+  status: ScriptStatus | boolean;
+  criadoEm?: string;
+  atualizadoEm?: string;
+}
+
+export interface ScriptListParams {
+  aplicacao?: ScriptApplication;
+  orientacao?: ScriptOrientation;
+  status?: ScriptStatus;
+}
+
+export interface CreateScriptPayload {
+  nome: string;
+  descricao?: string | null;
+  codigo: string;
+  aplicacao: ScriptApplication;
+  orientacao: ScriptOrientation;
+  status: ScriptStatus;
+}
+
+export type UpdateScriptPayload = Partial<CreateScriptPayload>;

--- a/src/api/websites/components/index.ts
+++ b/src/api/websites/components/index.ts
@@ -166,6 +166,13 @@ export {
   updateLoginImage,
   deleteLoginImage,
 } from "./imagem-login";
+export {
+  listWebsiteScripts,
+  getWebsiteScriptById,
+  createWebsiteScript,
+  updateWebsiteScript,
+  deleteWebsiteScript,
+} from "./scripts";
 
 export type {
   AboutApiResponse,

--- a/src/api/websites/components/scripts/index.ts
+++ b/src/api/websites/components/scripts/index.ts
@@ -1,0 +1,94 @@
+import { apiFetch } from "@/api/client";
+import { websiteRoutes } from "@/api/routes";
+import { apiConfig } from "@/lib/env";
+import type {
+  ScriptResponse,
+  CreateScriptPayload,
+  UpdateScriptPayload,
+  ScriptListParams,
+} from "@/api/scripts/types";
+
+function getAuthHeader(): Record<string, string> {
+  if (typeof document === "undefined") return {};
+  const token = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith("token="))
+    ?.split("=")[1];
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+function buildQuery(params?: ScriptListParams): string {
+  if (!params) return "";
+  const query = new URLSearchParams();
+  if (params.aplicacao) query.set("aplicacao", params.aplicacao);
+  if (params.orientacao) query.set("orientacao", params.orientacao);
+  if (params.status) query.set("status", params.status);
+  const str = query.toString();
+  return str ? `?${str}` : "";
+}
+
+export async function listWebsiteScripts(
+  params?: ScriptListParams,
+  init?: RequestInit,
+): Promise<ScriptResponse[]> {
+  const query = buildQuery(params);
+  return apiFetch<ScriptResponse[]>(`${websiteRoutes.scripts.list()}${query}`, {
+    init: init ?? { headers: apiConfig.headers },
+    cache: "no-cache",
+  });
+}
+
+export async function getWebsiteScriptById(id: string): Promise<ScriptResponse> {
+  return apiFetch<ScriptResponse>(websiteRoutes.scripts.get(id), {
+    init: { headers: apiConfig.headers },
+    cache: "no-cache",
+  });
+}
+
+export async function createWebsiteScript(
+  payload: CreateScriptPayload,
+): Promise<ScriptResponse> {
+  return apiFetch<ScriptResponse>(websiteRoutes.scripts.create(), {
+    init: {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: apiConfig.headers.Accept,
+        ...getAuthHeader(),
+      },
+      body: JSON.stringify(payload),
+    },
+    cache: "no-cache",
+  });
+}
+
+export async function updateWebsiteScript(
+  id: string,
+  payload: UpdateScriptPayload,
+): Promise<ScriptResponse> {
+  return apiFetch<ScriptResponse>(websiteRoutes.scripts.update(id), {
+    init: {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: apiConfig.headers.Accept,
+        ...getAuthHeader(),
+      },
+      body: JSON.stringify(payload),
+    },
+    cache: "no-cache",
+  });
+}
+
+export async function deleteWebsiteScript(id: string): Promise<void> {
+  await apiFetch<void>(websiteRoutes.scripts.delete(id), {
+    init: {
+      method: "DELETE",
+      headers: {
+        Accept: apiConfig.headers.Accept,
+        ...getAuthHeader(),
+      },
+    },
+    cache: "no-cache",
+  });
+}

--- a/src/app/dashboard/config/dashboard/geral/page.tsx
+++ b/src/app/dashboard/config/dashboard/geral/page.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { VerticalTabs, type VerticalTabItem } from "@/components/ui/custom";
 import LoginForm from "./login/LoginForm";
+import DashboardScriptsForm from "./scripts/ScriptsForm";
 
 export default function GeralDashboardPage() {
   const items: VerticalTabItem[] = [
@@ -11,6 +12,12 @@ export default function GeralDashboardPage() {
       label: "Login",
       icon: "LogIn",
       content: <LoginForm />,
+    },
+    {
+      value: "scripts",
+      label: "Scripts",
+      icon: "Code2",
+      content: <DashboardScriptsForm />,
     },
   ];
 

--- a/src/app/dashboard/config/dashboard/geral/scripts/ScriptsForm.tsx
+++ b/src/app/dashboard/config/dashboard/geral/scripts/ScriptsForm.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useEffect, useState, useCallback, useMemo } from "react";
+
+import { SliderManager, type Slider } from "@/components/ui/custom";
+import type { SliderFieldOption } from "@/components/ui/custom/slider-manager/types";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toastCustom } from "@/components/ui/custom/toast";
+import { Badge } from "@/components/ui/badge";
+
+import {
+  listDashboardScripts,
+  createDashboardScript,
+  updateDashboardScript,
+  deleteDashboardScript,
+} from "@/api/dashboard/scripts";
+import type {
+  ScriptResponse,
+  UpdateScriptPayload,
+} from "@/api/scripts/types";
+
+const ORIENTATION_OPTIONS: SliderFieldOption[] = [
+  { label: "Cabeçalho (HEAD)", value: "HEADER" },
+  { label: "Corpo (BODY)", value: "BODY" },
+  { label: "Rodapé (FOOTER)", value: "FOOTER" },
+] as const;
+
+const ORIENTATION_LABEL: Record<string, string> = ORIENTATION_OPTIONS.reduce(
+  (acc, option) => {
+    acc[option.value] = option.label;
+    return acc;
+  },
+  {} as Record<string, string>,
+);
+
+const statusToBackend = (status: boolean): "PUBLICADO" | "RASCUNHO" =>
+  status ? "PUBLICADO" : "RASCUNHO";
+
+function normalizeStatus(status: ScriptResponse["status"]): boolean {
+  if (typeof status === "string") {
+    return status.toUpperCase() === "PUBLICADO";
+  }
+  return Boolean(status);
+}
+
+function mapFromBackend(item: ScriptResponse, index: number): Slider {
+  return {
+    id: item.id,
+    title: item.nome,
+    image: "",
+    url: item.orientacao,
+    content: item.codigo,
+    status: normalizeStatus(item.status),
+    position: index + 1,
+    createdAt: item.criadoEm ?? new Date().toISOString(),
+    updatedAt: item.atualizadoEm,
+    meta: {
+      descricao: item.descricao ?? "",
+      orientacao: item.orientacao,
+    },
+  };
+}
+
+export default function DashboardScriptsForm() {
+  const [loading, setLoading] = useState(true);
+  const [initialScripts, setInitialScripts] = useState<Slider[]>([]);
+
+  const orientationOptions = useMemo(
+    () => ORIENTATION_OPTIONS.map((option) => ({ ...option })),
+    [],
+  );
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      setLoading(true);
+      try {
+        const data = await listDashboardScripts(
+          { aplicacao: "DASHBOARD" },
+          { headers: { Accept: "application/json" } },
+        );
+        const mapped = (data || []).map(mapFromBackend);
+        if (mounted) setInitialScripts(mapped);
+      } catch (error) {
+        console.error(error);
+        toastCustom.error("Não foi possível carregar os scripts do dashboard");
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const handleCreate = useCallback(
+    async (data: Omit<Slider, "id" | "createdAt">): Promise<Slider> => {
+      const created = await createDashboardScript({
+        nome: data.title,
+        descricao:
+          typeof data.meta?.descricao === "string"
+            ? data.meta.descricao
+            : undefined,
+        codigo: data.content,
+        aplicacao: "DASHBOARD",
+        orientacao: (data.url || "HEADER") as ScriptResponse["orientacao"],
+        status: statusToBackend(data.status),
+      });
+      const mapped = mapFromBackend(created, initialScripts.length);
+      setInitialScripts((prev) => [...prev, mapped]);
+      return mapped;
+    },
+    [initialScripts.length],
+  );
+
+  const handleUpdate = useCallback(
+    async (id: string, updates: Partial<Slider>): Promise<Slider> => {
+      if (
+        updates.status !== undefined &&
+        updates.title === undefined &&
+        updates.content === undefined &&
+        updates.url === undefined
+      ) {
+        const updated = await updateDashboardScript(id, {
+          status: statusToBackend(!!updates.status),
+        });
+        const index = initialScripts.findIndex((s) => s.id === id);
+        const mapped = mapFromBackend(updated, index === -1 ? 0 : index);
+        setInitialScripts((prev) => {
+          if (index === -1) return prev;
+          const next = [...prev];
+          next[index] = mapped;
+          return next;
+        });
+        return mapped;
+      }
+
+      const payload: UpdateScriptPayload = {
+        nome: updates.title,
+        descricao:
+          typeof updates.meta?.descricao === "string"
+            ? updates.meta.descricao
+            : undefined,
+        codigo: updates.content,
+        orientacao: updates.url as ScriptResponse["orientacao"] | undefined,
+        aplicacao: "DASHBOARD",
+        status:
+          updates.status === undefined
+            ? undefined
+            : statusToBackend(!!updates.status),
+      };
+
+      const updated = await updateDashboardScript(id, payload);
+      const index = initialScripts.findIndex((item) => item.id === id);
+      const mapped = mapFromBackend(updated, index === -1 ? 0 : index);
+      setInitialScripts((prev) => {
+        if (index === -1) return prev;
+        const next = [...prev];
+        next[index] = mapped;
+        return next;
+      });
+      return mapped;
+    },
+    [initialScripts],
+  );
+
+  const handleDelete = useCallback(async (id: string) => {
+    await deleteDashboardScript(id);
+    setInitialScripts((prev) => prev.filter((item) => item.id !== id));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-10 w-1/3" />
+        <Skeleton className="h-96 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <SliderManager
+      initialSliders={initialScripts}
+      entityName="Script"
+      entityNamePlural="Scripts"
+      firstFieldLabel="Nome do script"
+      secondFieldLabel="Orientação"
+      validateSecondFieldAsUrl={false}
+      secondFieldRequired
+      secondFieldType="select"
+      secondFieldOptions={orientationOptions}
+      showContentField
+      contentFieldLabel="Código"
+      contentFieldType="textarea"
+      contentFieldRequired
+      fieldsOrder={["title", "url", "content"]}
+      showImageField={false}
+      showImageColumn={false}
+      enableReorder={false}
+      showUrlPreview={false}
+      renderListItemDetails={(slider) => {
+        const orientation =
+          ORIENTATION_LABEL[String(slider.url)] || String(slider.url || "");
+        const codeSnippet = (slider.content || "").trim();
+        return (
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2 text-xs font-semibold text-foreground uppercase tracking-wide">
+              <span>Orientação:</span>
+              <Badge variant="outline" className="uppercase tracking-wide">
+                {orientation}
+              </Badge>
+            </div>
+            {codeSnippet && (
+              <pre className="max-h-32 overflow-auto rounded-lg bg-muted/60 p-3 text-xs text-muted-foreground">
+                {codeSnippet}
+              </pre>
+            )}
+          </div>
+        );
+      }}
+      onCreateSlider={handleCreate}
+      onUpdateSlider={handleUpdate}
+      onDeleteSlider={handleDelete}
+      onRefreshSliders={async () => {
+        const data = await listDashboardScripts(
+          { aplicacao: "DASHBOARD" },
+          { headers: { Accept: "application/json" } },
+        );
+        const mapped = (data || []).map(mapFromBackend);
+        setInitialScripts(mapped);
+        return mapped;
+      }}
+    />
+  );
+}

--- a/src/app/dashboard/config/website/geral/page.tsx
+++ b/src/app/dashboard/config/website/geral/page.tsx
@@ -11,6 +11,7 @@ import SocialsForm from "./socials/SocialsForm";
 import EnderecoForm from "./endereco/EnderecoForm";
 import ContatoForm from "./contato/ContatoForm";
 import AtendimentoForm from "./atendimento/AtendimentoForm";
+import ScriptsForm from "./scripts/ScriptsForm";
 
 export default function GeralPage() {
   const items: VerticalTabItem[] = [
@@ -49,6 +50,12 @@ export default function GeralPage() {
       label: "Logos",
       icon: "Image",
       content: <LogosForm />,
+    },
+    {
+      value: "scripts",
+      label: "Scripts",
+      icon: "Code2",
+      content: <ScriptsForm />,
     },
   ];
 

--- a/src/app/dashboard/config/website/geral/scripts/ScriptsForm.tsx
+++ b/src/app/dashboard/config/website/geral/scripts/ScriptsForm.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useEffect, useState, useCallback, useMemo } from "react";
+
+import { SliderManager, type Slider } from "@/components/ui/custom";
+import type { SliderFieldOption } from "@/components/ui/custom/slider-manager/types";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toastCustom } from "@/components/ui/custom/toast";
+import { Badge } from "@/components/ui/badge";
+
+import {
+  listWebsiteScripts,
+  createWebsiteScript,
+  updateWebsiteScript,
+  deleteWebsiteScript,
+} from "@/api/websites/components/scripts";
+import type {
+  ScriptResponse,
+  UpdateScriptPayload,
+} from "@/api/scripts/types";
+
+const ORIENTATION_OPTIONS: SliderFieldOption[] = [
+  { label: "Cabeçalho (HEAD)", value: "HEADER" },
+  { label: "Corpo (BODY)", value: "BODY" },
+  { label: "Rodapé (FOOTER)", value: "FOOTER" },
+] as const;
+
+const ORIENTATION_LABEL: Record<string, string> = ORIENTATION_OPTIONS.reduce(
+  (acc, option) => {
+    acc[option.value] = option.label;
+    return acc;
+  },
+  {} as Record<string, string>,
+);
+
+function normalizeStatus(status: ScriptResponse["status"]): boolean {
+  if (typeof status === "string") {
+    return status.toUpperCase() === "PUBLICADO";
+  }
+  return Boolean(status);
+}
+
+const statusToBackend = (status: boolean): "PUBLICADO" | "RASCUNHO" =>
+  status ? "PUBLICADO" : "RASCUNHO";
+
+function mapFromBackend(item: ScriptResponse, index: number): Slider {
+  return {
+    id: item.id,
+    title: item.nome,
+    image: "",
+    url: item.orientacao,
+    content: item.codigo,
+    status: normalizeStatus(item.status),
+    position: index + 1,
+    createdAt: item.criadoEm ?? new Date().toISOString(),
+    updatedAt: item.atualizadoEm,
+    meta: {
+      descricao: item.descricao ?? "",
+      orientacao: item.orientacao,
+    },
+  };
+}
+
+export default function ScriptsForm() {
+  const [loading, setLoading] = useState(true);
+  const [initialScripts, setInitialScripts] = useState<Slider[]>([]);
+
+  const orientationOptions = useMemo(
+    () => ORIENTATION_OPTIONS.map((option) => ({ ...option })),
+    [],
+  );
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      setLoading(true);
+      try {
+        const data = await listWebsiteScripts(
+          { aplicacao: "WEBSITE" },
+          { headers: { Accept: "application/json" } },
+        );
+        const mapped = (data || []).map(mapFromBackend);
+        if (mounted) setInitialScripts(mapped);
+      } catch (error) {
+        console.error(error);
+        toastCustom.error("Não foi possível carregar os scripts do website");
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const handleCreate = useCallback(
+    async (data: Omit<Slider, "id" | "createdAt">): Promise<Slider> => {
+      const created = await createWebsiteScript({
+        nome: data.title,
+        descricao:
+          typeof data.meta?.descricao === "string"
+            ? data.meta.descricao
+            : undefined,
+        codigo: data.content,
+        aplicacao: "WEBSITE",
+        orientacao: (data.url || "HEADER") as ScriptResponse["orientacao"],
+        status: statusToBackend(data.status),
+      });
+      const mapped = mapFromBackend(created, initialScripts.length);
+      setInitialScripts((prev) => [...prev, mapped]);
+      return mapped;
+    },
+    [initialScripts.length],
+  );
+
+  const handleUpdate = useCallback(
+    async (id: string, updates: Partial<Slider>): Promise<Slider> => {
+      // Toggle de status rápido
+      if (
+        updates.status !== undefined &&
+        updates.title === undefined &&
+        updates.content === undefined &&
+        updates.url === undefined
+      ) {
+        const updated = await updateWebsiteScript(id, {
+          status: statusToBackend(!!updates.status),
+        });
+        const index = initialScripts.findIndex((s) => s.id === id);
+        const mapped = mapFromBackend(updated, index === -1 ? 0 : index);
+        setInitialScripts((prev) => {
+          if (index === -1) return prev;
+          const next = [...prev];
+          next[index] = mapped;
+          return next;
+        });
+        return mapped;
+      }
+
+      const payload: UpdateScriptPayload = {
+        nome: updates.title,
+        descricao:
+          typeof updates.meta?.descricao === "string"
+            ? updates.meta.descricao
+            : undefined,
+        codigo: updates.content,
+        orientacao: updates.url as ScriptResponse["orientacao"] | undefined,
+        aplicacao: "WEBSITE",
+        status:
+          updates.status === undefined
+            ? undefined
+            : statusToBackend(!!updates.status),
+      };
+
+      const updated = await updateWebsiteScript(id, payload);
+      const index = initialScripts.findIndex((item) => item.id === id);
+      const mapped = mapFromBackend(updated, index === -1 ? 0 : index);
+      setInitialScripts((prev) => {
+        if (index === -1) return prev;
+        const next = [...prev];
+        next[index] = mapped;
+        return next;
+      });
+      return mapped;
+    },
+    [initialScripts],
+  );
+
+  const handleDelete = useCallback(async (id: string) => {
+    await deleteWebsiteScript(id);
+    setInitialScripts((prev) => prev.filter((item) => item.id !== id));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-10 w-1/3" />
+        <Skeleton className="h-96 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <SliderManager
+      initialSliders={initialScripts}
+      entityName="Script"
+      entityNamePlural="Scripts"
+      firstFieldLabel="Nome do script"
+      secondFieldLabel="Orientação"
+      validateSecondFieldAsUrl={false}
+      secondFieldRequired
+      secondFieldType="select"
+      secondFieldOptions={orientationOptions}
+      showContentField
+      contentFieldLabel="Código"
+      contentFieldType="textarea"
+      contentFieldRequired
+      fieldsOrder={["title", "url", "content"]}
+      showImageField={false}
+      showImageColumn={false}
+      enableReorder={false}
+      showUrlPreview={false}
+      renderListItemDetails={(slider) => {
+        const orientation =
+          ORIENTATION_LABEL[String(slider.url)] || String(slider.url || "");
+        const codeSnippet = (slider.content || "").trim();
+        return (
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2 text-xs font-semibold text-foreground uppercase tracking-wide">
+              <span>Orientação:</span>
+              <Badge variant="outline" className="uppercase tracking-wide">
+                {orientation}
+              </Badge>
+            </div>
+            {codeSnippet && (
+              <pre className="max-h-32 overflow-auto rounded-lg bg-muted/60 p-3 text-xs text-muted-foreground">
+                {codeSnippet}
+              </pre>
+            )}
+          </div>
+        );
+      }}
+      onCreateSlider={handleCreate}
+      onUpdateSlider={handleUpdate}
+      onDeleteSlider={handleDelete}
+      onRefreshSliders={async () => {
+        const data = await listWebsiteScripts(
+          { aplicacao: "WEBSITE" },
+          { headers: { Accept: "application/json" } },
+        );
+        const mapped = (data || []).map(mapFromBackend);
+        setInitialScripts(mapped);
+        return mapped;
+      }}
+    />
+  );
+}

--- a/src/app/dashboard/layout-client.tsx
+++ b/src/app/dashboard/layout-client.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { ReactNode, useEffect, useState } from "react";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { DashboardSidebar, DashboardHeader } from "@/theme";
+import { toastCustom, ToasterCustom } from "@/components/ui/custom/toast";
+import { DashboardHeader as Breadcrumb } from "@/components/layout";
+
+interface DashboardLayoutClientProps {
+  children: ReactNode;
+}
+
+/**
+ * Layout específico para a seção de Dashboard
+ */
+export default function DashboardLayoutClient({
+  children,
+}: DashboardLayoutClientProps) {
+  // Hook personalizado para detectar dispositivos móveis
+  const isMobileDevice = useIsMobile();
+
+  // Estados locais
+  const [mounted, setMounted] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const searchParams = useSearchParams();
+  const pathname = usePathname() || "";
+  const router = useRouter();
+
+  /**
+   * Alterna o estado de colapso do sidebar
+   */
+  function toggleSidebar() {
+    if (!isMobileDevice) {
+      setIsCollapsed(!isCollapsed);
+    } else {
+      setIsMobileMenuOpen(!isMobileMenuOpen);
+    }
+  }
+
+  // Efeito para manipulação do estado inicial e notificações
+  useEffect(() => {
+    setMounted(true);
+
+    if (searchParams && searchParams.get("denied")) {
+      toastCustom.error("Acesso negado");
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete("denied");
+      const query = params.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname, {
+        scroll: false,
+      });
+    }
+
+    // Reset collapsed state when switching to mobile
+    if (isMobileDevice && isCollapsed) {
+      setIsCollapsed(false);
+    }
+
+    // Adiciona classe ao body quando o menu está aberto em mobile
+    // para evitar scroll
+    if (isMobileMenuOpen && isMobileDevice) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [
+    isMobileDevice,
+    isCollapsed,
+    isMobileMenuOpen,
+    searchParams,
+    pathname,
+    router,
+  ]);
+
+  // Evita problemas de hidratação SSR
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="flex h-screen">
+        {/* Sidebar principal do dashboard */}
+        <DashboardSidebar
+          isMobileMenuOpen={isMobileMenuOpen}
+          setIsMobileMenuOpen={setIsMobileMenuOpen}
+          isCollapsed={isCollapsed}
+        />
+
+        {/* Container principal de conteúdo */}
+        <div className="flex flex-1 flex-col bg-white transition-all duration-300 ease-in-out">
+          {/* Header do Dashboard */}
+          <DashboardHeader
+            toggleSidebar={toggleSidebar}
+            isCollapsed={isCollapsed}
+          />
+
+          {/* Conteúdo principal */}
+          <main className="flex-1 overflow-auto bg-gray-100 p-10">
+            <div className="min-h-full">
+              <Breadcrumb showBreadcrumb={pathname !== "/empresas"} />
+              {children}
+            </div>
+          </main>
+        </div>
+      </div>
+      <ToasterCustom />
+    </>
+  );
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,114 +1,26 @@
-"use client";
+import type { ReactNode } from "react";
 
-import { ReactNode, useEffect, useState } from "react";
-import { useRouter, useSearchParams, usePathname } from "next/navigation";
-import { useIsMobile } from "@/hooks/use-mobile";
-import { DashboardSidebar, DashboardHeader } from "@/theme";
-import { toastCustom, ToasterCustom } from "@/components/ui/custom/toast";
-import { DashboardHeader as Breadcrumb } from "@/components/layout";
+import { listDashboardScripts } from "@/api/dashboard/scripts";
+import { ScriptInjector } from "@/components/scripts/script-injector";
+import { loadPublishedScripts } from "@/lib/scripts/load-published-scripts";
 
-interface DashboardLayoutProps {
-  children: ReactNode;
+import DashboardLayoutClient from "./layout-client";
+
+async function fetchDashboardScripts() {
+  return loadPublishedScripts(listDashboardScripts, "DASHBOARD");
 }
 
-/**
- * Layout específico para a seção de Dashboard
- */
-export default function DashboardLayout({ children }: DashboardLayoutProps) {
-  // Hook personalizado para detectar dispositivos móveis
-  const isMobileDevice = useIsMobile();
-
-  // Estados locais
-  const [mounted, setMounted] = useState(false);
-  const [isCollapsed, setIsCollapsed] = useState(false);
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-  const searchParams = useSearchParams();
-  const pathname = usePathname() || "";
-  const router = useRouter();
-
-  /**
-   * Alterna o estado de colapso do sidebar
-   */
-  function toggleSidebar() {
-    if (!isMobileDevice) {
-      setIsCollapsed(!isCollapsed);
-    } else {
-      setIsMobileMenuOpen(!isMobileMenuOpen);
-    }
-  }
-
-  // Efeito para manipulação do estado inicial e notificações
-  useEffect(() => {
-    setMounted(true);
-
-    if (searchParams && searchParams.get("denied")) {
-      toastCustom.error("Acesso negado");
-      const params = new URLSearchParams(searchParams.toString());
-      params.delete("denied");
-      const query = params.toString();
-      router.replace(query ? `${pathname}?${query}` : pathname, {
-        scroll: false,
-      });
-    }
-
-    // Reset collapsed state when switching to mobile
-    if (isMobileDevice && isCollapsed) {
-      setIsCollapsed(false);
-    }
-
-    // Adiciona classe ao body quando o menu está aberto em mobile
-    // para evitar scroll
-    if (isMobileMenuOpen && isMobileDevice) {
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = "";
-    }
-
-    return () => {
-      document.body.style.overflow = "";
-    };
-  }, [
-    isMobileDevice,
-    isCollapsed,
-    isMobileMenuOpen,
-    searchParams,
-    pathname,
-    router,
-  ]);
-
-  // Evita problemas de hidratação SSR
-  if (!mounted) {
-    return null;
-  }
+export default async function DashboardLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const scripts = await fetchDashboardScripts();
 
   return (
     <>
-      <div className="flex h-screen">
-        {/* Sidebar principal do dashboard */}
-        <DashboardSidebar
-          isMobileMenuOpen={isMobileMenuOpen}
-          setIsMobileMenuOpen={setIsMobileMenuOpen}
-          isCollapsed={isCollapsed}
-        />
-
-        {/* Container principal de conteúdo */}
-        <div className="flex flex-1 flex-col bg-white transition-all duration-300 ease-in-out">
-          {/* Header do Dashboard */}
-          <DashboardHeader
-            toggleSidebar={toggleSidebar}
-            isCollapsed={isCollapsed}
-          />
-
-          {/* Conteúdo principal */}
-          <main className="flex-1 overflow-auto bg-gray-100 p-10">
-            <div className="min-h-full">
-              <Breadcrumb showBreadcrumb={pathname !== "/empresas"} />
-              {children}
-            </div>
-          </main>
-        </div>
-      </div>
-      <ToasterCustom />
+      <ScriptInjector scripts={scripts} />
+      <DashboardLayoutClient>{children}</DashboardLayoutClient>
     </>
   );
 }

--- a/src/app/website/layout.tsx
+++ b/src/app/website/layout.tsx
@@ -1,5 +1,9 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { listWebsiteScripts } from "@/api/websites/components/scripts";
+import { ScriptInjector } from "@/components/scripts/script-injector";
+import { loadPublishedScripts } from "@/lib/scripts/load-published-scripts";
+
 import { LoadingProvider } from "./loading-context";
 import LayoutClient from "./layout-client";
 
@@ -54,13 +58,20 @@ export const metadata: Metadata = {
  * - Sem complexidade desnecessária
  * - Funciona de verdade
  */
-export default function WebsiteLayout({
+async function fetchWebsiteScripts() {
+  return loadPublishedScripts(listWebsiteScripts, "WEBSITE");
+}
+
+export default async function WebsiteLayout({
   children,
 }: Readonly<{
   children: ReactNode;
 }>) {
+  const scripts = await fetchWebsiteScripts();
+
   return (
     <LoadingProvider>
+      <ScriptInjector scripts={scripts} />
       <LayoutClient>{children}</LayoutClient>
     </LoadingProvider>
   );

--- a/src/components/scripts/script-injector.tsx
+++ b/src/components/scripts/script-injector.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+
+import type { PreparedScriptSnippet } from "@/lib/scripts/load-published-scripts";
+
+const ORIENTATION_TARGET: Record<PreparedScriptSnippet["orientation"], () => HTMLElement | null> = {
+  HEADER: () => (typeof document === "undefined" ? null : document.head),
+  BODY: () => (typeof document === "undefined" ? null : document.body),
+  FOOTER: () => (typeof document === "undefined" ? null : document.body),
+};
+
+interface ParsedScriptSnippet extends PreparedScriptSnippet {
+  signature: string;
+}
+
+function computeSignature(value: string): string {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(index);
+    hash |= 0;
+  }
+  return `${value.length}:${hash}`;
+}
+
+function parseScriptsPayload(
+  scripts: PreparedScriptSnippet[],
+): ParsedScriptSnippet[] {
+  return scripts.map((script) => ({
+    ...script,
+    signature: computeSignature(script.code),
+  }));
+}
+
+export function ScriptInjector({
+  scripts,
+}: {
+  scripts: PreparedScriptSnippet[];
+}): null {
+  const payload = useMemo(() => parseScriptsPayload(scripts), [scripts]);
+  const serialized = useMemo(() => JSON.stringify(payload), [payload]);
+
+  useEffect(() => {
+    if (!serialized) return;
+
+    let parsed: ParsedScriptSnippet[] = [];
+    try {
+      parsed = JSON.parse(serialized) as ParsedScriptSnippet[];
+    } catch (error) {
+      console.error("Failed to parse scripts payload", error);
+      return;
+    }
+
+    const insertedNodes: Node[] = [];
+
+    parsed.forEach((script) => {
+      const code = script.code.trim();
+      if (!code) return;
+
+      const getTarget = ORIENTATION_TARGET[script.orientation];
+      const target = getTarget?.();
+      if (!target) return;
+
+      const selector = `*[data-script-origin="custom-script"][data-script-id="${script.id}"]`;
+      const existing = target.querySelectorAll(selector);
+
+      if (
+        existing.length > 0 &&
+        Array.from(existing).every((node) =>
+          node instanceof HTMLElement
+            ? node.dataset.scriptSignature === script.signature
+            : node.textContent?.trim() === code,
+        )
+      ) {
+        return;
+      }
+
+      existing.forEach((node) => {
+        node.parentNode?.removeChild(node);
+      });
+
+      const template = document.createElement("template");
+      template.innerHTML = code;
+
+      const nodes = Array.from(template.content.childNodes).filter((node) => {
+        if (node.nodeType === Node.TEXT_NODE) {
+          return Boolean(node.textContent?.trim());
+        }
+        return true;
+      });
+
+      if (nodes.length === 0) {
+        const inlineScript = document.createElement("script");
+        inlineScript.type = "text/javascript";
+        inlineScript.dataset.scriptOrigin = "custom-script";
+        inlineScript.dataset.scriptId = script.id;
+        inlineScript.dataset.scriptSignature = script.signature;
+        inlineScript.textContent = code;
+        target.appendChild(inlineScript);
+        insertedNodes.push(inlineScript);
+        return;
+      }
+
+      nodes.forEach((node) => {
+        if (node.nodeType === Node.ELEMENT_NODE) {
+          const element = node as HTMLElement;
+          element.dataset.scriptOrigin = "custom-script";
+          element.dataset.scriptId = script.id;
+          element.dataset.scriptSignature = script.signature;
+          if (script.orientation === "FOOTER") {
+            element.dataset.scriptPosition = "footer";
+          }
+        }
+        const appended = target.appendChild(node);
+        insertedNodes.push(appended);
+      });
+    });
+
+    return () => {
+      insertedNodes.forEach((node) => {
+        node.parentNode?.removeChild(node);
+      });
+    };
+  }, [serialized]);
+
+  return null;
+}

--- a/src/components/ui/custom/slider-manager/index.tsx
+++ b/src/components/ui/custom/slider-manager/index.tsx
@@ -43,6 +43,15 @@ export function SliderManager({
   fieldsOrder,
   contentFieldRequired = false,
   imageFieldLabel,
+  showImageField = true,
+  enableReorder = true,
+  showImageColumn = true,
+  secondFieldType = "text",
+  secondFieldOptions,
+  contentFieldType = "text",
+  contentFieldOptions,
+  renderListItemDetails,
+  showUrlPreview = true,
 }: SliderManagerProps) {
   // Use our custom hook for state management
   const {
@@ -217,10 +226,18 @@ export function SliderManager({
               onToggleStatus={async (id) => {
                 await toggleSliderStatus(id);
               }}
-              onReorder={async (id, pos) => {
-                await reorderSlider(id, pos);
-              }}
+              onReorder={
+                enableReorder
+                  ? async (id, pos) => {
+                      await reorderSlider(id, pos);
+                    }
+                  : undefined
+              }
               isLoading={isLoading}
+              enableReorder={enableReorder}
+              showImageColumn={showImageColumn}
+              renderAdditionalInfo={renderListItemDetails}
+              showUrlPreview={showUrlPreview}
             />
           </motion.div>
         </AnimatePresence>
@@ -258,6 +275,11 @@ export function SliderManager({
                 contentFieldRequired={contentFieldRequired}
                 imageFieldLabel={imageFieldLabel}
                 uploadPath={uploadPath}
+                showImageField={showImageField}
+                secondFieldType={secondFieldType}
+                secondFieldOptions={secondFieldOptions}
+                contentFieldType={contentFieldType}
+                contentFieldOptions={contentFieldOptions}
                 entityName={entityName}
                 onSubmit={async (formData) => {
                   await handleFormSubmit(formData);

--- a/src/components/ui/custom/slider-manager/types/index.ts
+++ b/src/components/ui/custom/slider-manager/types/index.ts
@@ -15,6 +15,8 @@ export interface Slider {
   position: number;
   createdAt: string;
   updatedAt?: string;
+  /** Informações adicionais opcionais para entidades customizadas */
+  meta?: Record<string, unknown>;
 }
 
 export interface SliderFormData {
@@ -25,6 +27,12 @@ export interface SliderFormData {
   content: string;
   status: boolean;
   position: number;
+}
+
+export interface SliderFieldOption {
+  label: string;
+  value: string;
+  disabled?: boolean;
 }
 
 export interface SliderFormProps {
@@ -50,6 +58,16 @@ export interface SliderFormProps {
   contentFieldRequired?: boolean;
   /** Override image field label */
   imageFieldLabel?: string;
+  /** Controla a renderização do campo de imagem */
+  showImageField?: boolean;
+  /** Define o tipo do segundo campo (url) */
+  secondFieldType?: "text" | "textarea" | "select";
+  /** Opções para o segundo campo quando for select */
+  secondFieldOptions?: SliderFieldOption[];
+  /** Define o tipo do campo de conteúdo */
+  contentFieldType?: "text" | "textarea" | "select";
+  /** Opções para o campo de conteúdo quando for select */
+  contentFieldOptions?: SliderFieldOption[];
 }
 
 export interface SliderListProps {
@@ -57,11 +75,15 @@ export interface SliderListProps {
   onEdit: (slider: Slider) => void;
   onDelete: (slider: Slider) => Promise<void>;
   onToggleStatus: (id: string) => Promise<void>;
-  onReorder: (draggedId: string, targetPosition: number) => void;
+  onReorder?: (draggedId: string, targetPosition: number) => void;
   isLoading?: boolean;
   onCreateNew?: () => void;
   entityName?: string;
   entityNamePlural?: string;
+  enableReorder?: boolean;
+  showImageColumn?: boolean;
+  renderAdditionalInfo?: (slider: Slider) => React.ReactNode;
+  showUrlPreview?: boolean;
 }
 
 export interface SliderManagerProps {
@@ -88,6 +110,15 @@ export interface SliderManagerProps {
   fieldsOrder?: Array<"url" | "content" | "title">;
   contentFieldRequired?: boolean;
   imageFieldLabel?: string;
+  showImageField?: boolean;
+  enableReorder?: boolean;
+  showImageColumn?: boolean;
+  secondFieldType?: "text" | "textarea" | "select";
+  secondFieldOptions?: SliderFieldOption[];
+  contentFieldType?: "text" | "textarea" | "select";
+  contentFieldOptions?: SliderFieldOption[];
+  renderListItemDetails?: (slider: Slider) => React.ReactNode;
+  showUrlPreview?: boolean;
 }
 
 export interface ValidationError {

--- a/src/lib/scripts/load-published-scripts.ts
+++ b/src/lib/scripts/load-published-scripts.ts
@@ -1,0 +1,67 @@
+import type {
+  ScriptApplication,
+  ScriptListParams,
+  ScriptOrientation,
+  ScriptResponse,
+} from "@/api/scripts/types";
+
+export interface PreparedScriptSnippet {
+  id: string;
+  orientation: ScriptOrientation;
+  code: string;
+}
+
+type ListScriptsFn = (
+  params?: ScriptListParams,
+  init?: RequestInit,
+) => Promise<ScriptResponse[]>;
+
+const ORIENTATION_ORDER: Record<ScriptOrientation, number> = {
+  HEADER: 0,
+  BODY: 1,
+  FOOTER: 2,
+};
+
+function isPublished(status: ScriptResponse["status"]): boolean {
+  if (typeof status === "string") {
+    return status.toUpperCase() === "PUBLICADO";
+  }
+  return Boolean(status);
+}
+
+export async function loadPublishedScripts(
+  listFn: ListScriptsFn,
+  application: ScriptApplication,
+): Promise<PreparedScriptSnippet[]> {
+  try {
+    const data = await listFn({
+      aplicacao: application,
+      status: "PUBLICADO",
+    });
+
+    return (data || [])
+      .filter((item) =>
+        Boolean(item?.codigo?.trim()) &&
+        isPublished(item.status) &&
+        item.orientacao in ORIENTATION_ORDER,
+      )
+      .map((item, index) => ({
+        id: item.id,
+        orientation: item.orientacao,
+        code: item.codigo.trim(),
+        order: index,
+      }))
+      .sort((a, b) => {
+        const orientationCompare =
+          ORIENTATION_ORDER[a.orientation] - ORIENTATION_ORDER[b.orientation];
+        if (orientationCompare !== 0) {
+          return orientationCompare;
+        }
+        return a.order - b.order;
+      })
+      .map(({ order, ...item }) => item);
+  } catch (error) {
+    console.error("Failed to load published scripts", error);
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- load published scripts via shared helper and client-side injector
- convert dashboard layout into server+client split and reuse script injector
- inject website scripts during layout render to activate published snippets

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d2bf826c148332a33f47af034b8339