### PR TITLE
fix: ensure register payload is unmasked

### DIFF
--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -245,7 +245,7 @@ const RegisterPage = () => {
       const telefoneFormatado = formatPhoneForApi(formData.phone);
       const tipoUsuario: UsuarioRegisterPayload["tipoUsuario"] =
         selectedType === "company" ? "PESSOA_JURIDICA" : "PESSOA_FISICA";
-      const payload: UsuarioRegisterPayload = {
+      const payloadForApi: UsuarioRegisterPayload = {
         nomeCompleto: formData.name.trim(),
         documento: documentoLimpo,
         telefone: telefoneFormatado,
@@ -255,20 +255,23 @@ const RegisterPage = () => {
         aceitarTermos: acceptTerms,
         tipoUsuario,
       };
-      const sanitizedPayload = {
-        ...payload,
+      const maskedPayloadForLog = {
+        ...payloadForApi,
         documento: maskSensitiveValue(documentoLimpo),
         telefone: maskSensitiveValue(telefoneFormatado),
-        email: maskEmail(payload.email),
-        senha: `***(${payload.senha.length} chars)`,
-        confirmarSenha: `***(${payload.confirmarSenha.length} chars)`,
+        email: maskEmail(payloadForApi.email),
+        senha: `***(${payloadForApi.senha.length} chars)`,
+        confirmarSenha: `***(${payloadForApi.confirmarSenha.length} chars)`,
       };
       console.groupCollapsed("🧪 Registro | Payload sanitizado");
       console.log("Endpoint:", "POST /api/v1/usuarios/registrar");
-      console.table(sanitizedPayload);
+      console.table(maskedPayloadForLog);
+      console.info(
+        "ℹ️ Payload enviado sem máscara: os valores acima estão mascarados apenas para log.",
+      );
       console.groupEnd();
       try {
-        await registerUser(payload);
+        await registerUser(payloadForApi);
         toastCustom.success(
           "Cadastro realizado com sucesso! Verifique seu email para confirmar."
         );


### PR DESCRIPTION
## Summary
- ensure the registration form builds a dedicated payload with unmasked values for the API call
- keep logging masked data only for observability and add a note clarifying that real requests use the clean payload

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d2f01c7c7c8332b4fff64c701eadd2