### PR TITLE
Refine user API service and registration flow

### DIFF
--- a/src/api/brevo/index.ts
+++ b/src/api/brevo/index.ts
@@ -1,6 +1,6 @@
 import { apiFetch } from "@/api/client";
 import { brevoRoutes } from "@/api/routes";
-import { apiConfig } from "@/lib/env";
+import { acceptHeaders, publicHeaders } from "@/api/shared";
 
 import type {
   BrevoResendVerificationPayload,
@@ -8,12 +8,6 @@ import type {
   BrevoStatusResponse,
   BrevoVerificationResponse,
 } from "./types";
-
-const ACCEPT_HEADER = { Accept: apiConfig.headers.Accept } as const;
-const JSON_HEADERS = {
-  ...ACCEPT_HEADER,
-  "Content-Type": apiConfig.headers["Content-Type"],
-} as const;
 
 export async function verifyEmail(
   token: string,
@@ -23,7 +17,7 @@ export async function verifyEmail(
     {
       init: {
         method: "GET",
-        headers: ACCEPT_HEADER,
+        headers: acceptHeaders(),
       },
       cache: "no-cache",
       skipLogoutOn401: true,
@@ -39,7 +33,7 @@ export async function verifyEmailAlias(
     {
       init: {
         method: "GET",
-        headers: ACCEPT_HEADER,
+        headers: acceptHeaders(),
       },
       cache: "no-cache",
       skipLogoutOn401: true,
@@ -55,7 +49,7 @@ export async function resendVerificationEmail(
     {
       init: {
         method: "POST",
-        headers: JSON_HEADERS,
+        headers: publicHeaders(),
         body: JSON.stringify(payload),
       },
       cache: "no-cache",
@@ -72,7 +66,7 @@ export async function resendVerificationEmailAlias(
     {
       init: {
         method: "POST",
-        headers: JSON_HEADERS,
+        headers: publicHeaders(),
         body: JSON.stringify(payload),
       },
       cache: "no-cache",
@@ -89,7 +83,7 @@ export async function getVerificationStatusByUserId(
     {
       init: {
         method: "GET",
-        headers: ACCEPT_HEADER,
+        headers: acceptHeaders(),
       },
       cache: "no-cache",
     },
@@ -104,7 +98,7 @@ export async function getVerificationStatusByEmail(
     {
       init: {
         method: "GET",
-        headers: ACCEPT_HEADER,
+        headers: acceptHeaders(),
       },
       cache: "no-cache",
     },

--- a/src/api/dashboard/scripts/index.ts
+++ b/src/api/dashboard/scripts/index.ts
@@ -1,6 +1,6 @@
 import { apiFetch } from "@/api/client";
 import { dashboardRoutes } from "@/api/routes";
-import { apiConfig } from "@/lib/env";
+import { authHeaders, authJsonHeaders, buildQueryString, publicHeaders } from "@/api/shared";
 import type {
   ScriptResponse,
   CreateScriptPayload,
@@ -8,39 +8,24 @@ import type {
   ScriptListParams,
 } from "@/api/scripts/types";
 
-function getAuthHeader(): Record<string, string> {
-  if (typeof document === "undefined") return {};
-  const token = document.cookie
-    .split("; ")
-    .find((row) => row.startsWith("token="))
-    ?.split("=")[1];
-  return token ? { Authorization: `Bearer ${token}` } : {};
-}
-
-function buildQuery(params?: ScriptListParams): string {
-  if (!params) return "";
-  const query = new URLSearchParams();
-  if (params.aplicacao) query.set("aplicacao", params.aplicacao);
-  if (params.orientacao) query.set("orientacao", params.orientacao);
-  if (params.status) query.set("status", params.status);
-  const str = query.toString();
-  return str ? `?${str}` : "";
-}
-
 export async function listDashboardScripts(
   params?: ScriptListParams,
   init?: RequestInit,
 ): Promise<ScriptResponse[]> {
-  const query = buildQuery(params);
+  const query = buildQueryString({
+    aplicacao: params?.aplicacao,
+    orientacao: params?.orientacao,
+    status: params?.status,
+  });
   return apiFetch<ScriptResponse[]>(`${dashboardRoutes.scripts.list()}${query}`, {
-    init: init ?? { headers: apiConfig.headers },
+    init: init ?? { headers: publicHeaders() },
     cache: "no-cache",
   });
 }
 
 export async function getDashboardScriptById(id: string): Promise<ScriptResponse> {
   return apiFetch<ScriptResponse>(dashboardRoutes.scripts.get(id), {
-    init: { headers: apiConfig.headers },
+    init: { headers: publicHeaders() },
     cache: "no-cache",
   });
 }
@@ -51,11 +36,7 @@ export async function createDashboardScript(
   return apiFetch<ScriptResponse>(dashboardRoutes.scripts.create(), {
     init: {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: apiConfig.headers.Accept,
-        ...getAuthHeader(),
-      },
+      headers: authJsonHeaders(),
       body: JSON.stringify(payload),
     },
     cache: "no-cache",
@@ -69,11 +50,7 @@ export async function updateDashboardScript(
   return apiFetch<ScriptResponse>(dashboardRoutes.scripts.update(id), {
     init: {
       method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: apiConfig.headers.Accept,
-        ...getAuthHeader(),
-      },
+      headers: authJsonHeaders(),
       body: JSON.stringify(payload),
     },
     cache: "no-cache",
@@ -84,10 +61,7 @@ export async function deleteDashboardScript(id: string): Promise<void> {
   await apiFetch<void>(dashboardRoutes.scripts.delete(id), {
     init: {
       method: "DELETE",
-      headers: {
-        Accept: apiConfig.headers.Accept,
-        ...getAuthHeader(),
-      },
+      headers: authHeaders(),
     },
     cache: "no-cache",
   });

--- a/src/api/empresas/admin/index.ts
+++ b/src/api/empresas/admin/index.ts
@@ -1,6 +1,6 @@
-import { empresasRoutes } from "@/api/routes";
 import { apiFetch } from "@/api/client";
-import { apiConfig } from "@/lib/env";
+import { empresasRoutes } from "@/api/routes";
+import { authHeaders, authJsonHeaders, mergeHeaders } from "@/api/shared";
 import type {
   AdminCompanyDetailResponse,
   AdminCompanyVacancyDetailResponse,
@@ -18,28 +18,6 @@ import type {
   CreateAdminCompanyBanPayload,
 } from "./types";
 
-function normalizeHeaders(headers?: HeadersInit): Record<string, string> {
-  if (!headers) return {};
-  if (headers instanceof Headers) {
-    return Object.fromEntries(headers.entries());
-  }
-  if (Array.isArray(headers)) {
-    return Object.fromEntries(headers);
-  }
-  return headers as Record<string, string>;
-}
-
-function getAuthHeader(): Record<string, string> {
-  if (typeof document === "undefined") return {};
-
-  const token = document.cookie
-    .split("; ")
-    .find((row) => row.startsWith("token="))
-    ?.split("=")[1];
-
-  return token ? { Authorization: `Bearer ${token}` } : {};
-}
-
 export async function listAdminCompanies(
   params?: ListAdminCompaniesParams,
   init?: RequestInit,
@@ -56,23 +34,19 @@ export async function listAdminCompanies(
   if (params?.search) {
     query.set("search", params.search);
   }
-  if (params?.planNames && params.planNames.length > 0) {
-    for (const name of params.planNames) query.append("planName", name);
+  if (params?.planNames?.length) {
+    params.planNames.forEach((name) => query.append("planName", name));
   }
-  if (params?.planTypes && params.planTypes.length > 0) {
-    for (const t of params.planTypes) query.append("planType", String(t));
+  if (params?.planTypes?.length) {
+    params.planTypes.forEach((type) => query.append("planType", String(type)));
   }
-  if (params?.statuses && params.statuses.length > 0) {
-    for (const status of params.statuses) query.append("status", status);
+  if (params?.statuses?.length) {
+    params.statuses.forEach((status) => query.append("status", status));
   }
 
   const url = query.toString() ? `${endpoint}?${query.toString()}` : endpoint;
 
-  const headers = {
-    ...apiConfig.headers,
-    ...getAuthHeader(),
-    ...normalizeHeaders(init?.headers),
-  };
+  const headers = mergeHeaders(authHeaders(), init?.headers);
 
   return apiFetch<ListAdminCompaniesResponse>(url, {
     init: {
@@ -88,11 +62,7 @@ export async function listAdminCompanies(
 export async function getAdminCompanyById(id: string, init?: RequestInit): Promise<AdminCompanyDetailResponse> {
   const endpoint = empresasRoutes.adminEmpresas.get(id);
 
-  const headers = {
-    ...apiConfig.headers,
-    ...getAuthHeader(),
-    ...normalizeHeaders(init?.headers),
-  };
+  const headers = mergeHeaders(authHeaders(), init?.headers);
 
   return apiFetch<AdminCompanyDetailResponse>(endpoint, {
     init: {
@@ -109,12 +79,7 @@ export async function createAdminCompany(
 ): Promise<AdminCompanyDetailResponse> {
   const endpoint = empresasRoutes.adminEmpresas.create();
 
-  const headers = {
-    "Content-Type": "application/json",
-    Accept: apiConfig.headers.Accept,
-    ...getAuthHeader(),
-    ...normalizeHeaders(init?.headers),
-  };
+  const headers = mergeHeaders(authJsonHeaders(), init?.headers);
 
   return apiFetch<AdminCompanyDetailResponse>(endpoint, {
     init: {
@@ -134,12 +99,7 @@ export async function updateAdminCompany(
 ): Promise<AdminCompanyDetailResponse> {
   const endpoint = empresasRoutes.adminEmpresas.update(id);
 
-  const headers = {
-    "Content-Type": "application/json",
-    Accept: apiConfig.headers.Accept,
-    ...getAuthHeader(),
-    ...normalizeHeaders(init?.headers),
-  };
+  const headers = mergeHeaders(authJsonHeaders(), init?.headers);
 
   return apiFetch<AdminCompanyDetailResponse>(endpoint, {
     init: {
@@ -176,11 +136,7 @@ export async function listAdminCompanyPayments(
 
   const url = query.toString() ? `${endpoint}?${query}` : endpoint;
 
-  const headers = {
-    ...apiConfig.headers,
-    ...getAuthHeader(),
-    ...normalizeHeaders(init?.headers),
-  };
+  const headers = mergeHeaders(authHeaders(), init?.headers);
 
   return apiFetch<AdminCompanyPaymentHistoryResponse>(url, {
     init: {
@@ -203,11 +159,7 @@ export async function listAdminCompanyBans(
 
   const url = query.toString() ? `${endpoint}?${query}` : endpoint;
 
-  const headers = {
-    ...apiConfig.headers,
-    ...getAuthHeader(),
-    ...normalizeHeaders(init?.headers),
-  };
+  const headers = mergeHeaders(authHeaders(), init?.headers);
 
   return apiFetch<AdminCompanyBanHistoryResponse>(url, {
     init: {
@@ -226,12 +178,7 @@ export async function createAdminCompanyBan(
 ): Promise<AdminCompanyBanDetailResponse> {
   const endpoint = empresasRoutes.adminEmpresas.banimentos.create(id);
 
-  const headers = {
-    "Content-Type": "application/json",
-    Accept: apiConfig.headers.Accept,
-    ...getAuthHeader(),
-    ...normalizeHeaders(init?.headers),
-  };
+  const headers = mergeHeaders(authJsonHeaders(), init?.headers);
 
   return apiFetch<AdminCompanyBanDetailResponse>(endpoint, {
     init: {
@@ -270,11 +217,7 @@ export async function listAdminCompanyVacancies(
 
   const url = query.toString() ? `${endpoint}?${query}` : endpoint;
 
-  const headers = {
-    ...apiConfig.headers,
-    ...getAuthHeader(),
-    ...normalizeHeaders(init?.headers),
-  };
+  const headers = mergeHeaders(authHeaders(), init?.headers);
 
   return apiFetch<AdminCompanyVacancyListResponse>(url, {
     init: {
@@ -297,11 +240,7 @@ export async function listAdminCompanyVacanciesInReview(
 
   const url = query.toString() ? `${endpoint}?${query}` : endpoint;
 
-  const headers = {
-    ...apiConfig.headers,
-    ...getAuthHeader(),
-    ...normalizeHeaders(init?.headers),
-  };
+  const headers = mergeHeaders(authHeaders(), init?.headers);
 
   return apiFetch<AdminCompanyVacancyListResponse>(url, {
     init: {
@@ -320,12 +259,7 @@ export async function approveAdminCompanyVacancy(
 ): Promise<AdminCompanyVacancyDetailResponse> {
   const endpoint = empresasRoutes.adminEmpresas.vagas.aprovar(id, vacancyId);
 
-  const headers = {
-    "Content-Type": "application/json",
-    Accept: apiConfig.headers.Accept,
-    ...getAuthHeader(),
-    ...normalizeHeaders(init?.headers),
-  };
+  const headers = mergeHeaders(authJsonHeaders(), init?.headers);
 
   return apiFetch<AdminCompanyVacancyDetailResponse>(endpoint, {
     init: {

--- a/src/api/empresas/planos-empresariais/index.ts
+++ b/src/api/empresas/planos-empresariais/index.ts
@@ -1,6 +1,6 @@
 import { empresasRoutes } from "@/api/routes";
 import { apiFetch } from "@/api/client";
-import { apiConfig } from "@/lib/env";
+import { authHeaders, authJsonHeaders, publicHeaders } from "@/api/shared";
 import type {
   PlanoEmpresarialBackendResponse,
   CreatePlanoEmpresarialPayload,
@@ -12,7 +12,7 @@ export async function listPlanosEmpresariais(
 ): Promise<PlanoEmpresarialBackendResponse[]> {
   return apiFetch<PlanoEmpresarialBackendResponse[]>(
     empresasRoutes.planosEmpresariais.list(),
-    { init: init ?? { headers: apiConfig.headers } },
+    { init: init ?? { headers: publicHeaders() } },
   );
 }
 
@@ -21,17 +21,8 @@ export async function getPlanoEmpresarialById(
 ): Promise<PlanoEmpresarialBackendResponse> {
   return apiFetch<PlanoEmpresarialBackendResponse>(
     empresasRoutes.planosEmpresariais.get(id),
-    { init: { headers: apiConfig.headers } },
+    { init: { headers: publicHeaders() } },
   );
-}
-
-function getAuthHeader(): Record<string, string> {
-  if (typeof document === "undefined") return {};
-  const token = document.cookie
-    .split("; ")
-    .find((row) => row.startsWith("token="))
-    ?.split("=")[1];
-  return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
 export async function createPlanoEmpresarial(
@@ -42,11 +33,7 @@ export async function createPlanoEmpresarial(
     {
       init: {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Accept: apiConfig.headers.Accept,
-          ...getAuthHeader(),
-        },
+        headers: authJsonHeaders(),
         body: JSON.stringify(data),
       },
       cache: "no-cache",
@@ -63,11 +50,7 @@ export async function updatePlanoEmpresarial(
     {
       init: {
         method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-          Accept: apiConfig.headers.Accept,
-          ...getAuthHeader(),
-        },
+        headers: authJsonHeaders(),
         body: JSON.stringify(data),
       },
       cache: "no-cache",
@@ -79,10 +62,7 @@ export async function deletePlanoEmpresarial(id: string): Promise<void> {
   await apiFetch<void>(empresasRoutes.planosEmpresariais.delete(id), {
     init: {
       method: "DELETE",
-      headers: {
-        Accept: apiConfig.headers.Accept,
-        ...getAuthHeader(),
-      },
+      headers: authHeaders(),
     },
     cache: "no-cache",
   });

--- a/src/api/shared.ts
+++ b/src/api/shared.ts
@@ -1,0 +1,153 @@
+import { apiConfig } from "@/lib/env";
+
+const ACCEPT_HEADERS = Object.freeze({
+  Accept: apiConfig.headers.Accept,
+});
+
+const PUBLIC_HEADERS = Object.freeze({
+  ...apiConfig.headers,
+});
+
+type HeaderValue = HeadersInit | undefined;
+
+type QueryPrimitive = string | number | boolean;
+
+type QueryValue = QueryPrimitive | QueryPrimitive[] | null | undefined;
+
+function toRecord(input: HeaderValue): Record<string, string> | null {
+  if (!input) {
+    return null;
+  }
+
+  if (input instanceof Headers) {
+    return Object.fromEntries(input.entries());
+  }
+
+  if (Array.isArray(input)) {
+    const result = new Headers();
+    input.forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        result.set(key, String(value));
+      }
+    });
+    return Object.fromEntries(result.entries());
+  }
+
+  const entries: [string, string][] = [];
+  Object.entries(input).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      entries.push([key, String(value)]);
+    }
+  });
+  return Object.fromEntries(entries);
+}
+
+function mergeRecords(
+  ...headers: Array<Record<string, string> | null>
+): Record<string, string> {
+  const merged = new Headers();
+
+  headers.forEach((record) => {
+    if (!record) return;
+    Object.entries(record).forEach(([key, value]) => {
+      merged.set(key, value);
+    });
+  });
+
+  return Object.fromEntries(merged.entries());
+}
+
+function buildAuthHeader(token?: string): Record<string, string> | null {
+  const authToken = token ?? readBrowserToken();
+  if (!authToken) {
+    return null;
+  }
+
+  return { Authorization: `Bearer ${authToken}` };
+}
+
+export function readBrowserToken(cookieName = "token"): string | undefined {
+  if (typeof document === "undefined") {
+    return undefined;
+  }
+
+  const rawCookie = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith(`${cookieName}=`));
+
+  return rawCookie ? rawCookie.split("=")[1] : undefined;
+}
+
+export function mergeHeaders(
+  ...headers: HeaderValue[]
+): Record<string, string> {
+  const records = headers.map(toRecord);
+  return mergeRecords(...records);
+}
+
+export function publicHeaders(
+  extra?: HeadersInit,
+): Record<string, string> {
+  return mergeHeaders(PUBLIC_HEADERS, extra);
+}
+
+export function acceptHeaders(
+  extra?: HeadersInit,
+): Record<string, string> {
+  return mergeHeaders(ACCEPT_HEADERS, extra);
+}
+
+export function authHeaders(
+  token?: string,
+  extra?: HeadersInit,
+): Record<string, string> {
+  return mergeHeaders(ACCEPT_HEADERS, buildAuthHeader(token) ?? undefined, extra);
+}
+
+export function authJsonHeaders(
+  token?: string,
+  extra?: HeadersInit,
+): Record<string, string> {
+  return mergeHeaders(
+    PUBLIC_HEADERS,
+    buildAuthHeader(token) ?? undefined,
+    extra,
+  );
+}
+
+export function buildQueryString(
+  params?: Record<string, QueryValue>,
+): string {
+  if (!params) {
+    return "";
+  }
+
+  const query = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null) {
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      value.forEach((item) => {
+        if (item !== undefined && item !== null) {
+          query.append(key, String(item));
+        }
+      });
+      return;
+    }
+
+    query.set(key, String(value));
+  });
+
+  const queryString = query.toString();
+  return queryString ? `?${queryString}` : "";
+}
+
+export const apiHeaders = {
+  accept: () => ({ ...ACCEPT_HEADERS }),
+  json: () => ({ ...PUBLIC_HEADERS }),
+};
+
+export type { QueryValue };

--- a/src/api/usuarios/index.ts
+++ b/src/api/usuarios/index.ts
@@ -1,11 +1,12 @@
 import { apiFetch } from "@/api/client";
 import { usuarioRoutes } from "@/api/routes";
-import { apiConfig } from "@/lib/env";
+import { acceptHeaders, authHeaders, publicHeaders } from "@/api/shared";
 
 import type {
   UsuarioLoginPayload,
   UsuarioLoginResponse,
   UsuarioLogoutResponse,
+  UsuarioModuleInfoResponse,
   UsuarioPasswordRecoveryRequestPayload,
   UsuarioPasswordRecoveryResponse,
   UsuarioPasswordRecoveryValidationResponse,
@@ -18,32 +19,15 @@ import type {
   UsuarioRegisterResponse,
 } from "./types";
 
-const ACCEPT_HEADER = { Accept: apiConfig.headers.Accept } as const;
-const JSON_HEADERS = {
-  ...ACCEPT_HEADER,
-  "Content-Type": apiConfig.headers["Content-Type"],
-} as const;
-
-function readBrowserToken(): string | undefined {
-  if (typeof document === "undefined") return undefined;
-
-  return document.cookie
-    .split("; ")
-    .find((row) => row.startsWith("token="))
-    ?.split("=")[1];
-}
-
-function buildAuthHeaders(token?: string): Record<string, string> {
-  const resolvedToken = token ?? readBrowserToken();
-
-  if (!resolvedToken) {
-    return { ...ACCEPT_HEADER };
-  }
-
-  return {
-    ...ACCEPT_HEADER,
-    Authorization: `Bearer ${resolvedToken}`,
-  };
+export async function getUsersModuleInfo(): Promise<UsuarioModuleInfoResponse> {
+  return apiFetch<UsuarioModuleInfoResponse>(usuarioRoutes.info(), {
+    init: {
+      method: "GET",
+      headers: acceptHeaders(),
+    },
+    cache: "short",
+    skipLogoutOn401: true,
+  });
 }
 
 export async function requestPasswordRecovery(
@@ -54,7 +38,7 @@ export async function requestPasswordRecovery(
     {
       init: {
         method: "POST",
-        headers: JSON_HEADERS,
+        headers: publicHeaders(),
         body: JSON.stringify(payload),
       },
       cache: "no-cache",
@@ -71,7 +55,7 @@ export async function validatePasswordRecoveryToken(
     {
       init: {
         method: "GET",
-        headers: ACCEPT_HEADER,
+        headers: acceptHeaders(),
       },
       cache: "no-cache",
       skipLogoutOn401: true,
@@ -87,7 +71,7 @@ export async function resetPasswordWithToken(
     {
       init: {
         method: "POST",
-        headers: JSON_HEADERS,
+        headers: publicHeaders(),
         body: JSON.stringify(payload),
       },
       cache: "no-cache",
@@ -102,7 +86,7 @@ export async function registerUser(
   return apiFetch<UsuarioRegisterResponse>(usuarioRoutes.register(), {
     init: {
       method: "POST",
-      headers: JSON_HEADERS,
+      headers: publicHeaders(),
       body: JSON.stringify(payload),
     },
     cache: "no-cache",
@@ -116,7 +100,7 @@ export async function loginUser(
   return apiFetch<UsuarioLoginResponse>(usuarioRoutes.login(), {
     init: {
       method: "POST",
-      headers: JSON_HEADERS,
+      headers: publicHeaders(),
       body: JSON.stringify(payload),
     },
     cache: "no-cache",
@@ -131,7 +115,7 @@ export async function refreshUserToken(
   return apiFetch<UsuarioRefreshResponse>(usuarioRoutes.refresh(), {
     init: {
       method: "POST",
-      headers: JSON_HEADERS,
+      headers: publicHeaders(),
       body: JSON.stringify(payload),
     },
     cache: "no-cache",
@@ -144,7 +128,7 @@ export async function logoutUserSession(
   return apiFetch<UsuarioLogoutResponse>(usuarioRoutes.logout(), {
     init: {
       method: "POST",
-      headers: buildAuthHeaders(token),
+      headers: authHeaders(token),
     },
     cache: "no-cache",
   });
@@ -156,7 +140,7 @@ export async function getUserProfile(
   return apiFetch<UsuarioProfileResponse>(usuarioRoutes.profile.get(), {
     init: {
       method: "GET",
-      headers: buildAuthHeaders(token),
+      headers: authHeaders(token),
     },
     cache: "no-cache",
   });

--- a/src/api/usuarios/types.ts
+++ b/src/api/usuarios/types.ts
@@ -1,7 +1,68 @@
-export interface UsuarioResponseBase {
+export interface ApiMessageResponse {
   success?: boolean;
   message?: string;
   code?: string;
+  correlationId?: string;
+  duration?: string;
+  timestamp?: string;
+}
+
+export interface UsuarioSummary {
+  id: string;
+  email: string;
+  nomeCompleto: string;
+  tipoUsuario?: string;
+  role?: string;
+  roles?: string[];
+  status?: string;
+  criadoEm?: string;
+  codUsuario?: string;
+  supabaseId?: string;
+  emailVerificado?: boolean;
+  emailVerificadoEm?: string | null;
+  ultimoLogin?: string | null;
+  socialLinks?: Record<string, unknown>;
+  enderecos?: unknown[];
+  imagemPerfil?: string | null;
+  plano?: string | null;
+}
+
+export interface UsuarioModuleFeatures {
+  emailVerification: boolean;
+  registration: boolean;
+  authentication: boolean;
+  profileManagement: boolean;
+  passwordRecovery: boolean;
+}
+
+export interface UsuarioModuleInfoResponse {
+  module: string;
+  version: string;
+  timestamp: string;
+  environment: string;
+  features: UsuarioModuleFeatures;
+  endpoints: {
+    auth: {
+      register: string;
+      login: string;
+      logout: string;
+      refresh: string;
+    };
+    profile: {
+      get: string;
+      update: string;
+    };
+    recovery: {
+      request: string;
+      validate: string;
+      reset: string;
+    };
+    verification: {
+      verify: string;
+      resend: string;
+      status: string;
+    };
+  };
 }
 
 export interface UsuarioPasswordRecoveryRequestPayload {
@@ -11,9 +72,15 @@ export interface UsuarioPasswordRecoveryRequestPayload {
   cnpj?: string;
 }
 
-export type UsuarioPasswordRecoveryResponse = UsuarioResponseBase;
+export interface UsuarioPasswordRecoveryResponse extends ApiMessageResponse {
+  errors?: Array<{ path?: string; message: string }>;
+  retryAfter?: number;
+}
 
-export type UsuarioPasswordRecoveryValidationResponse = UsuarioResponseBase;
+export interface UsuarioPasswordRecoveryValidationResponse
+  extends ApiMessageResponse {
+  usuario?: Pick<UsuarioSummary, "email" | "nomeCompleto">;
+}
 
 export interface UsuarioPasswordResetPayload {
   token: string;
@@ -21,11 +88,12 @@ export interface UsuarioPasswordResetPayload {
   confirmarSenha: string;
 }
 
-export type UsuarioPasswordResetResponse = UsuarioResponseBase;
+export interface UsuarioPasswordResetResponse extends ApiMessageResponse {
+  detalhes?: string[];
+}
 
 export interface UsuarioRegisterPayload {
   nomeCompleto: string;
-  documento: string;
   telefone: string;
   email: string;
   senha: string;
@@ -40,12 +108,8 @@ export interface UsuarioRegisterPayload {
   role?: string;
 }
 
-export interface UsuarioRegisterResponse extends UsuarioResponseBase {
-  usuario?: {
-    id: string;
-    email: string;
-    nomeCompleto: string;
-  };
+export interface UsuarioRegisterResponse extends ApiMessageResponse {
+  usuario?: UsuarioSummary;
 }
 
 export interface UsuarioLoginPayload {
@@ -61,7 +125,8 @@ export interface UsuarioSessionInfo {
   expiresAt: string;
 }
 
-export interface UsuarioLoginResponse extends UsuarioResponseBase {
+export interface UsuarioLoginResponse extends ApiMessageResponse {
+  usuario?: UsuarioSummary;
   token: string;
   refreshToken: string;
   tokenType?: string;
@@ -70,49 +135,39 @@ export interface UsuarioLoginResponse extends UsuarioResponseBase {
   refreshTokenExpiresIn?: string;
   refreshTokenExpiresAt?: string;
   session?: UsuarioSessionInfo;
-  correlationId?: string;
-  timestamp?: string;
 }
 
 export interface UsuarioRefreshPayload {
   refreshToken?: string;
 }
 
-export interface UsuarioRefreshResponse extends UsuarioResponseBase {
+export interface UsuarioRefreshResponse extends ApiMessageResponse {
+  usuario?: UsuarioSummary;
   token: string;
   refreshToken: string;
   rememberMe?: boolean;
   refreshTokenExpiresAt?: string;
   session?: UsuarioSessionInfo;
-  correlationId?: string;
-  timestamp?: string;
 }
 
-export interface UsuarioLogoutResponse extends UsuarioResponseBase {
-  correlationId?: string;
-  timestamp?: string;
-}
+export type UsuarioLogoutResponse = ApiMessageResponse;
 
 export interface UsuarioEmailVerificationState {
   verified: boolean;
   verifiedAt: string | null;
   tokenExpiration: string | null;
-  attempts: number;
-  lastAttemptAt: string | null;
 }
 
-export interface UsuarioProfileResponse {
-  id: string;
-  email: string;
-  nomeCompleto: string;
-  role?: string;
-  roles?: string[];
-  tipoUsuario?: string;
-  supabaseId?: string;
-  emailVerificado?: boolean;
-  emailVerificadoEm?: string | null;
-  emailVerification?: UsuarioEmailVerificationState;
-  ultimoLogin?: string | null;
-  imagemPerfil?: string | null;
-  plano?: string | null;
+export interface UsuarioProfileStats {
+  accountAge: number;
+  hasCompletedProfile: boolean;
+  hasAddress: boolean;
+  totalOrders: number;
+  totalSubscriptions: number;
+  emailVerificationStatus: UsuarioEmailVerificationState;
+}
+
+export interface UsuarioProfileResponse extends ApiMessageResponse {
+  usuario: UsuarioSummary;
+  stats?: UsuarioProfileStats;
 }

--- a/src/api/websites/components/depoimentos/index.ts
+++ b/src/api/websites/components/depoimentos/index.ts
@@ -1,20 +1,11 @@
-import { websiteRoutes } from "@/api/routes";
 import { apiFetch } from "@/api/client";
-import { apiConfig } from "@/lib/env";
+import { websiteRoutes } from "@/api/routes";
+import { authHeaders, authJsonHeaders, publicHeaders } from "@/api/shared";
 import type {
   DepoimentoBackendResponse,
   CreateDepoimentoPayload,
   UpdateDepoimentoPayload,
 } from "./types";
-
-function getAuthHeader(): Record<string, string> {
-  if (typeof document === "undefined") return {};
-  const token = document.cookie
-    .split("; ")
-    .find((row) => row.startsWith("token="))
-    ?.split("=")[1];
-  return token ? { Authorization: `Bearer ${token}` } : {};
-}
 
 export async function listDepoimentos(
   init?: RequestInit,
@@ -24,14 +15,14 @@ export async function listDepoimentos(
     ? `${websiteRoutes.depoimentos.list()}?status=${encodeURIComponent(status)}`
     : websiteRoutes.depoimentos.list();
   return apiFetch<DepoimentoBackendResponse[]>(url, {
-    init: init ?? { headers: apiConfig.headers },
+    init: init ?? { headers: publicHeaders() },
     cache: "no-cache",
   });
 }
 
 export async function getDepoimentoById(id: string): Promise<DepoimentoBackendResponse> {
   return apiFetch<DepoimentoBackendResponse>(websiteRoutes.depoimentos.get(id), {
-    init: { headers: apiConfig.headers },
+    init: { headers: publicHeaders() },
     cache: "no-cache",
   });
 }
@@ -50,11 +41,7 @@ export async function createDepoimento(
   return apiFetch<DepoimentoBackendResponse>(websiteRoutes.depoimentos.create(), {
     init: {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: apiConfig.headers.Accept,
-        ...getAuthHeader(),
-      },
+      headers: authJsonHeaders(),
       body: JSON.stringify(payload),
     },
     cache: "no-cache",
@@ -76,11 +63,7 @@ export async function updateDepoimento(
   return apiFetch<DepoimentoBackendResponse>(websiteRoutes.depoimentos.update(id), {
     init: {
       method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: apiConfig.headers.Accept,
-        ...getAuthHeader(),
-      },
+      headers: authJsonHeaders(),
       body: JSON.stringify(payload),
     },
     cache: "no-cache",
@@ -91,7 +74,7 @@ export async function deleteDepoimento(id: string): Promise<void> {
   await apiFetch<void>(websiteRoutes.depoimentos.delete(id), {
     init: {
       method: "DELETE",
-      headers: { Accept: apiConfig.headers.Accept, ...getAuthHeader() },
+      headers: authHeaders(),
     },
     cache: "no-cache",
   });
@@ -104,11 +87,7 @@ export async function updateDepoimentoOrder(
   await apiFetch<DepoimentoBackendResponse>(websiteRoutes.depoimentos.reorder(id), {
     init: {
       method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: apiConfig.headers.Accept,
-        ...getAuthHeader(),
-      },
+      headers: authJsonHeaders(),
       body: JSON.stringify({ ordem: Number(ordem) }),
     },
     cache: "no-cache",
@@ -123,11 +102,7 @@ export async function updateDepoimentoStatus(
   return apiFetch<DepoimentoBackendResponse>(websiteRoutes.depoimentos.update(id), {
     init: {
       method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: apiConfig.headers.Accept,
-        ...getAuthHeader(),
-      },
+      headers: authJsonHeaders(),
       body: JSON.stringify(payload),
     },
     cache: "no-cache",

--- a/src/api/websites/components/imagem-login/index.ts
+++ b/src/api/websites/components/imagem-login/index.ts
@@ -3,8 +3,9 @@
  * Busca dados da imagem exibida na página de login
  */
 
-import { websiteRoutes } from "@/api/routes";
 import { apiFetch } from "@/api/client";
+import { websiteRoutes } from "@/api/routes";
+import { authHeaders, publicHeaders } from "@/api/shared";
 import { apiConfig, env } from "@/lib/env";
 import { loginImageMockData } from "./mock";
 import type {
@@ -30,7 +31,7 @@ function mapLoginImageResponse(
 export async function getLoginImageData(): Promise<LoginImageItem | null> {
   try {
     const raw = await listLoginImages({
-      headers: apiConfig.headers,
+      headers: publicHeaders(),
       ...apiConfig.cache.medium,
     });
     return mapLoginImageResponse(raw);
@@ -47,7 +48,7 @@ export async function getLoginImageDataClient(): Promise<
   LoginImageItem | null
 > {
   try {
-    const raw = await listLoginImages({ headers: apiConfig.headers });
+    const raw = await listLoginImages({ headers: publicHeaders() });
     return mapLoginImageResponse(raw);
   } catch (error) {
     console.error("❌ Erro ao buscar imagem de login (client):", error);
@@ -63,7 +64,7 @@ export async function listLoginImages(
 ): Promise<LoginImageBackendResponse[]> {
   return apiFetch<LoginImageBackendResponse[]>(
     websiteRoutes.loginImage.list(),
-    { init: init ?? { headers: apiConfig.headers }, cache: "no-cache" },
+    { init: init ?? { headers: publicHeaders() }, cache: "no-cache" },
   );
 }
 
@@ -72,23 +73,14 @@ export async function getLoginImageById(
 ): Promise<LoginImageBackendResponse> {
   return apiFetch<LoginImageBackendResponse>(
     websiteRoutes.loginImage.get(id),
-    { init: { headers: apiConfig.headers }, cache: "no-cache" },
+    { init: { headers: publicHeaders() }, cache: "no-cache" },
   );
-}
-
-function getAuthHeader(): Record<string, string> {
-  if (typeof document === "undefined") return {};
-  const token = document.cookie
-    .split("; ")
-    .find((row) => row.startsWith("token="))
-    ?.split("=")[1];
-  return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
 function buildRequest(
   data: CreateLoginImagePayload | UpdateLoginImagePayload,
 ): { body: BodyInit; headers: Record<string, string> } {
-  const headers = { Accept: apiConfig.headers.Accept, ...getAuthHeader() };
+  const headers = authHeaders();
   const form = new FormData();
   if (data.imagem) form.append("imagem", data.imagem);
   if (data.imagemUrl) form.append("imagemUrl", data.imagemUrl);
@@ -122,7 +114,7 @@ export async function deleteLoginImage(id: string): Promise<void> {
   await apiFetch<void>(websiteRoutes.loginImage.delete(id), {
     init: {
       method: "DELETE",
-      headers: { Accept: apiConfig.headers.Accept, ...getAuthHeader() },
+      headers: authHeaders(),
     },
     cache: "no-cache",
   });

--- a/src/api/websites/components/recrutamento-selecao/index.ts
+++ b/src/api/websites/components/recrutamento-selecao/index.ts
@@ -1,20 +1,11 @@
-import { websiteRoutes } from "@/api/routes";
 import { apiFetch } from "@/api/client";
-import { apiConfig } from "@/lib/env";
+import { websiteRoutes } from "@/api/routes";
+import { authHeaders, authJsonHeaders, publicHeaders } from "@/api/shared";
 import type {
   RecrutamentoSelecaoBackendResponse,
   CreateRecrutamentoSelecaoPayload,
   UpdateRecrutamentoSelecaoPayload,
 } from "./types";
-
-function getAuthHeader(): Record<string, string> {
-  if (typeof document === "undefined") return {};
-  const token = document.cookie
-    .split("; ")
-    .find((row) => row.startsWith("token="))
-    ?.split("=")[1];
-  return token ? { Authorization: `Bearer ${token}` } : {};
-}
 
 export async function listRecrutamentoSelecao(
   init?: RequestInit,
@@ -22,7 +13,7 @@ export async function listRecrutamentoSelecao(
   return apiFetch<RecrutamentoSelecaoBackendResponse[]>(
     websiteRoutes.recrutamentoSelecao.list(),
     {
-      init: init ?? { headers: apiConfig.headers },
+      init: init ?? { headers: publicHeaders() },
     },
   );
 }
@@ -32,22 +23,21 @@ export async function getRecrutamentoSelecaoById(
 ): Promise<RecrutamentoSelecaoBackendResponse> {
   return apiFetch<RecrutamentoSelecaoBackendResponse>(
     websiteRoutes.recrutamentoSelecao.get(id),
-    { init: { headers: apiConfig.headers } },
+    { init: { headers: publicHeaders() } },
   );
 }
 
 export async function createRecrutamentoSelecao(
   data: CreateRecrutamentoSelecaoPayload,
 ): Promise<RecrutamentoSelecaoBackendResponse> {
-  const headers = {
-    "Content-Type": "application/json",
-    Accept: apiConfig.headers.Accept,
-    ...getAuthHeader(),
-  } as Record<string, string>;
   return apiFetch<RecrutamentoSelecaoBackendResponse>(
     websiteRoutes.recrutamentoSelecao.create(),
     {
-      init: { method: "POST", body: JSON.stringify(data), headers },
+      init: {
+        method: "POST",
+        body: JSON.stringify(data),
+        headers: authJsonHeaders(),
+      },
       cache: "no-cache",
     },
   );
@@ -57,24 +47,22 @@ export async function updateRecrutamentoSelecao(
   id: string,
   data: UpdateRecrutamentoSelecaoPayload,
 ): Promise<RecrutamentoSelecaoBackendResponse> {
-  const headers = {
-    "Content-Type": "application/json",
-    Accept: apiConfig.headers.Accept,
-    ...getAuthHeader(),
-  } as Record<string, string>;
   return apiFetch<RecrutamentoSelecaoBackendResponse>(
     websiteRoutes.recrutamentoSelecao.update(id),
     {
-      init: { method: "PUT", body: JSON.stringify(data), headers },
+      init: {
+        method: "PUT",
+        body: JSON.stringify(data),
+        headers: authJsonHeaders(),
+      },
       cache: "no-cache",
     },
   );
 }
 
 export async function deleteRecrutamentoSelecao(id: string): Promise<void> {
-  const headers = { Accept: apiConfig.headers.Accept, ...getAuthHeader() } as Record<string, string>;
   await apiFetch<void>(websiteRoutes.recrutamentoSelecao.delete(id), {
-    init: { method: "DELETE", headers },
+    init: { method: "DELETE", headers: authHeaders() },
     cache: "no-cache",
   });
 }

--- a/src/api/websites/components/scripts/index.ts
+++ b/src/api/websites/components/scripts/index.ts
@@ -1,6 +1,6 @@
 import { apiFetch } from "@/api/client";
 import { websiteRoutes } from "@/api/routes";
-import { apiConfig } from "@/lib/env";
+import { authHeaders, authJsonHeaders, buildQueryString, publicHeaders } from "@/api/shared";
 import type {
   ScriptResponse,
   CreateScriptPayload,
@@ -8,39 +8,24 @@ import type {
   ScriptListParams,
 } from "@/api/scripts/types";
 
-function getAuthHeader(): Record<string, string> {
-  if (typeof document === "undefined") return {};
-  const token = document.cookie
-    .split("; ")
-    .find((row) => row.startsWith("token="))
-    ?.split("=")[1];
-  return token ? { Authorization: `Bearer ${token}` } : {};
-}
-
-function buildQuery(params?: ScriptListParams): string {
-  if (!params) return "";
-  const query = new URLSearchParams();
-  if (params.aplicacao) query.set("aplicacao", params.aplicacao);
-  if (params.orientacao) query.set("orientacao", params.orientacao);
-  if (params.status) query.set("status", params.status);
-  const str = query.toString();
-  return str ? `?${str}` : "";
-}
-
 export async function listWebsiteScripts(
   params?: ScriptListParams,
   init?: RequestInit,
 ): Promise<ScriptResponse[]> {
-  const query = buildQuery(params);
+  const query = buildQueryString({
+    aplicacao: params?.aplicacao,
+    orientacao: params?.orientacao,
+    status: params?.status,
+  });
   return apiFetch<ScriptResponse[]>(`${websiteRoutes.scripts.list()}${query}`, {
-    init: init ?? { headers: apiConfig.headers },
+    init: init ?? { headers: publicHeaders() },
     cache: "no-cache",
   });
 }
 
 export async function getWebsiteScriptById(id: string): Promise<ScriptResponse> {
   return apiFetch<ScriptResponse>(websiteRoutes.scripts.get(id), {
-    init: { headers: apiConfig.headers },
+    init: { headers: publicHeaders() },
     cache: "no-cache",
   });
 }
@@ -51,11 +36,7 @@ export async function createWebsiteScript(
   return apiFetch<ScriptResponse>(websiteRoutes.scripts.create(), {
     init: {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: apiConfig.headers.Accept,
-        ...getAuthHeader(),
-      },
+      headers: authJsonHeaders(),
       body: JSON.stringify(payload),
     },
     cache: "no-cache",
@@ -69,11 +50,7 @@ export async function updateWebsiteScript(
   return apiFetch<ScriptResponse>(websiteRoutes.scripts.update(id), {
     init: {
       method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: apiConfig.headers.Accept,
-        ...getAuthHeader(),
-      },
+      headers: authJsonHeaders(),
       body: JSON.stringify(payload),
     },
     cache: "no-cache",
@@ -84,10 +61,7 @@ export async function deleteWebsiteScript(id: string): Promise<void> {
   await apiFetch<void>(websiteRoutes.scripts.delete(id), {
     init: {
       method: "DELETE",
-      headers: {
-        Accept: apiConfig.headers.Accept,
-        ...getAuthHeader(),
-      },
+      headers: authHeaders(),
     },
     cache: "no-cache",
   });

--- a/src/api/websites/components/sistema/index.ts
+++ b/src/api/websites/components/sistema/index.ts
@@ -1,30 +1,21 @@
-import { websiteRoutes } from "@/api/routes";
 import { apiFetch } from "@/api/client";
-import { apiConfig } from "@/lib/env";
+import { websiteRoutes } from "@/api/routes";
+import { authHeaders, authJsonHeaders, publicHeaders } from "@/api/shared";
 import type {
   SistemaBackendResponse,
   CreateSistemaPayload,
   UpdateSistemaPayload,
 } from "./types";
 
-function getAuthHeader(): Record<string, string> {
-  if (typeof document === "undefined") return {};
-  const token = document.cookie
-    .split("; ")
-    .find((row) => row.startsWith("token="))
-    ?.split("=")[1];
-  return token ? { Authorization: `Bearer ${token}` } : {};
-}
-
 export async function listSistema(init?: RequestInit): Promise<SistemaBackendResponse[]> {
   return apiFetch<SistemaBackendResponse[]>(websiteRoutes.sistema.list(), {
-    init: init ?? { headers: apiConfig.headers },
+    init: init ?? { headers: publicHeaders() },
   });
 }
 
 export async function getSistemaById(id: string): Promise<SistemaBackendResponse> {
   return apiFetch<SistemaBackendResponse>(websiteRoutes.sistema.get(id), {
-    init: { headers: apiConfig.headers },
+    init: { headers: publicHeaders() },
   });
 }
 
@@ -34,11 +25,7 @@ export async function createSistema(
   return apiFetch<SistemaBackendResponse>(websiteRoutes.sistema.create(), {
     init: {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: apiConfig.headers.Accept,
-        ...getAuthHeader(),
-      },
+      headers: authJsonHeaders(),
       body: JSON.stringify(data),
     },
     cache: "no-cache",
@@ -52,11 +39,7 @@ export async function updateSistema(
   return apiFetch<SistemaBackendResponse>(websiteRoutes.sistema.update(id), {
     init: {
       method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: apiConfig.headers.Accept,
-        ...getAuthHeader(),
-      },
+      headers: authJsonHeaders(),
       body: JSON.stringify(data),
     },
     cache: "no-cache",
@@ -67,7 +50,7 @@ export async function deleteSistema(id: string): Promise<void> {
   await apiFetch<void>(websiteRoutes.sistema.delete(id), {
     init: {
       method: "DELETE",
-      headers: { Accept: apiConfig.headers.Accept, ...getAuthHeader() },
+      headers: authHeaders(),
     },
     cache: "no-cache",
   });

--- a/src/api/websites/components/treinamento-company/index.ts
+++ b/src/api/websites/components/treinamento-company/index.ts
@@ -1,20 +1,11 @@
-import { websiteRoutes } from "@/api/routes";
 import { apiFetch } from "@/api/client";
-import { apiConfig } from "@/lib/env";
+import { websiteRoutes } from "@/api/routes";
+import { authHeaders, authJsonHeaders, publicHeaders } from "@/api/shared";
 import type {
   TreinamentoCompanyBackendResponse,
   CreateTreinamentoCompanyPayload,
   UpdateTreinamentoCompanyPayload,
 } from "./types";
-
-function getAuthHeader(): Record<string, string> {
-  if (typeof document === "undefined") return {};
-  const token = document.cookie
-    .split("; ")
-    .find((row) => row.startsWith("token="))
-    ?.split("=")[1];
-  return token ? { Authorization: `Bearer ${token}` } : {};
-}
 
 export async function listTreinamentoCompany(
   init?: RequestInit,
@@ -22,7 +13,7 @@ export async function listTreinamentoCompany(
   return apiFetch<TreinamentoCompanyBackendResponse[]>(
     websiteRoutes.treinamentoCompany.list(),
     {
-      init: init ?? { headers: apiConfig.headers },
+      init: init ?? { headers: publicHeaders() },
     },
   );
 }
@@ -32,22 +23,21 @@ export async function getTreinamentoCompanyById(
 ): Promise<TreinamentoCompanyBackendResponse> {
   return apiFetch<TreinamentoCompanyBackendResponse>(
     websiteRoutes.treinamentoCompany.get(id),
-    { init: { headers: apiConfig.headers } },
+    { init: { headers: publicHeaders() } },
   );
 }
 
 export async function createTreinamentoCompany(
   data: CreateTreinamentoCompanyPayload,
 ): Promise<TreinamentoCompanyBackendResponse> {
-  const headers = {
-    "Content-Type": "application/json",
-    Accept: apiConfig.headers.Accept,
-    ...getAuthHeader(),
-  } as Record<string, string>;
   return apiFetch<TreinamentoCompanyBackendResponse>(
     websiteRoutes.treinamentoCompany.create(),
     {
-      init: { method: "POST", body: JSON.stringify(data), headers },
+      init: {
+        method: "POST",
+        body: JSON.stringify(data),
+        headers: authJsonHeaders(),
+      },
       cache: "no-cache",
     },
   );
@@ -57,24 +47,22 @@ export async function updateTreinamentoCompany(
   id: string,
   data: UpdateTreinamentoCompanyPayload,
 ): Promise<TreinamentoCompanyBackendResponse> {
-  const headers = {
-    "Content-Type": "application/json",
-    Accept: apiConfig.headers.Accept,
-    ...getAuthHeader(),
-  } as Record<string, string>;
   return apiFetch<TreinamentoCompanyBackendResponse>(
     websiteRoutes.treinamentoCompany.update(id),
     {
-      init: { method: "PUT", body: JSON.stringify(data), headers },
+      init: {
+        method: "PUT",
+        body: JSON.stringify(data),
+        headers: authJsonHeaders(),
+      },
       cache: "no-cache",
     },
   );
 }
 
 export async function deleteTreinamentoCompany(id: string): Promise<void> {
-  const headers = { Accept: apiConfig.headers.Accept, ...getAuthHeader() } as Record<string, string>;
   await apiFetch<void>(websiteRoutes.treinamentoCompany.delete(id), {
-    init: { method: "DELETE", headers },
+    init: { method: "DELETE", headers: authHeaders() },
     cache: "no-cache",
   });
 }

--- a/src/api/websites/components/treinamentos-in-company/index.ts
+++ b/src/api/websites/components/treinamentos-in-company/index.ts
@@ -1,20 +1,11 @@
-import { websiteRoutes } from "@/api/routes";
 import { apiFetch } from "@/api/client";
-import { apiConfig } from "@/lib/env";
+import { websiteRoutes } from "@/api/routes";
+import { authHeaders, authJsonHeaders, publicHeaders } from "@/api/shared";
 import type {
   TreinamentosInCompanyBackendResponse,
   CreateTreinamentosInCompanyPayload,
   UpdateTreinamentosInCompanyPayload,
 } from "./types";
-
-function getAuthHeader(): Record<string, string> {
-  if (typeof document === "undefined") return {};
-  const token = document.cookie
-    .split("; ")
-    .find((row) => row.startsWith("token="))
-    ?.split("=")[1];
-  return token ? { Authorization: `Bearer ${token}` } : {};
-}
 
 export async function listTreinamentosInCompany(
   init?: RequestInit,
@@ -22,7 +13,7 @@ export async function listTreinamentosInCompany(
   return apiFetch<TreinamentosInCompanyBackendResponse[]>(
     websiteRoutes.treinamentosInCompany.list(),
     {
-      init: init ?? { headers: apiConfig.headers },
+      init: init ?? { headers: publicHeaders() },
     },
   );
 }
@@ -32,22 +23,21 @@ export async function getTreinamentosInCompanyById(
 ): Promise<TreinamentosInCompanyBackendResponse> {
   return apiFetch<TreinamentosInCompanyBackendResponse>(
     websiteRoutes.treinamentosInCompany.get(id),
-    { init: { headers: apiConfig.headers } },
+    { init: { headers: publicHeaders() } },
   );
 }
 
 export async function createTreinamentosInCompany(
   data: CreateTreinamentosInCompanyPayload,
 ): Promise<TreinamentosInCompanyBackendResponse> {
-  const headers = {
-    "Content-Type": "application/json",
-    Accept: apiConfig.headers.Accept,
-    ...getAuthHeader(),
-  } as Record<string, string>;
   return apiFetch<TreinamentosInCompanyBackendResponse>(
     websiteRoutes.treinamentosInCompany.create(),
     {
-      init: { method: "POST", body: JSON.stringify(data), headers },
+      init: {
+        method: "POST",
+        body: JSON.stringify(data),
+        headers: authJsonHeaders(),
+      },
       cache: "no-cache",
     },
   );
@@ -57,24 +47,22 @@ export async function updateTreinamentosInCompany(
   id: string,
   data: UpdateTreinamentosInCompanyPayload,
 ): Promise<TreinamentosInCompanyBackendResponse> {
-  const headers = {
-    "Content-Type": "application/json",
-    Accept: apiConfig.headers.Accept,
-    ...getAuthHeader(),
-  } as Record<string, string>;
   return apiFetch<TreinamentosInCompanyBackendResponse>(
     websiteRoutes.treinamentosInCompany.update(id),
     {
-      init: { method: "PUT", body: JSON.stringify(data), headers },
+      init: {
+        method: "PUT",
+        body: JSON.stringify(data),
+        headers: authJsonHeaders(),
+      },
       cache: "no-cache",
     },
   );
 }
 
 export async function deleteTreinamentosInCompany(id: string): Promise<void> {
-  const headers = { Accept: apiConfig.headers.Accept, ...getAuthHeader() } as Record<string, string>;
   await apiFetch<void>(websiteRoutes.treinamentosInCompany.delete(id), {
-    init: { method: "DELETE", headers },
+    init: { method: "DELETE", headers: authHeaders() },
     cache: "no-cache",
   });
 }

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -70,15 +70,17 @@ const SignInPageDemo = () => {
         // Busca nome e role do usuário para saudar em futuros logins
         try {
           const profile = await getUserProfile(res.token);
+          const userData = profile?.usuario;
 
-          const fullName = profile.nomeCompleto;
+          const fullName = userData?.nomeCompleto;
           if (fullName) {
             const [firstName] = fullName.split(" ");
             localStorage.setItem("userName", firstName);
           }
+
           const candidateRoles = [
-            profile.role,
-            ...(Array.isArray(profile.roles) ? profile.roles : []),
+            userData?.role,
+            ...(Array.isArray(userData?.roles) ? userData.roles : []),
           ].filter(Boolean) as string[];
           userRole = candidateRoles.find((roleCandidate) =>
             ALL_ROLES.includes(roleCandidate as UserRole),

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -1,347 +1,469 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { Controller, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Building, GraduationCap, User } from "lucide-react";
+
+import { registerUser } from "@/api/usuarios";
+import type { UsuarioRegisterPayload } from "@/api/usuarios";
+import { UserRole } from "@/config/roles";
+import { MaskService } from "@/services";
+
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/radix-checkbox";
 import {
-  InputCustom,
   ButtonCustom,
-  toastCustom,
+  InputCustom,
   OfflineModal,
+  toastCustom,
 } from "@/components/ui/custom";
-import TermsOfUseModal from "@/components/partials/auth/register/terms-of-use-modal";
 import PrivacyPolicyModal from "@/components/partials/auth/register/privacy-policy-modal";
-import { GraduationCap, User, Building } from "lucide-react";
-import { registerUser } from "@/api/usuarios";
-import type { UsuarioRegisterPayload } from "@/api/usuarios";
-import { MaskService } from "@/services";
-import Image from "next/image";
-import { UserRole } from "@/config/roles";
+import TermsOfUseModal from "@/components/partials/auth/register/terms-of-use-modal";
 
-type SelectedType = "student" | "candidate" | "company" | null;
+const AUTH_LOGIN_URL = "https://auth.advancemais.com/login" as const;
 
-type RegisterFormData = {
+const STORAGE_KEYS = {
+  draft: "auth.register.formDraft",
+  legacyForm: "registerFormData",
+  legacyType: "registerSelectedType",
+} as const;
+
+const PASSWORD_VALIDATIONS = [
+  { test: (value: string) => value.length >= 8, message: "A senha deve conter pelo menos 8 caracteres." },
+  { test: (value: string) => /[A-Z]/.test(value), message: "Inclua ao menos uma letra maiúscula." },
+  { test: (value: string) => /[a-z]/.test(value), message: "Inclua ao menos uma letra minúscula." },
+  { test: (value: string) => /\d/.test(value), message: "Inclua ao menos um número." },
+  {
+    test: (value: string) => /[^A-Za-z0-9]/.test(value),
+    message: "Inclua ao menos um caractere especial.",
+  },
+] as const;
+
+const ACCOUNT_OPTIONS = [
+  {
+    id: "student" as const,
+    title: "Aluno",
+    description: "Acesso a cursos e conteúdos educacionais.",
+    icon: GraduationCap,
+  },
+  {
+    id: "candidate" as const,
+    title: "Candidato",
+    description: "Busca por oportunidades de carreira.",
+    icon: User,
+  },
+  {
+    id: "company" as const,
+    title: "Empresa",
+    description: "Publicação de vagas e busca por talentos.",
+    icon: Building,
+  },
+] as const;
+
+type RegisterAccountType = (typeof ACCOUNT_OPTIONS)[number]["id"];
+
+type RegisterFormValues = {
+  accountType?: RegisterAccountType;
   name: string;
   document: string;
   phone: string;
   email: string;
   password: string;
   confirmPassword: string;
+  acceptTerms: boolean;
 };
 
-const createInitialFormData = (): RegisterFormData => ({
+type PersistedRegisterDraft = Pick<
+  RegisterFormValues,
+  "accountType" | "name" | "document" | "phone" | "email"
+>;
+
+type MaskServiceInstance = ReturnType<typeof MaskService.getInstance>;
+
+const defaultValues: RegisterFormValues = {
+  accountType: undefined,
   name: "",
   document: "",
   phone: "",
   email: "",
   password: "",
   confirmPassword: "",
-});
+  acceptTerms: false,
+};
+
+function createRegisterSchema(maskService: MaskServiceInstance) {
+  return z
+    .object({
+      accountType: z
+        .enum(["student", "candidate", "company"], {
+          errorMap: () => ({ message: "Selecione o tipo de conta." }),
+        })
+        .optional(),
+      name: z
+        .string({ required_error: "Informe o nome." })
+        .trim()
+        .min(3, "Informe seu nome completo."),
+      document: z
+        .string({ required_error: "Informe o documento." })
+        .trim()
+        .min(1, "Informe o documento."),
+      phone: z
+        .string({ required_error: "Informe o telefone." })
+        .trim()
+        .min(1, "Informe o telefone."),
+      email: z
+        .string({ required_error: "Informe o e-mail." })
+        .trim()
+        .min(1, "Informe o e-mail.")
+        .email("Informe um e-mail válido."),
+      password: z
+        .string({ required_error: "Informe a senha." })
+        .min(8, PASSWORD_VALIDATIONS[0].message)
+        .superRefine((value, ctx) => {
+          PASSWORD_VALIDATIONS.slice(1).forEach(({ test, message }) => {
+            if (!test(value)) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message,
+              });
+            }
+          });
+        }),
+      confirmPassword: z
+        .string({ required_error: "Confirme a senha." })
+        .min(1, "Confirme a senha."),
+      acceptTerms: z
+        .boolean()
+        .refine((value) => value, {
+          message: "É necessário aceitar os termos para prosseguir.",
+        }),
+    })
+    .superRefine((data, ctx) => {
+      if (!data.accountType) {
+        ctx.addIssue({
+          path: ["accountType"],
+          code: z.ZodIssueCode.custom,
+          message: "Selecione o tipo de conta.",
+        });
+        return;
+      }
+
+      const documentMask = data.accountType === "company" ? "cnpj" : "cpf";
+
+      if (!maskService.validate(data.document, documentMask)) {
+        ctx.addIssue({
+          path: ["document"],
+          code: z.ZodIssueCode.custom,
+          message:
+            documentMask === "cnpj"
+              ? "Informe um CNPJ válido."
+              : "Informe um CPF válido.",
+        });
+      }
+
+      if (!maskService.validate(data.phone, "phone")) {
+        ctx.addIssue({
+          path: ["phone"],
+          code: z.ZodIssueCode.custom,
+          message: "Informe um telefone válido.",
+        });
+      }
+
+      if (data.password !== data.confirmPassword) {
+        ctx.addIssue({
+          path: ["confirmPassword"],
+          code: z.ZodIssueCode.custom,
+          message: "As senhas não coincidem.",
+        });
+      }
+    });
+}
+
+function resolveRegisterError(error: unknown): string {
+  const defaultMessage = "Não foi possível realizar o cadastro.";
+
+  if (!error || typeof error !== "object") {
+    return defaultMessage;
+  }
+
+  const status = (error as { status?: number }).status;
+  if (status === 409) {
+    return "Usuário já cadastrado, por favor faça login.";
+  }
+
+  const rawMessage =
+    typeof (error as { message?: unknown }).message === "string"
+      ? ((error as { message?: unknown }).message as string)
+      : undefined;
+
+  if (rawMessage) {
+    const normalized = rawMessage.toLowerCase();
+    if (normalized.includes("cpf")) return "CPF já cadastrado.";
+    if (normalized.includes("cnpj")) return "CNPJ já cadastrado.";
+    if (normalized.includes("email")) return "Email já cadastrado.";
+    if (normalized.includes("usuário") || normalized.includes("usuario")) {
+      return "Usuário já cadastrado, por favor faça login.";
+    }
+  }
+
+  if (error instanceof Error) {
+    const normalized = error.message.toLowerCase();
+    if (normalized.includes("cpf")) return "CPF já cadastrado.";
+    if (normalized.includes("cnpj")) return "CNPJ já cadastrado.";
+    if (normalized.includes("email")) return "Email já cadastrado.";
+  }
+
+  return defaultMessage;
+}
+
+function maskEmailForLog(email: string): string {
+  const [userPart, domainPart] = email.split("@");
+  if (!domainPart) return "***";
+  const maskedUser = userPart
+    ? `${userPart.slice(0, 1)}${"*".repeat(Math.max(userPart.length - 1, 0))}`
+    : "";
+  return `${maskedUser}@${domainPart}`;
+}
+
+function maskValue(value: string): string {
+  if (!value) return "";
+  const trimmed = value.trim();
+  if (trimmed.length <= 4) {
+    return `${"*".repeat(Math.max(trimmed.length - 1, 0))}${trimmed.slice(-1)}`;
+  }
+  return `${"*".repeat(trimmed.length - 4)}${trimmed.slice(-4)}`;
+}
+
+function logRegisterPayload(payload: UsuarioRegisterPayload): void {
+  if (process.env.NODE_ENV === "production") return;
+
+  const sanitized: Record<string, unknown> = {
+    ...payload,
+    telefone: maskValue(payload.telefone),
+    email: maskEmailForLog(payload.email),
+    senha: `***(${payload.senha.length} chars)`,
+    confirmarSenha: `***(${payload.confirmarSenha.length} chars)`,
+  };
+
+  if (payload.cpf) sanitized.cpf = maskValue(payload.cpf);
+  if (payload.cnpj) sanitized.cnpj = maskValue(payload.cnpj);
+
+  console.groupCollapsed("🧪 Registro | Payload sanitizado");
+  console.log("Endpoint:", "POST /api/v1/usuarios/registrar");
+  console.table(sanitized);
+  console.groupEnd();
+}
 
 const RegisterPage = () => {
-  const [selectedType, setSelectedType] = useState<SelectedType>(null);
-  const [acceptTerms, setAcceptTerms] = useState(false);
-  const [isPending, startTransition] = useTransition();
-  const [formData, setFormData] = useState<RegisterFormData>(
-    () => createInitialFormData(),
-  );
-  const [passwordError, setPasswordError] = useState("");
+  const maskService = useMemo(() => MaskService.getInstance(), []);
   const [isTermsModalOpen, setIsTermsModalOpen] = useState(false);
   const [isPrivacyModalOpen, setIsPrivacyModalOpen] = useState(false);
 
+  const registerSchema = useMemo(
+    () => createRegisterSchema(maskService),
+    [maskService],
+  );
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    setValue,
+    watch,
+    formState: { errors, isSubmitting, isValid },
+  } = useForm<RegisterFormValues>({
+    resolver: zodResolver(registerSchema),
+    defaultValues,
+    mode: "onChange",
+    reValidateMode: "onChange",
+  });
+
+  const accountType = watch("accountType");
+  const nameValue = watch("name");
+  const documentValue = watch("document");
+  const phoneValue = watch("phone");
+  const emailValue = watch("email");
+
   useEffect(() => {
-    const savedForm = localStorage.getItem("registerFormData");
-    const savedType = localStorage.getItem(
-      "registerSelectedType"
-    ) as SelectedType;
-    if (savedForm) {
-      try {
-        const parsed = JSON.parse(savedForm) as Partial<RegisterFormData>;
-        const allowedKeys = Object.keys(createInitialFormData());
-        const sanitized = Object.fromEntries(
-          Object.entries(parsed).filter(([key]) =>
-            allowedKeys.includes(key),
-          ),
-        ) as Partial<RegisterFormData>;
-        setFormData((prev) => ({ ...prev, ...sanitized }));
-      } catch (error) {
-        console.warn("Não foi possível restaurar o formulário de cadastro:", error);
-        localStorage.removeItem("registerFormData");
+    if (typeof window === "undefined") return;
+
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEYS.draft);
+      if (stored) {
+        const parsed = JSON.parse(stored) as PersistedRegisterDraft;
+        reset({
+          ...defaultValues,
+          ...parsed,
+          accountType: parsed.accountType ?? undefined,
+        });
+        return;
       }
+
+      const legacyForm = window.localStorage.getItem(STORAGE_KEYS.legacyForm);
+      const legacyType = window.localStorage.getItem(
+        STORAGE_KEYS.legacyType,
+      ) as RegisterAccountType | undefined | null;
+
+      if (legacyForm) {
+        const parsedLegacy = JSON.parse(legacyForm) as PersistedRegisterDraft;
+        reset({
+          ...defaultValues,
+          ...parsedLegacy,
+          accountType: legacyType ?? undefined,
+        });
+      }
+    } catch (error) {
+      console.warn("Não foi possível restaurar o formulário de cadastro:", error);
+    } finally {
+      window.localStorage.removeItem(STORAGE_KEYS.legacyForm);
+      window.localStorage.removeItem(STORAGE_KEYS.legacyType);
     }
-    if (savedType) {
-      setSelectedType(savedType);
-    }
-  }, []);
+  }, [reset]);
 
   useEffect(() => {
-    const isEmptyForm = Object.values(formData).every((value) => value === "");
-    if (isEmptyForm) {
-      localStorage.removeItem("registerFormData");
-      return;
-    }
-    localStorage.setItem("registerFormData", JSON.stringify(formData));
-  }, [formData]);
+    if (typeof window === "undefined") return;
 
-  useEffect(() => {
-    if (selectedType) {
-      localStorage.setItem("registerSelectedType", selectedType);
-    }
-  }, [selectedType]);
+    const draft: PersistedRegisterDraft = {
+      accountType: accountType ?? undefined,
+      name: nameValue ?? "",
+      document: documentValue ?? "",
+      phone: phoneValue ?? "",
+      email: emailValue ?? "",
+    };
 
-  useEffect(() => {
-    if (
-      formData.password &&
-      formData.confirmPassword &&
-      formData.password !== formData.confirmPassword
-    ) {
-      setPasswordError("As senhas não coincidem");
-    } else if (formData.password && !isPasswordValid(formData.password)) {
-      setPasswordError(
-        "A senha deve conter letras maiúsculas, minúsculas e caracteres especiais"
-      );
-    } else {
-      setPasswordError("");
-    }
-  }, [formData.password, formData.confirmPassword]);
-
-  const userTypes = [
-    {
-      id: "student",
-      title: "Aluno",
-      icon: GraduationCap,
-      description: "Acesso a cursos e conteúdos educacionais.",
-      color: "from-emerald-500 to-teal-600",
-      bgColor: "bg-emerald-50",
-      borderColor: "border-emerald-200",
-      hoverBg: "hover:bg-emerald-100",
-    },
-    {
-      id: "candidate",
-      title: "Candidato",
-      icon: User,
-      description: "Busca por oportunidades de carreira.",
-      color: "from-blue-500 to-indigo-600",
-      bgColor: "bg-blue-50",
-      borderColor: "border-blue-200",
-      hoverBg: "hover:bg-blue-100",
-    },
-    {
-      id: "company",
-      title: "Empresa",
-      icon: Building,
-      description: "Publicação de vagas e busca por talentos.",
-      color: "from-red-500 to-rose-600",
-      bgColor: "bg-red-50",
-      borderColor: "border-red-200",
-      hoverBg: "hover:bg-red-100",
-    },
-  ];
-
-  const typeStyles: Record<string, { ring: string }> = {
-    student: { ring: "focus-visible:ring-blue-500" },
-    candidate: { ring: "focus-visible:ring-blue-500" },
-    company: { ring: "focus-visible:ring-blue-500" },
-  };
-
-  const maskService = MaskService.getInstance();
-
-  const maskSensitiveValue = (value: string, visibleChars = 4) => {
-    const trimmed = value?.trim() ?? "";
-    if (!trimmed) return "";
-    if (trimmed.length <= visibleChars) {
-      return "*".repeat(Math.max(trimmed.length - 1, 0)) +
-        trimmed.slice(-1);
-    }
-    const maskedLength = Math.max(trimmed.length - visibleChars, 0);
-    return `${"*".repeat(maskedLength)}${trimmed.slice(-visibleChars)}`;
-  };
-
-  const maskEmail = (email: string) => {
-    const [userPart, domainPart] = email.split("@");
-    if (!domainPart) return maskSensitiveValue(email);
-    const maskedUser = userPart
-      ? `${userPart[0]}${"*".repeat(Math.max(userPart.length - 1, 0))}`
-      : "";
-    return `${maskedUser}@${domainPart}`;
-  };
-
-  const handleInputChange = (field: string, value: string) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
-  };
-
-  const resetForm = () => {
-    setSelectedType(null);
-    setFormData(createInitialFormData());
-    setAcceptTerms(false);
-    localStorage.removeItem("registerFormData");
-    localStorage.removeItem("registerSelectedType");
-  };
-
-  const isDocumentValid = () => {
-    if (!selectedType) {
-      return false;
-    }
-    const maskType = selectedType === "company" ? "cnpj" : "cpf";
-    return maskService.validate(formData.document, maskType);
-  };
-
-  const isPhoneValid = () => {
-    return maskService.validate(formData.phone, "phone");
-  };
-
-  const isPasswordValid = (password: string) => {
-    const hasUpper = /[A-Z]/.test(password);
-    const hasLower = /[a-z]/.test(password);
-    const hasSpecial = /[^A-Za-z0-9]/.test(password);
-    return hasUpper && hasLower && hasSpecial;
-  };
-
-  const isFormValid = () => {
-    const { name, document, phone, email, password, confirmPassword } =
-      formData;
-    const fieldsFilled = [
-      name,
-      document,
-      phone,
-      email,
-      password,
-      confirmPassword,
-    ].every((value) => value.trim() !== "");
-
-    return (
-      fieldsFilled &&
-      maskService.validate(email, "email") &&
-      isPhoneValid() &&
-      isDocumentValid() &&
-      password === confirmPassword &&
-      isPasswordValid(password) &&
-      acceptTerms
+    const hasData = Boolean(
+      draft.accountType ||
+        draft.name.trim() ||
+        draft.document.trim() ||
+        draft.phone.trim() ||
+        draft.email.trim(),
     );
-  };
 
-  const formatPhoneForApi = (phone: string): string => {
-    const trimmed = phone.trim();
-
-    if (!trimmed) {
-      return "";
-    }
-
-    const digits = maskService.removeMask(trimmed, "phone");
-
-    return digits;
-  };
-
-  const handleSignUp = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!selectedType) {
-      toastCustom.error("Selecione o tipo de conta para continuar.");
+    if (!hasData) {
+      window.localStorage.removeItem(STORAGE_KEYS.draft);
       return;
     }
-    startTransition(async () => {
-      const documentoLimpo = maskService.removeMask(
-        formData.document,
-        "cpfCnpj",
-      );
-      const telefoneFormatado = formatPhoneForApi(formData.phone);
-      const isCompanyAccount = selectedType === "company";
+
+    window.localStorage.setItem(STORAGE_KEYS.draft, JSON.stringify(draft));
+  }, [accountType, nameValue, documentValue, phoneValue, emailValue]);
+
+  const selectedOption = useMemo(
+    () => ACCOUNT_OPTIONS.find((option) => option.id === accountType) ?? null,
+    [accountType],
+  );
+
+  const documentLabel = accountType === "company" ? "CNPJ" : "CPF";
+  const documentPlaceholder = accountType === "company"
+    ? "00.000.000/0000-00"
+    : "000.000.000-00";
+
+  const handleSelectType = useCallback(
+    (type: RegisterAccountType) => {
+      setValue("accountType", type, {
+        shouldDirty: true,
+        shouldTouch: true,
+        shouldValidate: true,
+      });
+    },
+    [setValue],
+  );
+
+  const handleReset = useCallback(() => {
+    reset(defaultValues);
+    if (typeof window !== "undefined") {
+      window.localStorage.removeItem(STORAGE_KEYS.draft);
+    }
+  }, [reset]);
+
+  const onSubmit = useCallback(
+    async (values: RegisterFormValues) => {
+      if (!values.accountType) {
+        toastCustom.error("Selecione o tipo de conta para continuar.");
+        return;
+      }
+
       const tipoUsuario: UsuarioRegisterPayload["tipoUsuario"] =
-        isCompanyAccount ? "PESSOA_JURIDICA" : "PESSOA_FISICA";
+        values.accountType === "company"
+          ? "PESSOA_JURIDICA"
+          : "PESSOA_FISICA";
 
-      const payloadForApi: UsuarioRegisterPayload = {
-        nomeCompleto: formData.name.trim(),
-        documento: documentoLimpo,
-        telefone: telefoneFormatado,
-        email: formData.email.trim().toLowerCase(),
-        senha: formData.password,
-        confirmarSenha: formData.confirmPassword,
-        aceitarTermos: acceptTerms,
+      const cleanDocument = maskService
+        .removeMask(values.document, "cpfCnpj")
+        .trim();
+      const cleanPhone = maskService.removeMask(values.phone, "phone").trim();
+
+      const payload: UsuarioRegisterPayload = {
+        nomeCompleto: values.name.trim(),
+        telefone: cleanPhone,
+        email: values.email.trim().toLowerCase(),
+        senha: values.password,
+        confirmarSenha: values.confirmPassword,
+        aceitarTermos: values.acceptTerms,
         tipoUsuario,
+        role:
+          values.accountType === "company"
+            ? UserRole.EMPRESA
+            : UserRole.ALUNO_CANDIDATO,
       };
 
-      if (isCompanyAccount) {
-        payloadForApi.cnpj = documentoLimpo;
-        payloadForApi.role = UserRole.EMPRESA;
+      if (values.accountType === "company") {
+        payload.cnpj = cleanDocument;
       } else {
-        payloadForApi.cpf = documentoLimpo;
-        payloadForApi.role = UserRole.ALUNO_CANDIDATO;
+        payload.cpf = cleanDocument;
       }
 
-      const maskedPayloadForLog: Record<string, unknown> = {
-        ...payloadForApi,
-        documento: maskSensitiveValue(documentoLimpo),
-        telefone: maskSensitiveValue(telefoneFormatado),
-        email: maskEmail(payloadForApi.email),
-        senha: `***(${payloadForApi.senha.length} chars)`,
-        confirmarSenha: `***(${payloadForApi.confirmarSenha.length} chars)`,
-      };
+      logRegisterPayload(payload);
 
-      if (payloadForApi.cpf) {
-        maskedPayloadForLog.cpf = maskSensitiveValue(payloadForApi.cpf);
-      }
-
-      if (payloadForApi.cnpj) {
-        maskedPayloadForLog.cnpj = maskSensitiveValue(payloadForApi.cnpj);
-      }
-      console.groupCollapsed("🧪 Registro | Payload sanitizado");
-      console.log("Endpoint:", "POST /api/v1/usuarios/registrar");
-      console.table(maskedPayloadForLog);
-      console.info(
-        "ℹ️ Payload enviado sem máscara: os valores acima estão mascarados apenas para log.",
-      );
-      console.groupEnd();
       try {
-        await registerUser(payloadForApi);
+        await registerUser(payload);
         toastCustom.success(
-          "Cadastro realizado com sucesso! Verifique seu email para confirmar."
+          "Cadastro realizado com sucesso! Verifique seu email para confirmar.",
         );
-        resetForm();
+        handleReset();
         setTimeout(() => {
-          window.location.href = "https://auth.advancemais.com/login";
+          if (typeof window !== "undefined") {
+            window.location.href = AUTH_LOGIN_URL;
+          }
         }, 1000);
       } catch (error) {
         console.error("Erro ao cadastrar:", error);
-        let message = "Não foi possível realizar o cadastro.";
-        if (error instanceof Error) {
-          const msg = error.message.toLowerCase();
-          if (msg.includes("cpf")) {
-            message = "CPF já cadastrado.";
-          } else if (msg.includes("cnpj")) {
-            message = "CNPJ já cadastrado.";
-          } else if (msg.includes("email")) {
-            message = "Email já cadastrado.";
-          } else if (msg.includes("usuario") || msg.includes("usuário")) {
-            message = "Usuário já cadastrado, por favor faça login.";
-          } else if ((error as any).status === 409) {
-            message = "Usuário já cadastrado, por favor faça login.";
-          }
-        }
-        toastCustom.error(message);
+        toastCustom.error(resolveRegisterError(error));
       }
-    });
-  };
+    },
+    [handleReset, maskService],
+  );
 
   const renderForm = () => {
-    if (!selectedType) return null;
-    const isCompany = selectedType === "company";
+    if (!accountType) return null;
+    const isCompany = accountType === "company";
+    const mask = isCompany ? "cnpj" : "cpf";
 
     return (
-      <form onSubmit={handleSignUp} className="space-y-5 sm:space-y-6">
-        {/* Cabeçalho centralizado com botão à direita */}
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="space-y-5 sm:space-y-6"
+        noValidate
+      >
         <div className="grid grid-cols-1 sm:grid-cols-3 items-center gap-3">
           <div className="hidden sm:block" />
           <div className="text-center space-y-1">
             <h1 className="!text-2xl sm:text-xl md:text-2xl !mb-0 font-semibold text-gray-900 leading-tight">
-              Criar conta como{" "}
-              {userTypes.find((type) => type.id === selectedType)?.title}
+              Criar conta como {selectedOption?.title}
             </h1>
             <p className="sm:text-sm text-gray-500">
-              {userTypes.find((type) => type.id === selectedType)?.description}
+              {selectedOption?.description}
             </p>
           </div>
           <div className="flex justify-end">
             <ButtonCustom
-              onClick={resetForm}
+              onClick={handleReset}
               type="button"
               variant="ghost"
               size="sm"
@@ -354,99 +476,138 @@ const RegisterPage = () => {
         </div>
 
         <div className="space-y-3 sm:space-y-4">
-          {/* Nome + Documento na mesma linha */}
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <InputCustom
-              label={isCompany ? "Nome da empresa" : "Nome completo"}
+            <Controller
+              control={control}
               name="name"
-              value={formData.name}
-              onChange={(e) => handleInputChange("name", e.target.value)}
-              placeholder={
-                isCompany ? "Digite o nome da sua empresa" : "Digite seu nome"
-              }
-              size="md"
-              className="text-sm"
-              required
+              render={({ field }) => (
+                <InputCustom
+                  {...field}
+                  value={field.value ?? ""}
+                  label={isCompany ? "Nome da empresa" : "Nome completo"}
+                  placeholder={
+                    isCompany
+                      ? "Digite o nome da sua empresa"
+                      : "Digite seu nome"
+                  }
+                  size="md"
+                  className="text-sm"
+                  required
+                  error={errors.name?.message}
+                />
+              )}
             />
-            <InputCustom
-              label={isCompany ? "CNPJ" : "CPF"}
+            <Controller
+              control={control}
               name="document"
-              value={formData.document}
-              onChange={(e) => handleInputChange("document", e.target.value)}
-              mask={isCompany ? "cnpj" : "cpf"}
-              placeholder={isCompany ? "00.000.000/0000-00" : "000.000.000-00"}
-              size="md"
-              className="text-sm"
-              required
+              render={({ field }) => (
+                <InputCustom
+                  {...field}
+                  value={field.value ?? ""}
+                  label={documentLabel}
+                  placeholder={documentPlaceholder}
+                  size="md"
+                  className="text-sm"
+                  required
+                  mask={mask}
+                  error={errors.document?.message}
+                />
+              )}
             />
           </div>
 
           <div className="space-y-3 sm:space-y-0 sm:grid sm:grid-cols-2 sm:gap-4">
-            <InputCustom
-              label="Telefone"
+            <Controller
+              control={control}
               name="phone"
-              value={formData.phone}
-              onChange={(e) => handleInputChange("phone", e.target.value)}
-              mask="phone"
-              placeholder="(00) 00000-0000"
-              size="md"
-              className="text-sm"
-              required
+              render={({ field }) => (
+                <InputCustom
+                  {...field}
+                  value={field.value ?? ""}
+                  label="Telefone"
+                  placeholder="(00) 00000-0000"
+                  size="md"
+                  className="text-sm"
+                  required
+                  mask="phone"
+                  error={errors.phone?.message}
+                />
+              )}
             />
 
-            <InputCustom
-              label="Email"
+            <Controller
+              control={control}
               name="email"
-              type="email"
-              value={formData.email}
-              onChange={(e) => handleInputChange("email", e.target.value)}
-              mask="email"
-              placeholder="seuemail@email.com"
-              size="md"
-              className="text-sm"
-              required
+              render={({ field }) => (
+                <InputCustom
+                  {...field}
+                  value={field.value ?? ""}
+                  label="Email"
+                  type="email"
+                  placeholder="seuemail@email.com"
+                  size="md"
+                  className="text-sm"
+                  required
+                  mask="email"
+                  error={errors.email?.message}
+                />
+              )}
             />
           </div>
 
           <div className="space-y-3 sm:space-y-0 sm:grid sm:grid-cols-2 sm:gap-4">
-            <InputCustom
-              label="Senha"
+            <Controller
+              control={control}
               name="password"
-              type="password"
-              value={formData.password}
-              onChange={(e) => handleInputChange("password", e.target.value)}
-              placeholder="••••••••"
-              showPasswordToggle
-              size="md"
-              className="text-sm"
-              error={passwordError}
-              required
+              render={({ field }) => (
+                <InputCustom
+                  {...field}
+                  value={field.value ?? ""}
+                  label="Senha"
+                  type="password"
+                  placeholder="••••••••"
+                  showPasswordToggle
+                  size="md"
+                  className="text-sm"
+                  required
+                  error={errors.password?.message}
+                />
+              )}
             />
 
-            <InputCustom
-              label="Confirmar senha"
+            <Controller
+              control={control}
               name="confirmPassword"
-              type="password"
-              value={formData.confirmPassword}
-              onChange={(e) =>
-                handleInputChange("confirmPassword", e.target.value)
-              }
-              placeholder="••••••••"
-              showPasswordToggle
-              size="md"
-              className="text-sm"
-              error={passwordError}
-              required
+              render={({ field }) => (
+                <InputCustom
+                  {...field}
+                  value={field.value ?? ""}
+                  label="Confirmar senha"
+                  type="password"
+                  placeholder="••••••••"
+                  showPasswordToggle
+                  size="md"
+                  className="text-sm"
+                  required
+                  error={errors.confirmPassword?.message}
+                />
+              )}
             />
           </div>
         </div>
 
         <div className="flex items-start space-x-2.5 pt-1">
-          <Checkbox
-            id="terms"
-            checked={acceptTerms}
-            onCheckedChange={(v) => setAcceptTerms(!!v)}
-            required
+          <Controller
+            control={control}
+            name="acceptTerms"
+            render={({ field }) => (
+              <Checkbox
+                id="terms"
+                checked={field.value}
+                onCheckedChange={(checked) => field.onChange(Boolean(checked))}
+                required
+              />
+            )}
           />
           <Label
             htmlFor="terms"
@@ -477,6 +638,11 @@ const RegisterPage = () => {
               Política de Privacidade
             </button>{" "}
             e autorizo o uso das minhas informações conforme descrito.
+            {errors.acceptTerms?.message && (
+              <span className="block text-xs text-destructive mt-1">
+                {errors.acceptTerms.message}
+              </span>
+            )}
           </Label>
         </div>
 
@@ -487,8 +653,8 @@ const RegisterPage = () => {
             size="md"
             variant="primary"
             className="h-10 sm:h-11 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white font-medium transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer text-sm"
-            disabled={!isFormValid() || isPending}
-            isLoading={isPending}
+            disabled={!isValid || isSubmitting}
+            isLoading={isSubmitting}
             loadingText="Criando..."
           >
             Criar conta
@@ -499,128 +665,150 @@ const RegisterPage = () => {
   };
 
   return (
-    <div className="min-h-[100dvh] w-full bg-white font-geist flex flex-col">
-      {/* Header com logo centralizada */}
-      <header className="w-full border-b border-gray-100">
-        <div className="max-w-5xl mx-auto px-6 py-6 flex justify-center">
-          <Image
-            src="/images/logos/logo_padrao.webp"
-            alt="Logo"
-            width={120}
-            height={40}
-            priority
-            className="object-contain"
-          />
-        </div>
-      </header>
-
+    <div className="relative min-h-screen flex flex-col bg-slate-50">
       <main className="flex-1">
-        <section className="flex items-center justify-center px-6 py-24">
-          <div className="w-full max-w-5xl">
-            {!selectedType ? (
-              <div className="space-y-6 md:space-y-8">
-                <div className="space-y-1 sm:space-y-2">
-                  <h1 className="sm:text-4xl font-semibold text-[var(--primary-color)] text-center !mb-0">
-                    Criar conta
-                  </h1>
-                  <p className="!text-gray-500 text-sm md:text-base leading-relaxed text-center">
-                    Escolha o tipo de conta que melhor se adequa ao seu perfil.
+        <section className="relative overflow-hidden">
+          <div className="absolute inset-0 bg-[var(--primary-color)]" />
+          <div className="absolute inset-0 bg-gradient-to-br from-[var(--primary-color)] via-[var(--primary-color)]/95 to-[var(--secondary-color)]" />
+          <div className="relative max-w-6xl mx-auto px-6 py-12 sm:py-16 lg:py-24 grid lg:grid-cols-[1.1fr_0.9fr] gap-10 lg:gap-16 items-center">
+            <div className="space-y-8 text-white">
+              <div className="space-y-4">
+                <span className="inline-flex items-center px-3 py-1 rounded-full bg-white/10 text-sm">
+                  Plataforma completa para sua jornada profissional
+                </span>
+                <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold leading-tight">
+                  Conquiste novas oportunidades com a Advance+
+                </h1>
+                <p className="text-base sm:text-lg text-white/80 leading-relaxed">
+                  Faça parte do ecossistema que conecta alunos, candidatos e empresas. Cadastre-se gratuitamente e tenha acesso a recursos exclusivos para impulsionar sua carreira.
+                </p>
+              </div>
+
+              <div className="grid sm:grid-cols-2 gap-4">
+                {["Gestão completa de cursos", "Conexão com recrutadores", "Suporte especializado", "Tecnologia intuitiva"].map((feature) => (
+                  <div
+                    key={feature}
+                    className="flex items-center gap-3 bg-white/10 backdrop-blur-sm rounded-xl px-4 py-3"
+                  >
+                    <div className="size-8 rounded-full bg-white/20 grid place-items-center">
+                      <span className="text-lg">•</span>
+                    </div>
+                    <p className="text-sm font-medium text-white/90 leading-tight">
+                      {feature}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="relative bg-white rounded-3xl shadow-xl p-6 sm:p-8 md:p-10 lg:p-8 xl:p-10">
+              <div className="absolute -top-12 -right-8 hidden lg:block">
+                <div className="size-24 rounded-full bg-white/10 backdrop-blur" />
+              </div>
+              <div className="absolute -bottom-10 -left-10 hidden lg:block">
+                <div className="size-20 rounded-full bg-white/10 backdrop-blur" />
+              </div>
+
+              <div className="relative space-y-6">
+                <div className="text-center space-y-2">
+                  <h2 className="text-2xl font-semibold text-gray-900">
+                    Crie sua conta na Advance+
+                  </h2>
+                  <p className="text-sm text-gray-500">
+                    Selecione o perfil que melhor representa você para personalizarmos sua experiência.
                   </p>
                 </div>
 
-                {/* Grid 3 colunas no desktop, responsivo */}
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-5 lg:gap-6 items-stretch">
-                  {userTypes.map((type) => {
-                    const Icon = type.icon;
-                    const styles =
-                      typeStyles[type.id as keyof typeof typeStyles];
-                    return (
-                      <div
-                        key={type.id}
-                        className={`group flex flex-col items-center text-center rounded-2xl border border-transparent bg-[var(--primary-color)] text-white p-6 md:p-8 shadow-sm transition-all duration-150 focus-within:ring-2 focus-within:ring-offset-2 ${styles.ring} h-full min-h-[300px] md:min-h-[320px] cursor-pointer hover:shadow-md hover:-translate-y-0.5`}
-                        role="button"
-                        tabIndex={0}
-                        onClick={() => setSelectedType(type.id as SelectedType)}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter" || e.key === " ") {
-                            e.preventDefault();
-                            setSelectedType(type.id as SelectedType);
-                          }
-                        }}
-                      >
-                        <div className="grid place-items-center size-14 rounded-xl bg-[var(--secondary-color)] text-white mb-4">
-                          <Icon className="size-6" />
-                        </div>
-                        <h2
-                          id={`type-${type.id}-title`}
-                          className="md:text-xl font-semibold"
-                        >
-                          {type.title}
-                        </h2>
-                        <p
-                          id={`type-${type.id}-desc`}
-                          className="mt-2 !text-sm !text-white/70 min-h-[2.75rem] flex-1 !leading-normal"
-                        >
-                          {type.description}
-                        </p>
-                        <div className="w-full flex justify-center">
-                          <ButtonCustom
-                            type="button"
-                            onClick={() =>
-                              setSelectedType(type.id as SelectedType)
-                            }
-                            variant="secondary"
-                            size="md"
-                            className="mt-5 w-full sm:w-auto"
-                            aria-label={`Escolher ${type.title}`}
-                            withAnimation
+                {!accountType ? (
+                  <div className="space-y-5">
+                    <div className="grid gap-4 sm:grid-cols-2">
+                      {ACCOUNT_OPTIONS.map((option) => {
+                        const Icon = option.icon;
+                        const isSelected = option.id === accountType;
+                        return (
+                          <div
+                            key={option.id}
+                            className={`relative rounded-2xl border transition-all duration-300 bg-[var(--primary-color)]/5 hover:bg-[var(--primary-color)]/10 p-5 sm:p-6 cursor-pointer group ${
+                              isSelected
+                                ? "border-[var(--secondary-color)] shadow-[0_15px_35px_rgba(37,99,235,0.1)]"
+                                : "border-transparent"
+                            }`}
+                            role="button"
+                            tabIndex={0}
+                            onClick={() => handleSelectType(option.id)}
+                            onKeyDown={(event) => {
+                              if (event.key === "Enter" || event.key === " ") {
+                                event.preventDefault();
+                                handleSelectType(option.id);
+                              }
+                            }}
                           >
-                            Escolher
-                          </ButtonCustom>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
+                            <div className="grid place-items-center size-14 rounded-xl bg-[var(--secondary-color)] text-white mb-4">
+                              <Icon className="size-6" />
+                            </div>
+                            <h2 className="md:text-xl font-semibold text-gray-900">
+                              {option.title}
+                            </h2>
+                            <p className="mt-2 text-sm text-gray-500 min-h-[2.75rem] flex-1 leading-normal">
+                              {option.description}
+                            </p>
+                            <div className="w-full flex justify-center">
+                              <ButtonCustom
+                                type="button"
+                                onClick={() => handleSelectType(option.id)}
+                                variant="secondary"
+                                size="md"
+                                className="mt-5 w-full sm:w-auto"
+                                aria-label={`Escolher ${option.title}`}
+                                withAnimation
+                              >
+                                Escolher
+                              </ButtonCustom>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
 
-                <div className="pt-2 sm:pt-4 text-center">
-                  <p className="animate-element animate-delay-700 text-center text-sm text-muted-foreground">
-                    Já possui uma conta?{" "}
-                    <a
-                      href="https://auth.advancemais.com/login"
-                      className="hover:opacity-100 transition-colors text-[var(--primary-color)] cursor-pointer opacity-70 font-semibold"
-                    >
-                      Fazer login
-                    </a>
-                  </p>
-                </div>
-              </div>
-            ) : (
-              <div>
-                {renderForm()}
+                    <div className="pt-2 sm:pt-4 text-center">
+                      <p className="animate-element animate-delay-700 text-center text-sm text-muted-foreground">
+                        Já possui uma conta?{" "}
+                        <a
+                          href={AUTH_LOGIN_URL}
+                          className="hover:opacity-100 transition-colors text-[var(--primary-color)] cursor-pointer opacity-70 font-semibold"
+                        >
+                          Fazer login
+                        </a>
+                      </p>
+                    </div>
+                  </div>
+                ) : (
+                  <div>
+                    {renderForm()}
 
-                <div className="!pt-6 sm:pt-4 text-center">
-                  <p className="animate-element animate-delay-700 text-center text-sm text-muted-foreground">
-                    Já possui uma conta?{" "}
-                    <a
-                      href="https://auth.advancemais.com/login"
-                      className="hover:opacity-100 transition-colors text-[var(--primary-color)] cursor-pointer opacity-70 font-semibold"
-                    >
-                      Fazer login
-                    </a>
-                  </p>
-                </div>
+                    <div className="!pt-6 sm:pt-4 text-center">
+                      <p className="animate-element animate-delay-700 text-center text-sm text-muted-foreground">
+                        Já possui uma conta?{" "}
+                        <a
+                          href={AUTH_LOGIN_URL}
+                          className="hover:opacity-100 transition-colors text-[var(--primary-color)] cursor-pointer opacity-70 font-semibold"
+                        >
+                          Fazer login
+                        </a>
+                      </p>
+                    </div>
+                  </div>
+                )}
               </div>
-            )}
+            </div>
           </div>
         </section>
       </main>
 
-      {/* Footer minimalista */}
       <footer className="bg-[var(--color-blue)] text-white/80 py-8">
         <div className="max-w-5xl mx-auto px-6 text-center space-y-3">
-          <p className="sm:text-sm tracking-wide !text-white">
-            Todos os direitos reservados © {new Date().getFullYear()}{" "}
+          <p className="sm:text-sm tracking-wide text-white">
+            Todos os direitos reservados © {new Date().getFullYear()} {" "}
             <span className="font-semibold text-[var(--secondary-color)]">
               Advance+
             </span>
@@ -634,10 +822,7 @@ const RegisterPage = () => {
             >
               Política de Privacidade
             </a>
-            <span
-              className="h-4 w-px bg-blue-800/50 self-center"
-              aria-hidden
-            ></span>
+            <span className="h-4 w-px bg-blue-800/50 self-center" aria-hidden></span>
             <a
               href="http://advancemais.com/termos-uso"
               target="_blank"
@@ -646,10 +831,7 @@ const RegisterPage = () => {
             >
               Termos de Uso
             </a>
-            <span
-              className="h-4 w-px bg-blue-800/20 self-center"
-              aria-hidden
-            ></span>
+            <span className="h-4 w-px bg-blue-800/20 self-center" aria-hidden></span>
             <a href="#" className="hover:text-white transition-colors px-3">
               Preferências de Cookies
             </a>

--- a/src/components/ui/custom/user-button/components/UserButton.tsx
+++ b/src/components/ui/custom/user-button/components/UserButton.tsx
@@ -58,24 +58,25 @@ export function UserButton({ className, onNavigate }: UserButtonProps) {
         }
 
         const profile = await getUserProfile(token);
-        if (!profile?.email) {
+        const userData = profile?.usuario;
+        if (!userData?.email) {
           setIsLoading(false);
           return;
         }
 
-        const full = profile.nomeCompleto?.trim();
+        const full = userData.nomeCompleto?.trim();
         const parts = full ? full.split(" ") : [];
-        const firstName = parts[0] || profile.email.split("@")[0];
+        const firstName = parts[0] || userData.email.split("@")[0];
         const lastName = parts.slice(1).join(" ") || undefined;
 
         setUser({
           firstName,
           lastName,
-          email: profile.email,
+          email: userData.email,
           plan:
-            profile.plano === "pro"
+            userData.plano === "pro"
               ? "pro"
-              : profile.plano === "enterprise"
+              : userData.plano === "enterprise"
               ? "enterprise"
               : "free",
         });

--- a/src/components/ui/custom/user-button/components/UserMenuSimple.tsx
+++ b/src/components/ui/custom/user-button/components/UserMenuSimple.tsx
@@ -49,17 +49,21 @@ export default function UserMenuSimple() {
         }
 
         const profile = await getUserProfile(token);
-        if (!profile?.email) {
+        const userData = profile?.usuario;
+        if (!userData?.email) {
           setIsLoading(false);
           return;
         }
 
-        const fullName = profile.nomeCompleto?.trim();
-        const name = fullName && fullName.length > 0 ? fullName : profile.email.split("@")[0];
+        const fullName = userData.nomeCompleto?.trim();
+        const name =
+          fullName && fullName.length > 0
+            ? fullName
+            : userData.email.split("@")[0];
         setUser({
           name,
-          email: profile.email,
-          avatar: profile.imagemPerfil ?? undefined,
+          email: userData.email,
+          avatar: userData.imagemPerfil ?? undefined,
         });
       } catch (error) {
         console.error("Erro ao carregar perfil:", error);


### PR DESCRIPTION
## Summary
- align usuarios API types with backend docs, add a module info endpoint, and expose richer response metadata
- rebuild the registration page with react-hook-form + zod validation, safe local persistence, and clearer payload construction
- update login and user UI components to consume the new profile response structure

## Testing
- pnpm lint
- pnpm type-check

------
https://chatgpt.com/codex/tasks/task_e_68d3298852488325996b2f1e50e4ed1a