### PR TITLE
fix: normaliza detalhe de vaga

### DIFF
--- a/src/app/dashboard/vagas/[id]/page.tsx
+++ b/src/app/dashboard/vagas/[id]/page.tsx
@@ -44,7 +44,8 @@ export default function VagaDetailPage() {
         setLoading(true);
         setError(null);
         const response = await getVagaById(vagaId);
-        setVaga(response.data || response);
+        const vagaData = "data" in response ? response.data : response;
+        setVaga(vagaData);
       } catch (err) {
         console.error("Erro ao carregar vaga:", err);
         setError("Erro ao carregar os detalhes da vaga");

--- a/src/app/dashboard/vagas/page.tsx
+++ b/src/app/dashboard/vagas/page.tsx
@@ -47,7 +47,7 @@ export default function DashboardVagasPage() {
       <EmptyState
         title="Acesso restrito"
         description="Você não possui permissão para visualizar o módulo de vagas."
-        illustration="accessDenied"
+        illustration="pass"
         actions={
           <Link
             href="/dashboard"


### PR DESCRIPTION
## Summary
- normaliza o consumo da API de detalhes de vaga para lidar com respostas com ou sem envelope
- ajusta a ilustração do estado vazio de vagas para usar uma opção suportada

## Testing
- pnpm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68dc7a92a0b88332a48d915899109f5a